### PR TITLE
Enable extra warning flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,18 +6,31 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CUDA_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_LIST_DIR}")
+  set(NVBench_TOPLEVEL_PROJECT ON)
+else()
+  set(NVBench_TOPLEVEL_PROJECT OFF)
+endif()
+
 include(cmake/NVBenchRapidsCMake.cmake)
 nvbench_load_rapids_cmake()
 
 project(NVBench
-  LANGUAGES CUDA CXX # CXX to work around issues with CUDA-only CMake projects.
+  LANGUAGES CUDA CXX
   VERSION 0.1.0
 )
 
 nvbench_init_rapids_cmake()
 
+# See NVIDIA/NVBench#52
+find_package(CUDAToolkit REQUIRED)
+set(cupti_default ON)
+if (${CUDAToolkit_VERSION} VERSION_LESS 11.3)
+  set(cupti_default OFF)
+endif()
+
 option(NVBench_ENABLE_NVML "Build with NVML support from the Cuda Toolkit." ON)
-option(NVBench_ENABLE_CUPTI "Build NVBench with CUPTI." ON)
+option(NVBench_ENABLE_CUPTI "Build NVBench with CUPTI." ${cupti_default})
 
 option(NVBench_ENABLE_TESTING "Build NVBench testing suite." OFF)
 option(NVBench_ENABLE_EXAMPLES "Build NVBench examples." OFF)

--- a/cmake/NVBenchConfigTarget.cmake
+++ b/cmake/NVBenchConfigTarget.cmake
@@ -1,10 +1,81 @@
+include(CheckCXXCompilerFlag)
+
+option(NVBench_ENABLE_WERROR
+  "Treat warnings as errors while compiling NVBench."
+  ${NVBench_TOPLEVEL_PROJECT}
+)
+mark_as_advanced(NVBench_ENABLE_WERROR)
+
 # Builds all NVBench targets (libs, tests, examples, etc).
 add_custom_target(nvbench.all)
 
 set(NVBench_LIBRARY_OUTPUT_DIR "${CMAKE_BINARY_DIR}/lib")
 set(NVBench_EXECUTABLE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/bin")
 
+add_library(nvbench.build_interface INTERFACE)
+
+# TODO Why must this be installed/exported if it's just a private interface?
+# CMake complains about it missing from the export set unless we export it.
+# Is there way to avoid this?
+set_target_properties(nvbench.build_interface PROPERTIES
+  EXPORT_NAME internal_build_interface
+)
+
+function(nvbench_add_cxx_flag target_name type flag)
+  string(MAKE_C_IDENTIFIER "NVBench_CXX_FLAG_${flag}" var)
+  check_cxx_compiler_flag(${flag} ${var})
+
+  if (${${var}})
+    target_compile_options(${target_name} ${type}
+      $<$<COMPILE_LANGUAGE:CXX>:${flag}>
+      $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Xcompiler=${flag}>
+      # FIXME nvc++ case
+    )
+  endif()
+endfunction()
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "/W4")
+
+  if (NVBench_ENABLE_WERROR)
+    nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "/WX")
+  endif()
+
+  # Suppress overly-pedantic/unavoidable warnings brought in with /W4:
+  # C4505: unreferenced local function has been removed
+  # The CUDA `host_runtime.h` header emits this for
+  # `__cudaUnregisterBinaryUtil`.
+  nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "/wd4505")
+else()
+  nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "-Wall")
+  nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "-Wextra")
+  nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "-Wconversion")
+  nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "-Woverloaded-virtual")
+  nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "-Wcast-qual")
+  nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "-Wpointer-arith")
+  nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "-Wunused-local-typedef")
+  nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "-Wunused-parameter")
+  nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "-Wvla")
+  nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "-Wgnu")
+
+  if (NVBench_ENABLE_WERROR)
+    nvbench_add_cxx_flag(nvbench.build_interface INTERFACE "-Werror")
+  endif()
+endif()
+
+# CUDA-specific flags
+target_compile_options(nvbench.build_interface INTERFACE
+  $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Xcudafe=--display_error_number>
+  $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Wno-deprecated-gpu-targets>
+)
+if (NVBench_ENABLE_WERROR)
+  target_compile_options(nvbench.build_interface INTERFACE
+    $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Xcudafe=--promote_warnings>
+  )
+endif()
+
 function(nvbench_config_target target_name)
