### PR TITLE
Tag unused variables

### DIFF
--- a/nvbench/printer_base.cuh
+++ b/nvbench/printer_base.cuh
@@ -121,10 +121,10 @@ private:
   virtual void do_print_device_info() {}
   virtual void do_print_log_preamble() {}
   virtual void do_print_log_epilogue() {}
-  virtual void do_log(nvbench::log_level, const std::string &) {}
-  virtual void do_log_run_state(const nvbench::state &) {}
-  virtual void do_print_benchmark_list(const benchmark_vector &) {}
-  virtual void do_print_benchmark_results(const benchmark_vector &benches) {}
+  virtual void do_log([[maybe_unused]] nvbench::log_level, const std::string &) {}
+  virtual void do_log_run_state([[maybe_unused]] const nvbench::state &) {}
+  virtual void do_print_benchmark_list([[maybe_unused]] const benchmark_vector &) {}
+  virtual void do_print_benchmark_results([[maybe_unused]] const benchmark_vector &benches) {}
 };
 
 } // namespace nvbench

--- a/nvbench/printer_base.cuh
+++ b/nvbench/printer_base.cuh
@@ -121,10 +121,10 @@ private:
   virtual void do_print_device_info() {}
   virtual void do_print_log_preamble() {}
   virtual void do_print_log_epilogue() {}
-  virtual void do_log([[maybe_unused]] nvbench::log_level, const std::string &) {}
-  virtual void do_log_run_state([[maybe_unused]] const nvbench::state &) {}
-  virtual void do_print_benchmark_list([[maybe_unused]] const benchmark_vector &) {}
-  virtual void do_print_benchmark_results([[maybe_unused]] const benchmark_vector &benches) {}
+  virtual void do_log(nvbench::log_level, const std::string &) {}
+  virtual void do_log_run_state(const nvbench::state &) {}
+  virtual void do_print_benchmark_list(const benchmark_vector &) {}
+  virtual void do_print_benchmark_results(const benchmark_vector &) {}
 };
 
 } // namespace nvbench

--- a/nvbench/string_axis.cuh
+++ b/nvbench/string_axis.cuh
@@ -55,7 +55,7 @@ private:
   {
     return m_values[i];
   }
-  std::string do_get_description(std::size_t i) const final { return {}; }
+  std::string do_get_description([[maybe_unused]] std::size_t i) const final { return {}; }
 
   std::vector<std::string> m_values;
 };

--- a/nvbench/string_axis.cuh
+++ b/nvbench/string_axis.cuh
@@ -55,7 +55,7 @@ private:
   {
     return m_values[i];
   }
-  std::string do_get_description([[maybe_unused]] std::size_t i) const final { return {}; }
+  std::string do_get_description(std::size_t) const final { return {}; }
 
   std::vector<std::string> m_values;
 };


### PR DESCRIPTION
When compiling with `-Wall -Werror` unused variables in a couple files were giving errors.