### PR TITLE
Fix markdown table

### DIFF
--- a/nvbench/internal/markdown_table.cuh
+++ b/nvbench/internal/markdown_table.cuh
@@ -75,7 +75,7 @@ struct markdown_table : private table_builder
 
 private:
   template <typename Iter>
-  auto print_header(Iter iter)
+  Iter print_header(Iter iter)
   {
     fmt::format_to(iter, m_color ? (m_bg | m_vdiv_fg) : m_no_style, "|");
     for (const column &col : m_columns)
@@ -92,7 +92,7 @@ private:
   }
 
   template <typename Iter>
-  auto print_divider(Iter iter)
+  Iter print_divider(Iter iter)
   {
     iter = fmt::format_to(iter, m_color ? (m_bg | m_vdiv_fg) : m_no_style, "|");
     for (const column &col : m_columns)
@@ -109,7 +109,7 @@ private:
   }
 
   template <typename Iter>
-  auto print_rows(Iter iter)
+  Iter print_rows(Iter iter)
   {
     auto style     = m_bg | m_data_fg;
     auto style_alt = m_bg | m_data_fg_alt;


### PR DESCRIPTION
This is a fix for the following error:
```
nvbench/nvbench/internal/markdown_table.cuh:69:26: error: use of ‘auto nvbench::internal::markdown_table::print_header(Iter) [with Iter = std::back_insert_iterator<std::vector<char> >]’ before deduction of ‘auto’
   69 |     iter = this->print_header(iter);
      |        ~~~~~~~~~~~~~~~~~~^~~~~~
nvbench/nvbench/internal/markdown_table.cuh:70:27: error: use of ‘auto nvbench::internal::markdown_table::print_divider(Iter) [with Iter = std::back_insert_iterator<std::vector<char> >]’ before deduction of ‘auto’
   70 |     iter = this->print_divider(iter);
      |        ~~~~~~~~~~~~~~~~~~~^~~~~~
nvbench/nvbench/internal/markdown_table.cuh:71:24: error: use of ‘auto nvbench::internal::markdown_table::print_rows(Iter) [with Iter = std::back_insert_iterator<std::vector<char> >]’ before deduction of ‘auto’
   71 |     iter = this->print_rows(iter);
      |        ~~~~~~~~~~~~~~~~^~~~~~
```

cmake:  3.21.1
g++:  11.2.1 20210728 (Red Hat 11.2.1-1)
nvcc: 11.5, V11.5.119