+  target_link_libraries(${target_name} PRIVATE nvbench.build_interface)
   set_target_properties(${target_name} PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${NVBench_LIBRARY_OUTPUT_DIR}"
     LIBRARY_OUTPUT_DIRECTORY "${NVBench_LIBRARY_OUTPUT_DIR}"

--- a/cmake/NVBenchDependencies.cmake
+++ b/cmake/NVBenchDependencies.cmake
@@ -39,7 +39,7 @@ rapids_cpm_find(nlohmann_json 3.9.1
 )
 
 # nlohmann_json release headers
-add_library(nvbench_json INTERFACE)
+add_library(nvbench_json INTERFACE IMPORTED)
 target_include_directories(nvbench_json SYSTEM INTERFACE
   "${nlohmann_json_SOURCE_DIR}/include"
 )

--- a/cmake/NVBenchExports.cmake
+++ b/cmake/NVBenchExports.cmake
@@ -23,14 +23,14 @@ macro(nvbench_generate_exports)
   rapids_export(BUILD NVBench
     EXPORT_SET nvbench-targets
     NAMESPACE "nvbench::"
-    GLOBAL_TARGETS nvbench main
+    GLOBAL_TARGETS nvbench main internal_build_interface
     LANGUAGES CUDA CXX
     FINAL_CODE_BLOCK nvbench_build_export_code_block
   )
   rapids_export(INSTALL NVBench
     EXPORT_SET nvbench-targets
     NAMESPACE "nvbench::"
-    GLOBAL_TARGETS nvbench main
+    GLOBAL_TARGETS nvbench main internal_build_interface
     LANGUAGES CUDA CXX
     FINAL_CODE_BLOCK nvbench_install_export_code_block
   )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,8 +21,30 @@ foreach(example_src IN LISTS example_srcs)
   target_link_libraries(${example_name} PRIVATE nvbench::main)
   set_target_properties(${example_name} PROPERTIES COMPILE_FEATURES cuda_std_17)
   add_test(NAME ${example_name}
-    COMMAND "$<TARGET_FILE:${example_name}>" --timeout 1
+    COMMAND "$<TARGET_FILE:${example_name}>" --timeout 0.1
   )
 
   add_dependencies(nvbench.example.all ${example_name})
+endforeach()
+
+# Silence some warnings from old thrust headers:
+set(thrust_examples
+  auto_throughput
+  axes
+  exec_tag_sync
+  exec_tag_timer
+  skip
+  throughput
+)
+foreach (example IN LISTS thrust_examples)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    # C4324: structure was padded due to alignment specifier
+    nvbench_add_cxx_flag(nvbench.example.${example} PRIVATE "/wd4324")
+
+    # warning C4201: nonstandard extension used: nameless struct/union:
+    # Fixed in Thrust 1.12.0 (CTK 11.4, NV HPC 21.3)
+    if (${CUDAToolkit_VERSION} VERSION_LESS 11.4)
+      nvbench_add_cxx_flag(nvbench.example.${example} PRIVATE "/wd4201")
+    endif()
+  endif()
 endforeach()

--- a/examples/auto_throughput.cu
+++ b/examples/auto_throughput.cu
@@ -68,8 +68,8 @@ void throughput_bench(nvbench::state &state,
   state.collect_stores_efficiency();
 
   const auto threads_in_block = 256;
-  const auto blocks_in_grid = (elements + threads_in_block - 1) /
-                              threads_in_block;
+  const auto blocks_in_grid =
+    static_cast<int>((elements + threads_in_block - 1) / threads_in_block);
 
   state.exec([&](nvbench::launch &launch) {
     kernel<ItemsPerThread>

--- a/nvbench/CMakeLists.txt
+++ b/nvbench/CMakeLists.txt
@@ -39,10 +39,13 @@ endif()
 # output ( no PTX version info )
 if(CMAKE_CUDA_COMPILER_ID STREQUAL NVIDIA AND
    CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.1)
-  list(APPEND srcs json_printer.cxx)
+  set(json_printer_impl json_printer.cxx)
+  set(json_is_cu FALSE)
 else()
-  list(APPEND srcs json_printer.cu)
+  set(json_printer_impl json_printer.cu)
+  set(json_is_cu TRUE)
 endif()
+list(APPEND srcs ${json_printer_impl})
 
 # Generate doc strings from md files:
 include("../cmake/FileToString.cmake")
@@ -61,31 +64,44 @@ nvbench_write_config_header("${NVBench_BINARY_DIR}/nvbench/config.cuh")
 
 # nvbench (nvbench::nvbench)
 add_library(nvbench SHARED ${srcs})
+nvbench_config_target(nvbench)
 target_include_directories(nvbench PUBLIC
   "$<BUILD_INTERFACE:${NVBench_SOURCE_DIR}>"
   "$<BUILD_INTERFACE:${NVBench_BINARY_DIR}>"
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
-target_link_libraries(nvbench PUBLIC ${ctk_libraries})
-target_link_libraries(nvbench PRIVATE
-  fmt::fmt
-  nvbench_json
-  nvbench_git_revision
+target_link_libraries(nvbench
+  PUBLIC
+    ${ctk_libraries}
+  PRIVATE
+    fmt::fmt
+    nvbench_json
+    nvbench_git_revision
 )
-nvbench_config_target(nvbench)
 target_compile_features(nvbench PUBLIC cuda_std_17 PRIVATE cxx_std_17)
 add_dependencies(nvbench.all nvbench)
 
-# nvbench_main (nvbench::main)
-add_library(nvbench_main OBJECT main.cu)
-nvbench_config_target(nvbench_main)
-target_link_libraries(nvbench_main PUBLIC nvbench)
-set_target_properties(nvbench_main PROPERTIES EXPORT_NAME main)
-add_dependencies(nvbench.all nvbench_main)
+# nvbench.main (nvbench::main)
+add_library(nvbench.main OBJECT main.cu)
+nvbench_config_target(nvbench.main)
+target_link_libraries(nvbench.main PUBLIC nvbench)
+set_target_properties(nvbench.main PROPERTIES EXPORT_NAME main)
+add_dependencies(nvbench.all nvbench.main)
 
 # Support add_subdirectory:
 add_library(nvbench::nvbench ALIAS nvbench)
-add_library(nvbench::main ALIAS nvbench_main)
+add_library(nvbench::main ALIAS nvbench.main)
 
 nvbench_setup_dep_dlls(nvbench)
-nvbench_install_libraries(nvbench nvbench_main)
+nvbench_install_libraries(nvbench nvbench.main nvbench.build_interface)
+
+# nvcc emits several unavoidable warnings while compiling nlohmann_json:
+if (json_is_cu)
+  set_property(SOURCE ${json_printer_impl} APPEND PROPERTY COMPILE_OPTIONS
+    # error #186-D: pointless comparison of unsigned integer with zero
+    $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Xcudafe=--diag_suppress=186>
+    # error #940-D: missing return statement at end of non-void function
+    # (the end of the function in hash.hpp(114) is unreachable)
+    $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Xcudafe=--diag_suppress=940>
+  )
+endif()

--- a/nvbench/axes_metadata.cuh
+++ b/nvbench/axes_metadata.cuh
@@ -95,16 +95,16 @@ private:
   axes_type m_axes;
 };
 
-template <typename ...TypeAxes>
+template <typename... TypeAxes>
 axes_metadata::axes_metadata(nvbench::type_list<TypeAxes...>)
     : axes_metadata{}
 {
-  using type_axes = nvbench::type_list<TypeAxes...>;
-  constexpr auto num_type_axes = nvbench::tl::size<type_axes>::value;
+  using type_axes_list         = nvbench::type_list<TypeAxes...>;
+  constexpr auto num_type_axes = nvbench::tl::size<type_axes_list>::value;
   auto names = axes_metadata::generate_default_type_axis_names(num_type_axes);
 
   auto names_iter = names.begin(); // contents will be moved from
-  nvbench::tl::foreach<type_axes>(
+  nvbench::tl::foreach<type_axes_list>(
     [&axes = m_axes, &names_iter]([[maybe_unused]] auto wrapped_type) {
       // This is always called before other axes are added, so the length of the
       // axes vector will be the type axis index:

--- a/nvbench/axes_metadata.cxx
+++ b/nvbench/axes_metadata.cxx
@@ -167,10 +167,7 @@ const nvbench::type_axis &axes_metadata::get_type_axis(std::size_t index) const
       }
     }
   }
-  throw std::runtime_error(fmt::format("{}:{}: Invalid type axis index: {}.",
-                                       __FILE__,
-                                       __LINE__,
-                                       index));
+  NVBENCH_THROW(std::runtime_error, "Invalid type axis index: {}.", index);
 }
 
 nvbench::type_axis &axes_metadata::get_type_axis(std::size_t index)
@@ -186,10 +183,7 @@ nvbench::type_axis &axes_metadata::get_type_axis(std::size_t index)
       }
     }
   }
-  throw std::runtime_error(fmt::format("{}:{}: Invalid type axis index: {}.",
-                                       __FILE__,
-                                       __LINE__,
-                                       index));
+  NVBENCH_THROW(std::runtime_error, "Invalid type axis index: {}.", index);
 }
 
 const axis_base &axes_metadata::get_axis(std::string_view name) const
@@ -201,8 +195,7 @@ const axis_base &axes_metadata::get_axis(std::string_view name) const
 
   if (iter == m_axes.cend())
   {
-    throw std::runtime_error(
-      fmt::format("{}:{}: Axis '{}' not found.", __FILE__, __LINE__, name));
+    NVBENCH_THROW(std::runtime_error, "Axis '{}' not found.", name);
   }
 
   return **iter;
@@ -217,8 +210,7 @@ axis_base &axes_metadata::get_axis(std::string_view name)
 
   if (iter == m_axes.end())
   {
-    throw std::runtime_error(
-      fmt::format("{}:{}: Axis '{}' not found.", __FILE__, __LINE__, name));
+    NVBENCH_THROW(std::runtime_error, "Axis '{}' not found.", name);
   }
 
   return **iter;
@@ -230,13 +222,11 @@ const axis_base &axes_metadata::get_axis(std::string_view name,
   const auto &axis = this->get_axis(name);
   if (axis.get_type() != type)
   {
-    throw std::runtime_error(fmt::format("{}:{}: Axis '{}' type mismatch "
-                                         "(expected {}, actual {}).",
-                                         __FILE__,
-                                         __LINE__,
-                                         name,
-                                         type,
-                                         axis.get_type()));
+    NVBENCH_THROW(std::runtime_error,
+                  "Axis '{}' type mismatch (expected {}, actual {}).",
+                  name,
+                  type,
+                  axis.get_type());
   }
   return axis;
 }
@@ -247,13 +237,11 @@ axis_base &axes_metadata::get_axis(std::string_view name,
   auto &axis = this->get_axis(name);
   if (axis.get_type() != type)
   {
-    throw std::runtime_error(fmt::format("{}:{}: Axis '{}' type mismatch "
-                                         "(expected {}, actual {}).",
-                                         __FILE__,
-                                         __LINE__,
-                                         name,
-                                         type,
-                                         axis.get_type()));
+    NVBENCH_THROW(std::runtime_error,
+                  "Axis '{}' type mismatch (expected {}, actual {}).",
+                  name,
+                  type,
+                  axis.get_type());
   }
   return axis;
 }

--- a/nvbench/benchmark_base.cxx
+++ b/nvbench/benchmark_base.cxx
@@ -39,7 +39,7 @@ std::unique_ptr<benchmark_base> benchmark_base::clone() const
   result->m_skip_time = m_skip_time;
   result->m_timeout   = m_timeout;
 
-  return std::move(result);
+  return result;
 }
 
 benchmark_base &benchmark_base::set_devices(std::vector<int> device_ids)

