### PR TITLE
Don't explicitly link with cudart.

### DIFF
--- a/cmake/NVBenchDependencies.cmake
+++ b/cmake/NVBenchDependencies.cmake
@@ -51,8 +51,5 @@ rapids_find_package(CUDAToolkit REQUIRED
   INSTALL_EXPORT_SET nvbench-targets
 )
 
-if (CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "Shared")
-  set(ctk_libraries CUDA::cudart)
-elseif(CMAKE_CUDA_RUNTIME_LIBRARY STREQUAL "Static")
-  set(ctk_libraries CUDA::cudart_static)
-endif()
+# Append CTK targets to this as we add optional deps (NMVL, CUPTI, ...)
+set(ctk_libraries CUDA::toolkit)

--- a/cmake/NVBenchRapidsCMake.cmake
+++ b/cmake/NVBenchRapidsCMake.cmake
@@ -13,8 +13,6 @@ macro(nvbench_load_rapids_cmake)
   include(rapids-find)
 
   rapids_cuda_init_architectures(NVBench)
-  # Only sets CMAKE_CUDA_RUNTIME_LIBRARY if it is currently unset:
-  rapids_cuda_init_runtime(USE_STATIC TRUE)
 endmacro()
 
 # Called after project(...)


### PR DESCRIPTION
This is implicitly added by nvcc, and the explicit setting was breaking
environments where cudart_static is unavailable, e.g. conda.