### PR TITLE
Reduce the width of pow2 axes in markdown tables.

### DIFF
--- a/nvbench/markdown_printer.cu
+++ b/nvbench/markdown_printer.cu
@@ -274,13 +274,9 @@ void markdown_printer::do_print_benchmark_results(
               const nvbench::int64_t value    = axis_values.get_int64(name);
               const nvbench::int64_t exponent = int64_axis::compute_log2(value);
               table.add_cell(row,
-                             name + "_axis_pretty",
                              name,
-                             fmt::format("2^{}", exponent));
-              table.add_cell(row,
-                             name + "_axis_descriptive",
-                             fmt::format("({})", name),
-                             fmt::to_string(value));
+                             name,
+                             fmt::format("2^{} = {}", exponent, value));
             }
             else
             {


### PR DESCRIPTION
Before:

```
| BlockSize | (BlockSize) | NumBlocks | (NumBlocks) |
|-----------|-------------|-----------|-------------|
|       2^6 |          64 |       2^6 |          64 |
|       2^8 |         256 |       2^6 |          64 |
|      2^10 |        1024 |       2^6 |          64 |
|       2^6 |          64 |       2^8 |         256 |
|       2^8 |         256 |       2^8 |         256 |
|      2^10 |        1024 |       2^8 |         256 |
|       2^6 |          64 |      2^10 |        1024 |
|       2^8 |         256 |      2^10 |        1024 |
|      2^10 |        1024 |      2^10 |        1024 |
```

After:

```
|  BlockSize  |  NumBlocks  |
|-------------|-------------|
|    2^6 = 64 |    2^6 = 64 |
|   2^8 = 256 |    2^6 = 64 |
| 2^10 = 1024 |    2^6 = 64 |
|    2^6 = 64 |   2^8 = 256 |
|   2^8 = 256 |   2^8 = 256 |
| 2^10 = 1024 |   2^8 = 256 |
|    2^6 = 64 | 2^10 = 1024 |
|   2^8 = 256 | 2^10 = 1024 |
| 2^10 = 1024 | 2^10 = 1024 |
```