--- a/nvbench/benchmark_manager.cxx
+++ b/nvbench/benchmark_manager.cxx
@@ -18,6 +18,8 @@
 
 #include <nvbench/benchmark_manager.cuh>
 
+#include <nvbench/detail/throw.cuh>
+
 #include <fmt/format.h>
 
 #include <algorithm>
@@ -58,8 +60,7 @@ benchmark_manager::get_benchmark(const std::string &name) const
                            });
   if (iter == m_benchmarks.cend())
   {
-    throw std::out_of_range(
-      fmt::format("{}:{}: No benchmark named '{}'.", name));
+    NVBENCH_THROW(std::out_of_range, "No benchmark named '{}'.", name);
   }
 
   return **iter;

--- a/nvbench/cpu_timer.cuh
+++ b/nvbench/cpu_timer.cuh
@@ -51,7 +51,7 @@ struct cpu_timer
     const auto duration = m_stop - m_start;
     const auto ns =
       std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
-    return ns * (1e-9);
+    return static_cast<nvbench::float64_t>(ns) * (1e-9);
   }
 
 private:

--- a/nvbench/cupti_profiler.cxx
+++ b/nvbench/cupti_profiler.cxx
@@ -108,16 +108,16 @@ void cupti_profiler::initialize_profiler()
                   m_device.get_sm_version());
   }
 
