### PR TITLE
Fix a bug in config count unit test: count number of devices as well

### DIFF
--- a/testing/benchmark.cu
+++ b/testing/benchmark.cu
@@ -298,7 +298,9 @@ void test_get_config_count()
   bench.add_string_axis("baz", {"str", "ing"});                        // 2, 72
   bench.add_string_axis("baz", {"single"});                            // 1, 72
 
-  ASSERT_MSG(bench.get_config_count() == 72,
+  auto const num_devices = bench.get_devices().size();
+
+  ASSERT_MSG(bench.get_config_count() == 72 * num_devices,
              "Got {}",
              bench.get_config_count());
 }


### PR DESCRIPTION
This PR fixes a minor bug when testing `benchmark::get_config_count()`. The number of devices should be taken into consideration as well.