### PR TITLE
Get rid of unused parameter errors

### DIFF
--- a/nvbench/device_info.cu
+++ b/nvbench/device_info.cu
@@ -25,6 +25,8 @@
 
 #include <cuda_runtime_api.h>
 
+#define UNUSED(x) (void)(x)
+
 namespace nvbench
 {
 
@@ -57,6 +59,7 @@ device_info::device_info(int id)
 void device_info::set_persistence_mode(bool state)
 #ifndef NVBENCH_HAS_NVML
 {
+  UNUSED(state);
   throw nvbench::nvml::not_enabled{};
 }
 #else  // NVBENCH_HAS_NVML
@@ -88,6 +91,7 @@ catch (nvml::call_failed &e)
 void device_info::lock_gpu_clocks(device_info::clock_rate rate)
 #ifndef NVBENCH_HAS_NVML
 {
+  UNUSED(rate);
   throw nvbench::nvml::not_enabled{};
 }
 #else  // NVBENCH_HAS_NVML


### PR DESCRIPTION
This PR gets rid of unused parameter errors when building `nvbench` with `NVBench_ENABLE_NVML=OFF`:
```bash
/home/yunsongw/Work/nvbench/nvbench/device_info.cu:57:45: error: unused parameter ‘state’ [-Werror=unused-parameter]
   57 | void device_info::set_persistence_mode(bool state)
      |                                        ~~~~~^~~~~
/home/yunsongw/Work/nvbench/nvbench/device_info.cu: In member function ‘void nvbench::device_info::lock_gpu_clocks(nvbench::device_info::clock_rate)’:
/home/yunsongw/Work/nvbench/nvbench/device_info.cu:88:46: error: unused parameter ‘rate’ [-Werror=unused-parameter]
   88 | void device_info::lock_gpu_clocks(device_info::clock_rate rate)
      |                                   ~~~~~~~~~~~^~~~
```