-  CUpti_Profiler_Initialize_Params params = {
-    CUpti_Profiler_Initialize_Params_STRUCT_SIZE};
+  CUpti_Profiler_Initialize_Params params{};
+  params.structSize = CUpti_Profiler_Initialize_Params_STRUCT_SIZE;
   cupti_call(cuptiProfilerInitialize(&params));
 }
 
 void cupti_profiler::initialize_chip_name()
 {
-  CUpti_Device_GetChipName_Params params = {
-    CUpti_Device_GetChipName_Params_STRUCT_SIZE};
-  params.deviceIndex = m_device.get_id();
+  CUpti_Device_GetChipName_Params params{};
+  params.structSize  = CUpti_Device_GetChipName_Params_STRUCT_SIZE;
+  params.deviceIndex = static_cast<size_t>(m_device.get_id());
   cupti_call(cuptiDeviceGetChipName(&params));
 
   m_chip_name = std::string(params.pChipName);
@@ -125,10 +125,10 @@ void cupti_profiler::initialize_chip_name()
 
 void cupti_profiler::initialize_availability_image()
 {
-  CUpti_Profiler_GetCounterAvailability_Params params = {
-    CUpti_Profiler_GetCounterAvailability_Params_STRUCT_SIZE};
+  CUpti_Profiler_GetCounterAvailability_Params params{};
 
-  params.ctx = m_device.get_context();
+  params.structSize = CUpti_Profiler_GetCounterAvailability_Params_STRUCT_SIZE;
+  params.ctx        = m_device.get_context();
 
   cupti_call(cuptiProfilerGetCounterAvailability(&params));
 
@@ -141,8 +141,8 @@ void cupti_profiler::initialize_availability_image()
 
 void cupti_profiler::initialize_nvpw()
 {
-  NVPW_InitializeHost_Params params = {NVPW_InitializeHost_Params_STRUCT_SIZE};
-
+  NVPW_InitializeHost_Params params{};
+  params.structSize = NVPW_InitializeHost_Params_STRUCT_SIZE;
   nvpw_call(NVPW_InitializeHost(&params));
 }
 
@@ -158,9 +158,11 @@ public:
                const std::string &metric_name)
       : evaluator_ptr(evaluator_ptr)
   {
-    NVPW_MetricsEvaluator_ConvertMetricNameToMetricEvalRequest_Params params = {
-      NVPW_MetricsEvaluator_ConvertMetricNameToMetricEvalRequest_Params_STRUCT_SIZE};
+    NVPW_MetricsEvaluator_ConvertMetricNameToMetricEvalRequest_Params params =
+      {};
 
+    params.structSize =
+      NVPW_MetricsEvaluator_ConvertMetricNameToMetricEvalRequest_Params_STRUCT_SIZE;
     params.pMetricsEvaluator           = evaluator_ptr;
     params.pMetricName                 = metric_name.c_str();
     params.pMetricEvalRequest          = &request;
@@ -174,9 +176,10 @@ public:
   {
     std::vector<const char *> raw_dependencies;
 
-    NVPW_MetricsEvaluator_GetMetricRawDependencies_Params params = {
-      NVPW_MetricsEvaluator_GetMetricRawDependencies_Params_STRUCT_SIZE};
+    NVPW_MetricsEvaluator_GetMetricRawDependencies_Params params{};
 
+    params.structSize =
+      NVPW_MetricsEvaluator_GetMetricRawDependencies_Params_STRUCT_SIZE;
     params.pMetricsEvaluator           = evaluator_ptr;
     params.pMetricEvalRequests         = &request;
     params.numMetricEvalRequests       = 1;
@@ -209,9 +212,10 @@ public:
                    const std::size_t counter_data_image_size      = 0)
   {
     NVPW_CUDA_MetricsEvaluator_CalculateScratchBufferSize_Params
-      scratch_buffer_param = {
-        NVPW_CUDA_MetricsEvaluator_CalculateScratchBufferSize_Params_STRUCT_SIZE};
+      scratch_buffer_param{};
 
+    scratch_buffer_param.structSize =
+      NVPW_CUDA_MetricsEvaluator_CalculateScratchBufferSize_Params_STRUCT_SIZE;
     scratch_buffer_param.pChipName                 = chip_name.c_str();
     scratch_buffer_param.pCounterAvailabilityImage = counter_availability_image;
 
@@ -220,9 +224,10 @@ public:
 
     scratch_buffer.resize(scratch_buffer_param.scratchBufferSize);
 
-    NVPW_CUDA_MetricsEvaluator_Initialize_Params evaluator_params = {
-      NVPW_CUDA_MetricsEvaluator_Initialize_Params_STRUCT_SIZE};
+    NVPW_CUDA_MetricsEvaluator_Initialize_Params evaluator_params{};
 
+    evaluator_params.structSize =
+      NVPW_CUDA_MetricsEvaluator_Initialize_Params_STRUCT_SIZE;
     evaluator_params.scratchBufferSize         = scratch_buffer.size();
     evaluator_params.pScratchBuffer            = scratch_buffer.data();
     evaluator_params.pChipName                 = chip_name.c_str();
@@ -240,9 +245,9 @@ public:
   {
     if (initialized)
     {
-      NVPW_MetricsEvaluator_Destroy_Params params = {
-        NVPW_MetricsEvaluator_Destroy_Params_STRUCT_SIZE};
+      NVPW_MetricsEvaluator_Destroy_Params params{};
 
+      params.structSize = NVPW_MetricsEvaluator_Destroy_Params_STRUCT_SIZE;
       params.pMetricsEvaluator = evaluator_ptr;
 
       nvpw_call(NVPW_MetricsEvaluator_Destroy(&params));
@@ -289,7 +294,8 @@ namespace
 
   for (auto &raw_name : raw_metric_names)
   {
-    NVPA_RawMetricRequest metricRequest = {NVPA_RAW_METRIC_REQUEST_STRUCT_SIZE};
+    NVPA_RawMetricRequest metricRequest{};
+    metricRequest.structSize            = NVPA_RAW_METRIC_REQUEST_STRUCT_SIZE;
     metricRequest.pMetricName           = raw_name;
     metricRequest.isolated              = true;
     metricRequest.keepInstances         = true;
@@ -306,9 +312,9 @@ class metrics_config
   void create(const std::string &chip_name,
               const std::uint8_t *availability_image)
   {
-    NVPW_CUDA_RawMetricsConfig_Create_V2_Params params = {
-      NVPW_CUDA_RawMetricsConfig_Create_V2_Params_STRUCT_SIZE};
+    NVPW_CUDA_RawMetricsConfig_Create_V2_Params params{};
 
+    params.structSize = NVPW_CUDA_RawMetricsConfig_Create_V2_Params_STRUCT_SIZE;
     params.activityKind              = NVPA_ACTIVITY_KIND_PROFILER;
     params.pChipName                 = chip_name.c_str();
     params.pCounterAvailabilityImage = availability_image;
@@ -321,9 +327,10 @@ class metrics_config
 
   void set_availability_image(const std::uint8_t *availability_image)
   {
-    NVPW_RawMetricsConfig_SetCounterAvailability_Params params = {
-      NVPW_RawMetricsConfig_SetCounterAvailability_Params_STRUCT_SIZE};
+    NVPW_RawMetricsConfig_SetCounterAvailability_Params params{};
 
+    params.structSize =
+      NVPW_RawMetricsConfig_SetCounterAvailability_Params_STRUCT_SIZE;
     params.pRawMetricsConfig         = raw_metrics_config;
     params.pCounterAvailabilityImage = availability_image;
 
@@ -332,9 +339,9 @@ class metrics_config
 
   void begin_config_group()
   {
-    NVPW_RawMetricsConfig_BeginPassGroup_Params params = {
-      NVPW_RawMetricsConfig_BeginPassGroup_Params_STRUCT_SIZE};
+    NVPW_RawMetricsConfig_BeginPassGroup_Params params{};
 
+    params.structSize = NVPW_RawMetricsConfig_BeginPassGroup_Params_STRUCT_SIZE;
     params.pRawMetricsConfig = raw_metrics_config;
 
     nvpw_call(NVPW_RawMetricsConfig_BeginPassGroup(&params));
@@ -342,9 +349,9 @@ class metrics_config
 
   void add_metrics(const std::vector<NVPA_RawMetricRequest> &raw_metric_requests)
   {
-    NVPW_RawMetricsConfig_AddMetrics_Params params = {
-      NVPW_RawMetricsConfig_AddMetrics_Params_STRUCT_SIZE};
+    NVPW_RawMetricsConfig_AddMetrics_Params params{};
 
+    params.structSize = NVPW_RawMetricsConfig_AddMetrics_Params_STRUCT_SIZE;
     params.pRawMetricsConfig  = raw_metrics_config;
     params.pRawMetricRequests = raw_metric_requests.data();
     params.numMetricRequests  = raw_metric_requests.size();
@@ -354,9 +361,9 @@ class metrics_config
 
   void end_config_group()
   {
-    NVPW_RawMetricsConfig_EndPassGroup_Params params = {
-      NVPW_RawMetricsConfig_EndPassGroup_Params_STRUCT_SIZE};
+    NVPW_RawMetricsConfig_EndPassGroup_Params params{};
 
+    params.structSize = NVPW_RawMetricsConfig_EndPassGroup_Params_STRUCT_SIZE;
     params.pRawMetricsConfig = raw_metrics_config;
 
     nvpw_call(NVPW_RawMetricsConfig_EndPassGroup(&params));
@@ -364,9 +371,10 @@ class metrics_config
 
   void generate()
   {
-    NVPW_RawMetricsConfig_GenerateConfigImage_Params params = {
-      NVPW_RawMetricsConfig_GenerateConfigImage_Params_STRUCT_SIZE};
+    NVPW_RawMetricsConfig_GenerateConfigImage_Params params{};
 
+    params.structSize =
+      NVPW_RawMetricsConfig_GenerateConfigImage_Params_STRUCT_SIZE;
     params.pRawMetricsConfig = raw_metrics_config;
 
     nvpw_call(NVPW_RawMetricsConfig_GenerateConfigImage(&params));
@@ -388,9 +396,9 @@ public:
 
   [[nodiscard]] std::vector<std::uint8_t> get_config_image()
   {
-    NVPW_RawMetricsConfig_GetConfigImage_Params params = {
-      NVPW_RawMetricsConfig_GetConfigImage_Params_STRUCT_SIZE};
+    NVPW_RawMetricsConfig_GetConfigImage_Params params{};
 
+    params.structSize = NVPW_RawMetricsConfig_GetConfigImage_Params_STRUCT_SIZE;
     params.pRawMetricsConfig = raw_metrics_config;
     params.bytesAllocated    = 0;
     params.pBuffer           = nullptr;
@@ -409,9 +417,9 @@ public:
   {
     if (initialized)
     {
-      NVPW_RawMetricsConfig_Destroy_Params params = {
-        NVPW_RawMetricsConfig_Destroy_Params_STRUCT_SIZE};
+      NVPW_RawMetricsConfig_Destroy_Params params{};
 
+      params.structSize = NVPW_RawMetricsConfig_Destroy_Params_STRUCT_SIZE;
       params.pRawMetricsConfig = raw_metrics_config;
 
       NVPW_RawMetricsConfig_Destroy(&params);
@@ -445,9 +453,9 @@ public:
   counter_data_builder(const std::string &chip_name,
                        const std::uint8_t *pCounterAvailabilityImage)
   {
-    NVPW_CUDA_CounterDataBuilder_Create_Params params = {
-      NVPW_CUDA_CounterDataBuilder_Create_Params_STRUCT_SIZE};
+    NVPW_CUDA_CounterDataBuilder_Create_Params params{};
 
+    params.structSize = NVPW_CUDA_CounterDataBuilder_Create_Params_STRUCT_SIZE;
     params.pChipName                 = chip_name.c_str();
     params.pCounterAvailabilityImage = pCounterAvailabilityImage;
 
@@ -461,9 +469,9 @@ public:
   {
     if (initialized)
     {
-      NVPW_CounterDataBuilder_Destroy_Params params = {
-        NVPW_CounterDataBuilder_Destroy_Params_STRUCT_SIZE};
+      NVPW_CounterDataBuilder_Destroy_Params params{};
 
+      params.structSize = NVPW_CounterDataBuilder_Destroy_Params_STRUCT_SIZE;
       params.pCounterDataBuilder = builder;
 
       NVPW_CounterDataBuilder_Destroy(&params);
@@ -487,9 +495,9 @@ void cupti_profiler::initialize_counter_data_prefix_image()
   counter_data_builder data_builder(m_chip_name, counter_availability_image);
 
   {
-    NVPW_CounterDataBuilder_AddMetrics_Params params = {
-      NVPW_CounterDataBuilder_AddMetrics_Params_STRUCT_SIZE};
+    NVPW_CounterDataBuilder_AddMetrics_Params params{};
 
+    params.structSize = NVPW_CounterDataBuilder_AddMetrics_Params_STRUCT_SIZE;
     params.pCounterDataBuilder = data_builder.builder;
     params.pRawMetricRequests  = raw_metric_requests.data();
     params.numMetricRequests   = raw_metric_requests.size();
@@ -498,9 +506,10 @@ void cupti_profiler::initialize_counter_data_prefix_image()
   }
 
   {
-    NVPW_CounterDataBuilder_GetCounterDataPrefix_Params params = {
-      NVPW_CounterDataBuilder_GetCounterDataPrefix_Params_STRUCT_SIZE};
+    NVPW_CounterDataBuilder_GetCounterDataPrefix_Params params{};
 
+    params.structSize =
+      NVPW_CounterDataBuilder_GetCounterDataPrefix_Params_STRUCT_SIZE;
     params.pCounterDataBuilder = data_builder.builder;
     params.bytesAllocated      = 0;
     params.pBuffer             = nullptr;
@@ -521,9 +530,10 @@ namespace
 [[nodiscard]] std::size_t
 get_counter_data_image_size(CUpti_Profiler_CounterDataImageOptions *options)
 {
-  CUpti_Profiler_CounterDataImage_CalculateSize_Params params = {
-    CUpti_Profiler_CounterDataImage_CalculateSize_Params_STRUCT_SIZE};
+  CUpti_Profiler_CounterDataImage_CalculateSize_Params params{};
 
+  params.structSize =
+    CUpti_Profiler_CounterDataImage_CalculateSize_Params_STRUCT_SIZE;
   params.pOptions = options;
   params.sizeofCounterDataImageOptions =
     CUpti_Profiler_CounterDataImageOptions_STRUCT_SIZE;
@@ -547,9 +557,10 @@ void cupti_profiler::initialize_counter_data_image()
   m_data_image.resize(get_counter_data_image_size(&counter_data_image_options));
 
   {
-    CUpti_Profiler_CounterDataImage_Initialize_Params params = {
-      CUpti_Profiler_CounterDataImage_Initialize_Params_STRUCT_SIZE};
+    CUpti_Profiler_CounterDataImage_Initialize_Params params{};
 
+    params.structSize =
+      CUpti_Profiler_CounterDataImage_Initialize_Params_STRUCT_SIZE;
     params.sizeofCounterDataImageOptions =
       CUpti_Profiler_CounterDataImageOptions_STRUCT_SIZE;
     params.pOptions             = &counter_data_image_options;
@@ -560,9 +571,10 @@ void cupti_profiler::initialize_counter_data_image()
   }
 
   {
-    CUpti_Profiler_CounterDataImage_CalculateScratchBufferSize_Params params = {
-      CUpti_Profiler_CounterDataImage_CalculateScratchBufferSize_Params_STRUCT_SIZE};
+    CUpti_Profiler_CounterDataImage_CalculateScratchBufferSize_Params params{};
 
+    params.structSize =
+      CUpti_Profiler_CounterDataImage_CalculateScratchBufferSize_Params_STRUCT_SIZE;
     params.counterDataImageSize = m_data_image.size();
     params.pCounterDataImage    = &m_data_image[0];
 
@@ -573,9 +585,10 @@ void cupti_profiler::initialize_counter_data_image()
   }
 
   {
-    CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params params = {
-      CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params_STRUCT_SIZE};
+    CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params params{};
 
+    params.structSize =
+      CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params_STRUCT_SIZE;
     params.counterDataImageSize         = m_data_image.size();
     params.pCounterDataImage            = &m_data_image[0];
     params.counterDataScratchBufferSize = m_data_scratch_buffer.size();
@@ -589,9 +602,8 @@ cupti_profiler::~cupti_profiler()
 {
   if (is_initialized())
   {
-    CUpti_Profiler_DeInitialize_Params params = {
-      CUpti_Profiler_DeInitialize_Params_STRUCT_SIZE};
-
+    CUpti_Profiler_DeInitialize_Params params{};
+    params.structSize = CUpti_Profiler_DeInitialize_Params_STRUCT_SIZE;
     cuptiProfilerDeInitialize(&params);
   }
 }
@@ -604,9 +616,9 @@ bool cupti_profiler::is_initialized() const
 void cupti_profiler::prepare_user_loop()
 {
   {
-    CUpti_Profiler_BeginSession_Params params = {
-      CUpti_Profiler_BeginSession_Params_STRUCT_SIZE};
+    CUpti_Profiler_BeginSession_Params params{};
 
+    params.structSize = CUpti_Profiler_BeginSession_Params_STRUCT_SIZE;
     params.ctx                          = nullptr;
     params.counterDataImageSize         = m_data_image.size();
     params.pCounterDataImage            = &m_data_image[0];
@@ -623,9 +635,9 @@ void cupti_profiler::prepare_user_loop()
   }
 
   {
-    CUpti_Profiler_SetConfig_Params params = {
-      CUpti_Profiler_SetConfig_Params_STRUCT_SIZE};
+    CUpti_Profiler_SetConfig_Params params{};
 
+    params.structSize       = CUpti_Profiler_SetConfig_Params_STRUCT_SIZE;
     params.pConfig          = &m_config_image[0];
     params.configSize       = m_config_image.size();
     params.minNestingLevel  = 1;
@@ -639,25 +651,24 @@ void cupti_profiler::prepare_user_loop()
 void cupti_profiler::start_user_loop()
 {
   {
-    CUpti_Profiler_BeginPass_Params params = {
-      CUpti_Profiler_BeginPass_Params_STRUCT_SIZE};
-
+    CUpti_Profiler_BeginPass_Params params{};
+    params.structSize = CUpti_Profiler_BeginPass_Params_STRUCT_SIZE;
     cupti_call(cuptiProfilerBeginPass(&params));
   }
 
   {
-    CUpti_Profiler_EnableProfiling_Params params = {
-      CUpti_Profiler_EnableProfiling_Params_STRUCT_SIZE};
-
+    CUpti_Profiler_EnableProfiling_Params params{};
+    params.structSize = CUpti_Profiler_EnableProfiling_Params_STRUCT_SIZE;
     cupti_call(cuptiProfilerEnableProfiling(&params));
   }
 
   {
-    CUpti_Profiler_PushRange_Params params = {
-      CUpti_Profiler_PushRange_Params_STRUCT_SIZE};
+    CUpti_Profiler_PushRange_Params params{};
 
     std::string rangeName = "nvbench";
-    params.pRangeName     = rangeName.c_str();
+
+    params.structSize = CUpti_Profiler_PushRange_Params_STRUCT_SIZE;
+    params.pRangeName = rangeName.c_str();
 
     cupti_call(cuptiProfilerPushRange(&params));
   }
@@ -666,25 +677,22 @@ void cupti_profiler::start_user_loop()
 void cupti_profiler::stop_user_loop()
 {
   {
-    CUpti_Profiler_PopRange_Params params = {
-      CUpti_Profiler_PopRange_Params_STRUCT_SIZE};
-
+    CUpti_Profiler_PopRange_Params params{};
+    params.structSize = CUpti_Profiler_PopRange_Params_STRUCT_SIZE;
     cupti_call(cuptiProfilerPopRange(&params));
   }
 
   {
-    CUpti_Profiler_DisableProfiling_Params params = {
-      CUpti_Profiler_DisableProfiling_Params_STRUCT_SIZE};
-
+    CUpti_Profiler_DisableProfiling_Params params{};
+    params.structSize = CUpti_Profiler_DisableProfiling_Params_STRUCT_SIZE;
     cupti_call(cuptiProfilerDisableProfiling(&params));
   }
 }
 
 bool cupti_profiler::is_replay_required()
 {
-  CUpti_Profiler_EndPass_Params params = {
-    CUpti_Profiler_EndPass_Params_STRUCT_SIZE};
-
+  CUpti_Profiler_EndPass_Params params{};
+  params.structSize = CUpti_Profiler_EndPass_Params_STRUCT_SIZE;
   cupti_call(cuptiProfilerEndPass(&params));
 
   return !params.allPassesSubmitted;
@@ -693,23 +701,20 @@ bool cupti_profiler::is_replay_required()
 void cupti_profiler::process_user_loop()
 {
   {
-    CUpti_Profiler_FlushCounterData_Params params = {
-      CUpti_Profiler_FlushCounterData_Params_STRUCT_SIZE};
-
+    CUpti_Profiler_FlushCounterData_Params params{};
+    params.structSize = CUpti_Profiler_FlushCounterData_Params_STRUCT_SIZE;
     cupti_call(cuptiProfilerFlushCounterData(&params));
   }
 
   {
-    CUpti_Profiler_UnsetConfig_Params params = {
-      CUpti_Profiler_UnsetConfig_Params_STRUCT_SIZE};
-
+    CUpti_Profiler_UnsetConfig_Params params{};
+    params.structSize = CUpti_Profiler_UnsetConfig_Params_STRUCT_SIZE;
     cupti_call(cuptiProfilerUnsetConfig(&params));
   }
 
   {
-    CUpti_Profiler_EndSession_Params params = {
-      CUpti_Profiler_EndSession_Params_STRUCT_SIZE};
-
+    CUpti_Profiler_EndSession_Params params{};
+    params.structSize = CUpti_Profiler_EndSession_Params_STRUCT_SIZE;
     cupti_call(cuptiProfilerEndSession(&params));
   }
 }
@@ -722,9 +727,9 @@ std::vector<double> cupti_profiler::get_counter_values()
                              m_data_image.size());
 
   {
-    NVPW_CounterData_GetNumRanges_Params params = {
-      NVPW_CounterData_GetNumRanges_Params_STRUCT_SIZE};
+    NVPW_CounterData_GetNumRanges_Params params{};
 
+    params.structSize        = NVPW_CounterData_GetNumRanges_Params_STRUCT_SIZE;
     params.pCounterDataImage = m_data_image.data();
     nvpw_call(NVPW_CounterData_GetNumRanges(&params));
 
@@ -745,9 +750,10 @@ std::vector<double> cupti_profiler::get_counter_values()
     eval_request request = evaluator.create_request(metric_name);
 
     {
-      NVPW_MetricsEvaluator_SetDeviceAttributes_Params params = {
-        NVPW_MetricsEvaluator_SetDeviceAttributes_Params_STRUCT_SIZE};
+      NVPW_MetricsEvaluator_SetDeviceAttributes_Params params{};
 
+      params.structSize =
+        NVPW_MetricsEvaluator_SetDeviceAttributes_Params_STRUCT_SIZE;
       params.pMetricsEvaluator    = evaluator;
       params.pCounterDataImage    = m_data_image.data();
       params.counterDataImageSize = m_data_image.size();
@@ -756,9 +762,10 @@ std::vector<double> cupti_profiler::get_counter_values()
     }
 
     {
-      NVPW_MetricsEvaluator_EvaluateToGpuValues_Params params = {
-        NVPW_MetricsEvaluator_EvaluateToGpuValues_Params_STRUCT_SIZE};
+      NVPW_MetricsEvaluator_EvaluateToGpuValues_Params params{};
 
+      params.structSize =
+        NVPW_MetricsEvaluator_EvaluateToGpuValues_Params_STRUCT_SIZE;
       params.pMetricsEvaluator           = evaluator;
       params.pMetricEvalRequests         = &request.request;
       params.numMetricEvalRequests       = 1;

--- a/nvbench/cupti_profiler.cxx
+++ b/nvbench/cupti_profiler.cxx
@@ -16,10 +16,14 @@
  *  limitations under the License.
  */
 
+#include <nvbench/cupti_profiler.cuh>
+
+#include <nvbench/detail/throw.cuh>
+#include <nvbench/device_info.cuh>
+
 #include <cupti_profiler_target.h>
 #include <cupti_target.h>
-#include <nvbench/cupti_profiler.cuh>
-#include <nvbench/device_info.cuh>
+
 #include <nvperf_cuda_host.h>
 #include <nvperf_host.h>
 #include <nvperf_target.h>
@@ -41,8 +45,7 @@ void cupti_call(const CUptiResult status)
     const char *errstr{};
     cuptiGetResultString(status, &errstr);
 
-    throw std::runtime_error(
-      fmt::format("CUPTI call returned error: {}\n", errstr));
+    NVBENCH_THROW(std::runtime_error, "CUPTI call returned error: {}", errstr);
   }
 }
 
@@ -50,8 +53,7 @@ void nvpw_call(const NVPA_Status status)
 {
   if (status != NVPA_STATUS_SUCCESS)
   {
-    throw std::runtime_error(
-      fmt::format("NVPW call returned error: {}\n", status));
+    NVBENCH_THROW(std::runtime_error, "NVPW call returned error: {}", status);
   }
 }
 
@@ -100,9 +102,10 @@ void cupti_profiler::initialize_profiler()
 {
   if (!m_device.is_cupti_supported())
   {
-    throw std::runtime_error(fmt::format("Device: {} isn't supported (CC {})",
-                                         m_device.get_id(),
-                                         m_device.get_sm_version()));
+    NVBENCH_THROW(std::runtime_error,
+                  "Device: {} isn't supported (CC {})",
+                  m_device.get_id(),
+                  m_device.get_sm_version());
   }
 
   CUpti_Profiler_Initialize_Params params = {
@@ -727,7 +730,9 @@ std::vector<double> cupti_profiler::get_counter_values()
 
     if (params.numRanges != 1)
     {
-      throw std::runtime_error("Something's gone wrong, one range is expected");
+      NVBENCH_THROW(std::runtime_error,
+                    "{}",
+                    "Something's gone wrong, one range is expected");
     }
   }
 

--- a/nvbench/detail/measure_cold.cu
+++ b/nvbench/detail/measure_cold.cu
@@ -19,6 +19,7 @@
 #include <nvbench/detail/measure_cold.cuh>
 
 #include <nvbench/benchmark_base.cuh>
+#include <nvbench/detail/throw.cuh>
 #include <nvbench/device_info.cuh>
 #include <nvbench/printer_base.cuh>
 #include <nvbench/state.cuh>
@@ -49,17 +50,15 @@ void measure_cold_base::check()
   const auto device = m_state.get_device();
   if (!device)
   {
-    throw std::runtime_error(fmt::format("{}:{}: Device required for `cold` "
-                                         "measurement.",
-                                         __FILE__,
-                                         __LINE__));
+    NVBENCH_THROW(std::runtime_error,
+                  "{}",
+                  "Device required for `cold` measurement.");
   }
   if (!device->is_active())
   { // This means something went wrong higher up. Throw an error.
-    throw std::runtime_error(fmt::format("{}:{}: Internal error: Current "
-                                         "device is not active.",
-                                         __FILE__,
-                                         __LINE__));
+    NVBENCH_THROW(std::runtime_error,
+                  "{}",
+                  "Internal error: Current device is not active.");
   }
 }
 
@@ -216,7 +215,7 @@ void measure_cold_base::check_skip_time(nvbench::float64_t warmup_time)
                               m_skip_time * 1e6);
 
     m_state.skip(reason);
-    throw std::runtime_error{std::move(reason)};
+    NVBENCH_THROW(std::runtime_error, "{}", std::move(reason));
   }
 }
 

--- a/nvbench/detail/measure_hot.cu
+++ b/nvbench/detail/measure_hot.cu
@@ -19,6 +19,7 @@
 #include <nvbench/detail/measure_hot.cuh>
 
 #include <nvbench/benchmark_base.cuh>
+#include <nvbench/detail/throw.cuh>
 #include <nvbench/device_info.cuh>
 #include <nvbench/printer_base.cuh>
 #include <nvbench/state.cuh>
@@ -70,17 +71,15 @@ void measure_hot_base::check()
   const auto device = m_state.get_device();
   if (!device)
   {
-    throw std::runtime_error(fmt::format("{}:{}: Device required for `hot` "
-                                         "measurement.",
-                                         __FILE__,
-                                         __LINE__));
+    NVBENCH_THROW(std::runtime_error,
+                  "{}",
+                  "Device required for `hot` measurement.");
   }
   if (!device->is_active())
   { // This means something went wrong higher up. Throw an error.
-    throw std::runtime_error(fmt::format("{}:{}: Internal error: Current "
-                                         "device is not active.",
-                                         __FILE__,
-                                         __LINE__));
+    NVBENCH_THROW(std::runtime_error,
+                  "{}",
+                  "Internal error: Current device is not active.");
   }
 }
 
@@ -158,7 +157,7 @@ void measure_hot_base::check_skip_time(nvbench::float64_t warmup_time)
                               m_skip_time * 1e6);
 
     m_state.skip(reason);
-    throw std::runtime_error{std::move(reason)};
+    NVBENCH_THROW(std::runtime_error, "{}", std::move(reason));
   }
 }
 

--- a/nvbench/detail/measure_hot.cuh
+++ b/nvbench/detail/measure_hot.cuh
@@ -179,8 +179,9 @@ private:
       m_total_samples += batch_size;
 
       // Predict number of remaining iterations:
-      batch_size = (m_min_time - m_total_cuda_time) /
-                   (m_total_cuda_time / m_total_samples);
+      batch_size = static_cast<nvbench::int64_t>(
+        (m_min_time - m_total_cuda_time) /
+        (m_total_cuda_time / static_cast<nvbench::float64_t>(m_total_samples)));
 
       m_timeout_timer.stop();
       const auto total_time = m_timeout_timer.get_duration();

--- a/nvbench/float64_axis.cxx
+++ b/nvbench/float64_axis.cxx
@@ -30,6 +30,6 @@ std::string float64_axis::do_get_input_string(std::size_t i) const
   return fmt::format("{:0.5g}", m_values[i]);
 }
 
-std::string float64_axis::do_get_description(std::size_t i) const { return {}; }
+std::string float64_axis::do_get_description(std::size_t) const { return {}; }
 
 } // namespace nvbench

--- a/nvbench/int64_axis.cxx
+++ b/nvbench/int64_axis.cxx
@@ -18,6 +18,8 @@
 
 #include <nvbench/int64_axis.cuh>
 
+#include <nvbench/detail/throw.cuh>
+
 #include <fmt/format.h>
 
 #include <algorithm>
@@ -45,12 +47,10 @@ void int64_axis::set_inputs(std::vector<int64_t> inputs, int64_axis_flags flags)
     auto conv = [](int64_t in) -> int64_t {
       if (in < 0 || in >= 64)
       {
-        throw std::runtime_error(fmt::format("{}:{}: Input value exceeds valid "
-                                             "range for power-of-two mode. "
-                                             "Input={} ValidRange=[0, 63]",
-                                             __FILE__,
-                                             __LINE__,
-                                             in));
+        NVBENCH_THROW(std::runtime_error,
+                      "Input value exceeds valid range for power-of-two mode. "
+                      "Input={} ValidRange=[0, 63]",
+                      in);
       }
       return int64_axis::compute_pow2(in);
     };

--- a/nvbench/internal/table_builder.cuh
+++ b/nvbench/internal/table_builder.cuh
@@ -73,7 +73,7 @@ struct table_builder
     m_num_rows = nvbench::detail::transform_reduce(
       m_columns.cbegin(),
       m_columns.cend(),
-      0ll,
+      std::size_t{},
       [](const auto &a, const auto &b) { return a > b ? a : b; },
       [](const column &col) { return col.rows.size(); });
     std::for_each(m_columns.begin(),

--- a/nvbench/markdown_printer.cu
+++ b/nvbench/markdown_printer.cu
@@ -420,7 +420,7 @@ std::string markdown_printer::do_format_item_rate(const summary &data)
 
 std::string markdown_printer::do_format_bytes(const summary &data)
 {
-  const auto bytes = data.get_int64("value");
+  const auto bytes = static_cast<nvbench::float64_t>(data.get_int64("value"));
   if (bytes >= 1024. * 1024. * 1024.) // 1 GiB
   {
     return fmt::format("{:0.3f} GiB", bytes / (1024. * 1024. * 1024.));

--- a/nvbench/named_values.cxx
+++ b/nvbench/named_values.cxx
@@ -18,6 +18,8 @@
 
 #include <nvbench/named_values.cuh>
 
+#include <nvbench/detail/throw.cuh>
+
 #include <fmt/format.h>
 
 #include <algorithm>
@@ -68,8 +70,7 @@ named_values::get_value(const std::string &name) const
                  [&name](const auto &val) { return val.name == name; });
   if (iter == m_storage.cend())
   {
-    throw std::runtime_error(
-      fmt::format("{}:{}: No value with name '{}'.", __FILE__, __LINE__, name));
+    NVBENCH_THROW(std::runtime_error, "No value with name '{}'.", name);
   }
   return iter->value;
 }
@@ -91,11 +92,9 @@ named_values::type named_values::get_type(const std::string &name) const
       {
         return nvbench::named_values::type::string;
       }
-      throw std::runtime_error(fmt::format("{}:{}: Unknown variant type for "
-                                           "entry '{}'.",
-                                           __FILE__,
-                                           __LINE__,
-                                           name));
+      NVBENCH_THROW(std::runtime_error,
+                    "Unknown variant type for entry '{}'.",
+                    name);
     },
     this->get_value(name));
 }
@@ -107,12 +106,10 @@ try
 }
 catch (std::exception &err)
 {
-  throw std::runtime_error(fmt::format("{}:{}: Error looking up int64 value "
-                                       "`{}`:\n{}",
-                                       __FILE__,
-                                       __LINE__,
-                                       name,
-                                       err.what()));
+  NVBENCH_THROW(std::runtime_error,
+                "Error looking up int64 value `{}`:\n{}",
+                name,
+                err.what());
 }
 
 nvbench::float64_t named_values::get_float64(const std::string &name) const
@@ -122,12 +119,10 @@ try
 }
 catch (std::exception &err)
 {
-  throw std::runtime_error(fmt::format("{}:{}: Error looking up float64 value "
-                                       "`{}`:\n{}",
-                                       __FILE__,
-                                       __LINE__,
-                                       name,
-                                       err.what()));
+  NVBENCH_THROW(std::runtime_error,
+                "Error looking up float64 value `{}`:\n{}",
+                name,
+                err.what());
 }
 
 const std::string &named_values::get_string(const std::string &name) const
@@ -137,12 +132,10 @@ try
 }
 catch (std::exception &err)
 {
-  throw std::runtime_error(fmt::format("{}:{}: Error looking up string value "
-                                       "`{}`:\n{}",
-                                       __FILE__,
-                                       __LINE__,
-                                       name,
-                                       err.what()));
+  NVBENCH_THROW(std::runtime_error,
+                "Error looking up string value `{}`:\n{}",
+                name,
+                err.what());
 }
 
 void named_values::set_int64(std::string name, nvbench::int64_t value)

--- a/nvbench/state.cxx
+++ b/nvbench/state.cxx
@@ -19,6 +19,7 @@
 #include <nvbench/state.cuh>
 
 #include <nvbench/benchmark_base.cuh>
+#include <nvbench/detail/throw.cuh>
 #include <nvbench/types.cuh>
 
 #include <fmt/color.h>
@@ -127,8 +128,7 @@ const summary &state::get_summary(std::string_view name) const
                  [&name](const auto &s) { return s.get_name() == name; });
   if (iter == m_summaries.cend())
   {
-    throw std::runtime_error(
-      fmt::format("{}:{}: No summary named '{}'.", __FILE__, __LINE__, name));
+    NVBENCH_THROW(std::runtime_error, "No summary named '{}'.", name);
   }
   return *iter;
 }
@@ -140,8 +140,7 @@ summary &state::get_summary(std::string_view name)
                            [&name](auto &s) { return s.get_name() == name; });
   if (iter == m_summaries.end())
   {
-    throw std::runtime_error(
-      fmt::format("{}:{}: No summary named '{}'.", __FILE__, __LINE__, name));
+    NVBENCH_THROW(std::runtime_error, "No summary named '{}'.", name);
   }
   return *iter;
 }

--- a/nvbench/state.cxx
+++ b/nvbench/state.cxx
@@ -187,8 +187,8 @@ std::string state::get_axis_values_as_string(bool color) const
     if (axis_type == named_values::type::int64 &&
         axes.get_int64_axis(name).is_power_of_two())
     {
-      const nvbench::uint64_t value    = m_axis_values.get_int64(name);
-      const nvbench::uint64_t exponent = int64_axis::compute_log2(value);
+      const nvbench::int64_t value    = m_axis_values.get_int64(name);
+      const nvbench::int64_t exponent = int64_axis::compute_log2(value);
       append_key_value(name, exponent, "2^{}");
     }
     else if (axis_type == named_values::type::float64)

--- a/nvbench/type_axis.cxx
+++ b/nvbench/type_axis.cxx
@@ -18,6 +18,8 @@
 
 #include <nvbench/type_axis.cuh>
 
+#include <nvbench/detail/throw.cuh>
+
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
@@ -56,10 +58,12 @@ std::size_t type_axis::get_type_index(const std::string &input_string) const
     std::find(m_input_strings.cbegin(), m_input_strings.cend(), input_string);
   if (it == m_input_strings.end())
   {
-    throw std::runtime_error(
-      fmt::format("{}:{}: Invalid input string '{}' for type_axis `{}`.\n"
+    NVBENCH_THROW(std::runtime_error,
+                  "Invalid input string '{}' for type_axis `{}`.\n"
                   "Valid input strings: {}",
-      __FILE__, __LINE__, input_string, this->get_name(), m_input_strings));
+                  input_string,
+                  this->get_name(),
+                  m_input_strings);
   }
 
   return it - m_input_strings.cbegin();

--- a/testing/benchmark.cu
+++ b/testing/benchmark.cu
@@ -138,7 +138,7 @@ void test_type_configs()
   lots_of_types_bench bench;
   bench.set_type_axes_names({"Integer", "Float", "Other"});
 
-  ASSERT(bench.num_type_configs == 16);
+  static_assert(bench.num_type_configs == 16);
 
   std::size_t idx = 0;
   fmt::memory_buffer buffer;

--- a/testing/range.cu
+++ b/testing/range.cu
@@ -64,11 +64,12 @@ void test_fp_tolerance()
   // Make sure that the range is padded a bit for floats to prevent rounding
   // errors from skipping `end`. This test will trigger failures without
   // the padding.
-  const nvbench::float32_t start  = 0.1;
-  const nvbench::float32_t stride = 1e-4;
+  const nvbench::float32_t start  = 0.1f;
+  const nvbench::float32_t stride = 1e-4f;
   for (std::size_t size = 1; size < 1024; ++size)
   {
-    const nvbench::float32_t end = start + stride * (size - 1);
+    const nvbench::float32_t end =
+      start + stride * static_cast<nvbench::float32_t>(size - 1);
     ASSERT_MSG(nvbench::range(start, end, stride).size() == size,
                "size={}", size);
   }


### PR DESCRIPTION
- /W4 on MSVC
- -Wall -Wextra + others on gcc/clang
- New NVBench_ENABLE_WERROR option to toggle "warnings as errors"
- Mark the nlohmann_json library as IMPORTED to switch to system includes
- Rename nvbench_main -> nvbench.main to follow target name conventions
- Explicitly suppress some cudafe warnings when compiling templates in
  nlohmann_json headers.
- Explicitly suppress some warnings from Thrust headers.
- Various fixes for warnings exposed by new flags.
- Disable CUPTI on CTK < 11.3 (See #52).
- Refactor to use `NVBENCH_THROW` where possible.