### PR TITLE
Add NVML support for persistence mode, locking clocks.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 # 3.20.1 required for rapids-cmake
+# 3.21.0 required for NVBench_ADD_DEPENDENT_DLLS_TO_* (MSVC only)
 cmake_minimum_required(VERSION 3.20.1)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -15,16 +16,20 @@ project(NVBench
 
 nvbench_init_rapids_cmake()
 
+option(NVBench_ENABLE_NVML "Build with NVML support from the Cuda Toolkit." ON)
+
+option(NVBench_ENABLE_TESTING "Build NVBench testing suite." OFF)
+option(NVBench_ENABLE_EXAMPLES "Build NVBench examples." OFF)
+
 include(cmake/NVBenchConfigTarget.cmake)
-include(cmake/NVBenchDependencies.cmake)
+include(cmake/NVBenchDependentDlls.cmake)
 include(cmake/NVBenchExports.cmake)
+include(cmake/NVBenchWriteConfigHeader.cmake)
+include(cmake/NVBenchDependencies.cmake)
 include(cmake/NVBenchInstallRules.cmake)
 include(cmake/NVBenchUtilities.cmake)
 
 message(STATUS "NVBench CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
-
-option(NVBench_ENABLE_TESTING "Build NVBench testing suite." OFF)
-option(NVBench_ENABLE_EXAMPLES "Build NVBench examples." OFF)
 
 add_subdirectory(nvbench)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ features:
   be dynamic numbers/strings or [static types](docs/benchmarks.md#type-axes).
 * [Runtime customization](docs/cli_help.md): A rich command-line interface
   allows [redefinition of parameter axes](docs/cli_help_axis.md), CUDA device
-  selection, changing output formats, and more.
+  selection, locking GPU clocks (Volta+), changing output formats, and more.
 * [Throughput calculations](docs/benchmarks.md#throughput-measurements): Compute
   and report:
   * Item throughput (elements/second)

--- a/cmake/NVBenchDependencies.cmake
+++ b/cmake/NVBenchDependencies.cmake
@@ -57,3 +57,10 @@ rapids_find_package(CUDAToolkit REQUIRED
 
 # Append CTK targets to this as we add optional deps (NMVL, CUPTI, ...)
 set(ctk_libraries CUDA::toolkit)
+
+################################################################################
+# CUDAToolkit -> NVML
+if (NVBench_ENABLE_NVML)
+  include("${CMAKE_CURRENT_LIST_DIR}/NVBenchNVML.cmake")
+  list(APPEND ctk_libraries nvbench::nvml)
+endif()

--- a/cmake/NVBenchDependentDlls.cmake
+++ b/cmake/NVBenchDependentDlls.cmake
@@ -1,0 +1,36 @@
+# By default, add dependent DLLs to the build dir on MSVC. This avoids
+# a variety of runtime issues when using NVML, etc.
+# This behavior can be disabled using the following options:
+if (WIN32)
+  option(NVBench_ADD_DEPENDENT_DLLS_TO_BUILD
+    "Copy dependent dlls to NVBench library build location (MSVC only)."
+    ON
+  )
+else()
+  # These are forced off for non-MSVC builds, as $<TARGET_RUNTIME_DLLS:...>
+  # will always be empty on non-dll platforms.
+  set(NVBench_ADD_DEPENDENT_DLLS_TO_BUILD OFF)
+endif()
+
+if (NVBench_ADD_DEPENDENT_DLLS_TO_BUILD)
+  message(STATUS
+    "CMake 3.21.0 is required when NVBench_ADD_DEPENDENT_DLLS_TO_BUILD "
+    "is enabled."
+  )
+  cmake_minimum_required(VERSION 3.21.0)
+endif()
+
+function(nvbench_setup_dep_dlls target_name)
+  # The custom command below fails when there aren't any runtime DLLs to copy,
+  # so only enable it when a relevant dependency is enabled:
+  if (NVBench_ADD_DEPENDENT_DLLS_TO_BUILD AND NVBench_ENABLE_NVML)
+    add_custom_command(TARGET ${target_name}
+      POST_BUILD
+      COMMAND
+        "${CMAKE_COMMAND}" -E copy
+          "$<TARGET_RUNTIME_DLLS:${target_name}>"
+          "$<TARGET_FILE_DIR:${target_name}>"
+      COMMAND_EXPAND_LISTS
+    )
+  endif()
+endfunction()

--- a/cmake/NVBenchExports.cmake
+++ b/cmake/NVBenchExports.cmake
@@ -1,14 +1,28 @@
 macro(nvbench_generate_exports)
+  set(nvbench_build_export_code_block "")
+  set(nvbench_install_export_code_block "")
+
+  if (NVBench_ENABLE_NVML)
+    string(APPEND nvbench_build_export_code_block
+      "include(\"${NVBench_SOURCE_DIR}/cmake/NVBenchNVML.cmake\")\n"
+    )
+    string(APPEND nvbench_install_export_code_block
+      "include(\"\${CMAKE_CURRENT_LIST_DIR}/NVBenchNVML.cmake\")\n"
+    )
+  endif()
+
   rapids_export(BUILD NVBench
     EXPORT_SET nvbench-targets
     NAMESPACE "nvbench::"
     GLOBAL_TARGETS nvbench main
     LANGUAGES CUDA CXX
+    FINAL_CODE_BLOCK nvbench_build_export_code_block
   )
   rapids_export(INSTALL NVBench
     EXPORT_SET nvbench-targets
     NAMESPACE "nvbench::"
     GLOBAL_TARGETS nvbench main
     LANGUAGES CUDA CXX
+    FINAL_CODE_BLOCK nvbench_install_export_code_block
   )
 endmacro()

--- a/cmake/NVBenchInstallRules.cmake
+++ b/cmake/NVBenchInstallRules.cmake
@@ -10,12 +10,34 @@ install(DIRECTORY "${NVBench_SOURCE_DIR}/nvbench"
 )
 
 # generated headers from build dir:
-install(FILES
-  "${NVBench_BINARY_DIR}/nvbench/detail/version.cuh"
-  "${NVBench_BINARY_DIR}/nvbench/detail/git_revision.cuh"
-
+install(
+  FILES
+    "${NVBench_BINARY_DIR}/nvbench/config.cuh"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/nvbench"
+)
+install(
+  FILES
+    "${NVBench_BINARY_DIR}/nvbench/detail/version.cuh"
+    "${NVBench_BINARY_DIR}/nvbench/detail/git_revision.cuh"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/nvbench/detail"
 )
+
+#
+# Install CMake files needed by consumers to locate dependencies:
+#
+
+# Borrowing this logic from rapids_cmake's export logic to make sure these end
+# up in the same location as nvbench-config.cmake:
+rapids_cmake_install_lib_dir(config_install_location)
+set(config_install_location "${config_install_location}/cmake/nvbench")
+
+if (NVBench_ENABLE_NVML)
+  install(
+    FILES
+      "${NVBench_SOURCE_DIR}/cmake/NVBenchNVML.cmake"
+    DESTINATION "${config_install_location}"
+  )
+endif()
 
 # Call with a list of library targets to generate install rules:
 function(nvbench_install_libraries)

--- a/cmake/NVBenchNVML.cmake
+++ b/cmake/NVBenchNVML.cmake
@@ -1,0 +1,37 @@
+# Since this file is installed, we need to make sure that the CUDAToolkit has
+# been found by consumers:
+if (NOT TARGET CUDA::toolkit)
+  find_package(CUDAToolkit REQUIRED)
+endif()
+
+if (WIN32)
+  # The CUDA:: targets currently don't provide dll locations through the
+  # `IMPORTED_LOCATION` property, nor are they marked as `SHARED` libraries
+  # (they're currently `UNKNOWN`). This prevents the `nvbench_setup_dep_dlls`
+  # CMake function from copying the dlls to the build / install directories.
+  # This is discussed in https://gitlab.kitware.com/cmake/cmake/-/issues/22845
+  # and the other CMake issues it links to.
+  #
+  # We create a nvbench-specific target that configures the nvml interface as
+  # described here:
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/22845#note_1077538
+  #
+  # Use find_file instead of find_library, which would search for a .lib file.
+  # This is also nice because find_file searches recursively (find_library
+  # does not) and some versions of CTK nest nvml.dll several directories deep
+  # under C:\Windows\System32.
+  find_file(NVBench_NVML_DLL nvml.dll REQUIRED
+    DOC "The full path to nvml.dll. Usually somewhere under C:/Windows/System32."
+    PATHS "C:/Windows/System32"
+  )
+  mark_as_advanced(NVBench_NVML_DLL)
+  add_library(nvbench::nvml SHARED IMPORTED)
+  target_link_libraries(nvbench::nvml INTERFACE CUDA::toolkit)
+  set_target_properties(nvbench::nvml PROPERTIES
+    IMPORTED_LOCATION "${NVBench_NVML_DLL}"
+    IMPORTED_IMPLIB "${CUDA_nvml_LIBRARY}"
+  )
+else()
+  # Linux is much easier...
+  add_library(nvbench::nvml ALIAS CUDA::nvml)
+endif()

--- a/cmake/NVBenchWriteConfigHeader.cmake
+++ b/cmake/NVBenchWriteConfigHeader.cmake
@@ -1,0 +1,7 @@
+function(nvbench_write_config_header filepath)
+  if (NVBench_ENABLE_NVML)
+    set(NVBENCH_HAS_NVML 1)
+  endif()
+
+  configure_file("${NVBench_SOURCE_DIR}/cmake/config.cuh.in" "${filepath}")
+endfunction()

--- a/cmake/config.cuh.in
+++ b/cmake/config.cuh.in
@@ -1,0 +1,22 @@
+/*
+*  Copyright 2021 NVIDIA Corporation
+*
+*  Licensed under the Apache License, Version 2.0 with the LLVM exception
+*  (the "License"); you may not use this file except in compliance with
+*  the License.
+*
+*  You may obtain a copy of the License at
+*
+*      http://llvm.org/foundation/relicensing/LICENSE.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*/
+
+#pragma once
+
+// Defined if NVBench has been built with NVML support.
+#cmakedefine NVBENCH_HAS_NVML

--- a/docs/cli_help.md
+++ b/docs/cli_help.md
@@ -12,6 +12,33 @@
 * `--version`
   * Print information about the version of NVBench used to build the executable.
 
+# Device Modification
+
+* `--persistence-mode <state>`, `--pm <state>`
+  * Sets persistence mode for one or more GPU devices.
+  * Applies to the devices described by the most recent `--devices` option,
+    or all devices if `--devices` is not specified.
+  * This option requires root / admin permissions.
+  * This option is only supported on Linux.
+  * This call must precede all other device modification options, if any.
+  * Note that persistence mode is deprecated and will be removed at some point
+    in favor of the new persistence daemon. See the following link for more
+    details: https://docs.nvidia.com/deploy/driver-persistence/index.html
+  * Valid values for `state` are:
+    * `0`: Disable persistence mode.
+    * `1`: Enable persistence mode.
+
+* `--lock-gpu-clocks <rate>`, `--lgc <rate>`
+  * Lock GPU clocks for one or more devices to a particular rate.
+  * Applies to the devices described by the most recent `--devices` option,
+    or all devices if `--devices` is not specified.
+  * This option requires root / admin permissions.
+  * This option is only supported in Volta+ (sm_70+) devices.
+  * Valid values for `rate` are:
+    * `reset`, `unlock`, `none`: Unlock the GPU clocks.
+    * `base`, `tdp`: Lock clocks to base frequency (best for stable results).
+    * `max`, `maximum`: Lock clocks to max frequency (best for fastest results).
+
 # Output
 
 * `--csv <filename/stream>`
@@ -51,7 +78,7 @@
 
 * `--devices <device ids>`, `--device <device ids>`, `-d <device ids>`
   * Limit execution to one or more devices.
-  * `<device ids>` is a single id, or a comma separated list.
+  * `<device ids>` is a single id, a comma separated list, or the string "all".
   * Device ids can be obtained from `--list`.
   * Applies to the most recent `--benchmark`, or all benchmarks if specified
     before any `--benchmark` arguments.

--- a/nvbench/CMakeLists.txt
+++ b/nvbench/CMakeLists.txt
@@ -26,6 +26,10 @@ set(srcs
   detail/state_generator.cxx
 )
 
+if (NVBench_ENABLE_NVML)
+  list(APPEND srcs internal/nvml.cxx)
+endif()
+
 # CUDA 11.0 can't compile json_printer without crashing
 # So for that version fall back to C++ with degraded
 # output ( no PTX version info )
@@ -48,6 +52,8 @@ file_to_string("../docs/cli_help_axis.md"
   ""
   cli_help_axis_text
 )
+
+nvbench_write_config_header("${NVBench_BINARY_DIR}/nvbench/config.cuh")
 
 # nvbench (nvbench::nvbench)
 add_library(nvbench SHARED ${srcs})
@@ -77,4 +83,5 @@ add_dependencies(nvbench.all nvbench_main)
 add_library(nvbench::nvbench ALIAS nvbench)
 add_library(nvbench::main ALIAS nvbench_main)
 
+nvbench_setup_dep_dlls(nvbench)
 nvbench_install_libraries(nvbench nvbench_main)

--- a/nvbench/internal/nvml.cuh
+++ b/nvbench/internal/nvml.cuh
@@ -1,0 +1,119 @@
+/*
+ *  Copyright 2021 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <nvbench/config.cuh>
+#include <nvbench/detail/throw.cuh>
+
+#include <fmt/format.h>
+
+#ifdef NVBENCH_HAS_NVML
+#include <nvml.h>
+#endif // NVBENCH_HAS_NVML
+
+#include <stdexcept>
+
+namespace nvbench::nvml
+{
+
+/// Base class for NVML-specific exceptions
+struct error : std::runtime_error
+{
+  using runtime_error::runtime_error;
+};
+
+/// Thrown when NVML support is disabled.
+struct not_enabled : error
+{
+  not_enabled()
+      : error{"NVML not available. Reconfigure NVBench with the CMake option "
+              "`-DNVBench_ENABLE_NVML=ON`."}
+  {}
+};
+
+// Only `error` and `not_enabled` are defined when NVML is disabled.
+// Other exceptions may hold types defined by NVML.
+#ifdef NVBENCH_HAS_NVML
+
+/// Thrown when a generic NVML call inside NVBENCH_NVML_CALL fails
+struct call_failed : error
+{
+  call_failed(const std::string &filename,
+              std::size_t lineno,
+              const std::string &call,
+              nvmlReturn_t error_code,
+              std::string error_string)
+      : error(fmt::format("{}:{}:\n"
+                          "\tNVML call failed:\n"
+                          "\t\tCall: {}\n"
+                          "\t\tError: ({}) {}",
+                          filename,
+                          lineno,
+                          call,
+                          static_cast<int>(error_code),
+                          error_string))
+      , m_error_code(error_code)
+      , m_error_string(error_string)
+  {}
+
+  [[nodiscard]] nvmlReturn_t get_error_code() const { return m_error_code; }
+
+  [[nodiscard]] const std::string &get_error_string() const
+  {
+    return m_error_string;
+  }
+
+private:
+  nvmlReturn_t m_error_code;
+  std::string m_error_string;
+};
+
+#endif // NVBENCH_HAS_NVML
+
+} // namespace nvbench::nvml
+
+#ifdef NVBENCH_HAS_NVML
+
+#define NVBENCH_NVML_CALL(call)                                                \
+  do                                                                           \
+  {                                                                            \
+    const auto _rr = call;                                                     \
+    if (_rr != NVML_SUCCESS)                                                   \
+    {                                                                          \
+      throw nvbench::nvml::call_failed(__FILE__,                               \
+                                       __LINE__,                               \
+                                       #call,                                  \
+                                       _rr,                                    \
+                                       nvmlErrorString(_rr));                  \
+    }                                                                          \
+  } while (false)
+
+// Same as above, but used for nvmlInit(), where a failure means that
+// nvmlErrorString is not available.
+#define NVBENCH_NVML_CALL_NO_API(call)                                         \
+  do                                                                           \
+  {                                                                            \
+    const auto _rr = call;                                                     \
+    if (_rr != NVML_SUCCESS)                                                   \
+    {                                                                          \
+      throw nvbench::nvml::call_failed(__FILE__, __LINE__, #call, _rr, "");    \
+    }                                                                          \
+  } while (false)
+
+#endif // NVBENCH_HAS_NVML

--- a/nvbench/internal/nvml.cxx
+++ b/nvbench/internal/nvml.cxx
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2021 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <nvbench/internal/nvml.cuh>
+
+#include <nvbench/config.cuh>
+
+#include <fmt/format.h>
+
+#include <nvml.h>
+
+#include <stdexcept>
+
+namespace
+{
+
+// RAII struct that initializes and shuts down NVML
+struct NVMLLifetimeManager
+{
+  NVMLLifetimeManager()
+  {
+    try
+    {
+      NVBENCH_NVML_CALL_NO_API(nvmlInit());
+      m_inited = true;
+    }
+    catch (std::exception &e)
+    {
+      fmt::print("NVML initialization failed:\n {}", e.what());
+    }
+  }
+
+  ~NVMLLifetimeManager()
+  {
+    if (m_inited)
+    {
+      try
+      {
+        NVBENCH_NVML_CALL_NO_API(nvmlShutdown());
+      }
+      catch (std::exception &e)
+      {
+        fmt::print("NVML shutdown failed:\n {}", e.what());
+      }
+    }
+  }
+
+private:
+  bool m_inited{false};
+};
+
+// NVML's lifetime should extend for the entirety of the process, so store in a
+// global.
+auto nvml_lifetime = NVMLLifetimeManager{};
+
+} // namespace

--- a/nvbench/nvbench.cuh
+++ b/nvbench/nvbench.cuh
@@ -22,6 +22,7 @@
 #include <nvbench/benchmark_base.cuh>
 #include <nvbench/benchmark_manager.cuh>
 #include <nvbench/callable.cuh>
+#include <nvbench/config.cuh>
 #include <nvbench/cpu_timer.cuh>
 #include <nvbench/create.cuh>
 #include <nvbench/cuda_call.cuh>

--- a/nvbench/option_parser.cuh
+++ b/nvbench/option_parser.cuh
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <nvbench/device_info.cuh>
 #include <nvbench/printer_multiplex.cuh>
 
 #include <iosfwd>
@@ -89,6 +90,9 @@ private:
   void print_help() const;
   void print_help_axis() const;
 
+  void set_persistence_mode(const std::string &state);
+  void lock_gpu_clocks(const std::string &rate);
+
   void enable_run_once();
 
   void add_benchmark(const std::string &name);
@@ -123,6 +127,11 @@ private:
   // Store benchmark modifiers passed in before any benchmarks are requested as
   // "global args". Replay them after every benchmark.
   std::vector<std::string> m_global_benchmark_args;
+
+  // List of devices specified by the most recent --devices option, or all
+  // devices if --devices has not been used.
+  std::vector<nvbench::device_info> m_recent_devices;
+
   benchmark_vector m_benchmarks;
 
   // Manages lifetimes of any ofstreams opened for m_printer.
@@ -136,6 +145,9 @@ private:
 
   // True if any stdout printers have been added to m_printer.
   bool m_have_stdout_printer{false};
+
+  // Used for device modification commands like --log-gpu-clocks
+  bool m_exit_after_parsing{false};
 };
 
 } // namespace nvbench


### PR DESCRIPTION
Locking clocks is currently only implemented for Volta+ devices.

Example usage: 

```
# Enable persistence mode and lock clocks to base rates for device 3:
my_bench --persistence-mode 3 1 --lock-gpu-clocks 3 base

# Enable persistence mode and lock clocks to base rates for all devices:
my_bench --pm all 1 --lgc all base

# Enable persistence mode and lock clocks to base rates to devices 0 and 3:
my_bench --pm [0,3] 1 --lock-gpu-clocks [0,3] base
```

See the cli_help.md docs for more info.

Ref #6.