### PR TITLE
Allow users to control iteration via the concept of iteration spaces.

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -237,9 +237,34 @@ NVBENCH_BENCH_TYPES(benchmark, NVBENCH_TYPE_AXES(input_types, output_types))
 ```
 
 This would generate a total of 36 configurations and instantiate the benchmark 6
-times. Keep the rapid growth of these combinations in mind when choosing the
-number of values in an axis. See the section about combinatorial explosion for
-more examples and information.
+times.
+
+Keep the rapid growth of combinations due to multiple parameter axes in mind when
+choosing the number of values in an axis. See the section about combinatorial
+explosion for more examples and information.
+
+## Zipped/Tied Iteration of Value Axes
+
+At times multiple value axes need to be iterated like they are actually a tuple
+or zipped together. To enable this behavior you can request axes to be 'tied'
+together.
+
+```cpp
+// InputTypes: {char, int, unsigned int}
+// OutputTypes: {float, double}
+// NumInputs: {2^10, 2^20, 2^30}
+// Quality: {0.5, 1.0}
+
+using input_types = nvbench::type_list<char, int, unsigned int>;
+using output_types = nvbench::type_list<float, double>;
+NVBENCH_BENCH_TYPES(benchmark, NVBENCH_TYPE_AXES(input_types, output_types))
+  .set_type_axes_names({"InputType", "OutputType"})
+  .add_int64_axis("NumInputs", {1000, 10000, 100000, 200000, 200000, 200000})
+  .add_float64_axis("Quality", {0.05, 0.1, 0.25, 0.5, 0.75, 1.});
+```
+
+This tieing reduces the total combinations from 24 to 6, reducing the
+combinatorial explosion.
 
 # Throughput Measurements
 
@@ -426,9 +451,9 @@ NVBENCH_BENCH_TYPES(my_benchmark,
 ```
 
 For large configuration spaces like this, pruning some of the less useful
-combinations (e.g. `sizeof(init_type) < sizeof(output)`) using the techniques
-described in the "Skip Uninteresting / Invalid Benchmarks" section can help
-immensely with keeping compile / run times manageable.
+combinations using the techniques described in the "Zipped/Tied Iteration of Value Axes"
+or "Skip Uninteresting / Invalid Benchmarks" section can help immensely with
+keeping compile / run times manageable.
 
 Splitting a single large configuration space into multiple, more focused
 benchmarks with reduced dimensionality will likely be worth the effort as well.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,6 +7,7 @@ set(example_srcs
   stream.cu
   throughput.cu
   auto_throughput.cu
+  custom_iteration_spaces.cu
 )
 
 # Metatarget for all examples:

--- a/examples/custom_iteration_spaces.cu
+++ b/examples/custom_iteration_spaces.cu
@@ -1,0 +1,247 @@
+/*
+ *  Copyright 2021 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <nvbench/nvbench.cuh>
+
+// Grab some testing kernels from NVBench:
+#include <nvbench/test_kernels.cuh>
+
+// Thrust vectors simplify memory management:
+#include <thrust/device_vector.h>
+
+#include <random>
+
+//==============================================================================
+// Multiple parameters:
+// Varies block_size and num_blocks while invoking a naive copy of 256 MiB worth
+// of int32_t.
+void copy_sweep_grid_shape(nvbench::state &state)
+{
+  // Get current parameters:
+  const int block_size = static_cast<int>(state.get_int64("BlockSize"));
+  const int num_blocks = static_cast<int>(state.get_int64("NumBlocks"));
+
+  // Number of int32s in 256 MiB:
+  const std::size_t num_values = 256 * 1024 * 1024 / sizeof(nvbench::int32_t);
+
+  // Report throughput stats:
+  state.add_element_count(num_values);
+  state.add_global_memory_reads<nvbench::int32_t>(num_values);
+  state.add_global_memory_writes<nvbench::int32_t>(num_values);
+
+  // Allocate device memory:
+  thrust::device_vector<nvbench::int32_t> in(num_values, 0);
+  thrust::device_vector<nvbench::int32_t> out(num_values, 0);
+
+  state.exec(
+    [block_size,
+     num_blocks,
+     num_values,
+     in_ptr  = thrust::raw_pointer_cast(in.data()),
+     out_ptr = thrust::raw_pointer_cast(out.data())](nvbench::launch &launch) {
+      nvbench::copy_kernel<<<num_blocks, block_size, 0, launch.get_stream()>>>(
+        in_ptr,
+        out_ptr,
+        num_values);
+    });
+}
+
+//==============================================================================
+// Tied iteration space allows you to iterate two or more axes at the same
+// time allowing for sparse exploration of the search space. Can also be used
+// to test the diagonal of a square matrix
+//
+void tied_copy_sweep_grid_shape(nvbench::state &state)
+{
+  copy_sweep_grid_shape(state);
+}
+NVBENCH_BENCH(tied_copy_sweep_grid_shape)
+  // Every power of two from  64->1024:
+  .add_int64_axis("BlockSize", {32,64,128,256})
+  .add_int64_axis("NumBlocks", {1024,512,256,128})
+  .tie_axes({"BlockSize", "NumBlocks"});
+
+//==============================================================================
+// under_diag:
+// Custom iterator that only searches the `X` locations of two axi
+// [- - - - X]
+// [- - - X X]
+// [- - X X X]
+// [- X X X X]
+// [X X X X X]
+//
+struct under_diag final : nvbench::user_axis_space
+{
+  under_diag(std::vector<std::size_t> input_indices,
+             std::vector<std::size_t> output_indices)
+      : nvbench::user_axis_space(std::move(input_indices), std::move(output_indices))
+  {}
+
+  mutable std::size_t x_pos   = 0;
+  mutable std::size_t y_pos   = 0;
+  mutable std::size_t x_start = 0;
+
+  nvbench::detail::axis_space_iterator do_iter(axes_info info) const
+  {
+    // generate our increment function
+    auto adv_func = [&, info](std::size_t &inc_index,
+                              std::size_t /*len*/) -> bool {
+      inc_index++;
+      x_pos++;
+      if (x_pos == info[0].size)
+      {
+        x_pos = ++x_start;
+        y_pos = x_start;
+        return true;
+      }
+      return false;
+    };
+
+    // our update function
+    std::vector<std::size_t> locs = m_output_indices;
+    auto diag_under =
+      [&, locs, info](std::size_t,
+                      std::vector<nvbench::detail::axis_index> &indices) {
+        nvbench::detail::axis_index temp = info[0];
+        temp.index                       = x_pos;
+        indices[locs[0]]                 = temp;
+
+        temp             = info[1];
+        temp.index       = y_pos;
+        indices[locs[1]] = temp;
+      };
+
+    const size_t iteration_length = ((info[0].size * (info[1].size + 1)) / 2);
+    return nvbench::detail::make_space_iterator(2,
+                                                iteration_length,
+                                                adv_func,
+                                                diag_under);
+  }
+
+  std::size_t do_size(const axes_info &info) const
+  {
+    return ((info[0].size * (info[1].size + 1)) / 2);
+  }
+
+  std::size_t do_valid_count(const axes_info &info) const
+  {
+    return ((info[0].size * (info[1].size + 1)) / 2);
+  }
+
+  std::unique_ptr<nvbench::axis_space_base> do_clone() const
+  {
+    return std::make_unique<under_diag>(*this);
+  }
+};
+
+void user_copy_sweep_grid_shape(nvbench::state &state)
+{
+  copy_sweep_grid_shape(state);
+}
+NVBENCH_BENCH(user_copy_sweep_grid_shape)
+  // Every power of two from  64->1024:
+  .add_int64_power_of_two_axis("BlockSize", nvbench::range(6, 10))
+  .add_int64_power_of_two_axis("NumBlocks", nvbench::range(6, 10))
+  .user_iteration_axes({"NumBlocks", "BlockSize"},
+                       [](auto... args)
+                         -> std::unique_ptr<nvbench::axis_space_base> {
+                         return std::make_unique<under_diag>(args...);
+                       });
+
+
+//==============================================================================
+// gauss:
+// Custom iteration space that uses a gauss distribution to
+// sample the points near the middle of the index space
+//
+struct gauss final : nvbench::user_axis_space
+{
+
+  gauss(std::vector<std::size_t> input_indices,
+        std::vector<std::size_t> output_indices)
+      : nvbench::user_axis_space(std::move(input_indices), std::move(output_indices))
+  {}
+
+  nvbench::detail::axis_space_iterator do_iter(axes_info info) const
+  {
+    const double mid_point = static_cast<double>((info[0].size / 2));
+
+    std::random_device rd{};
+    std::mt19937 gen{rd()};
+    std::normal_distribution<> d{mid_point, 2};
+
+    const size_t iteration_length = info[0].size;
+    std::vector<std::size_t> gauss_indices(iteration_length);
+    for (auto &g : gauss_indices)
+    {
+      auto v = std::min(static_cast<double>(info[0].size), d(gen));
+      v      = std::max(0.0, v);
+      g      = static_cast<std::size_t>(v);
+    }
+
+    // our update function
+    std::vector<std::size_t> locs = m_output_indices;
+    auto gauss_func               = [=](std::size_t index,
+                          std::vector<nvbench::detail::axis_index> &indices) {
+      nvbench::detail::axis_index temp = info[0];
+      temp.index                       = gauss_indices[index];
+      indices[locs[0]]                 = temp;
+    };
+
+    return nvbench::detail::make_space_iterator(1,
+                                                iteration_length,
+                                                gauss_func);
+  }
+
+  std::size_t do_size(const axes_info &info) const { return info[0].size; }
+
+  std::size_t do_valid_count(const axes_info &info) const
+  {
+    return info[0].size;
+  }
+
+  std::unique_ptr<axis_space_base> do_clone() const
+  {
+    return std::make_unique<gauss>(*this);
+  }
+};
+//==============================================================================
+// Dual parameter sweep:
+void dual_float64_axis(nvbench::state &state)
+{
+  const auto duration_A = state.get_float64("Duration_A");
+  const auto duration_B = state.get_float64("Duration_B");
+
+  state.exec([duration_A, duration_B](nvbench::launch &launch) {
+    nvbench::sleep_kernel<<<1, 1, 0, launch.get_stream()>>>(duration_A +
+                                                            duration_B);
+  });
+}
+NVBENCH_BENCH(dual_float64_axis)
+  .add_float64_axis("Duration_A", nvbench::range(0., 1e-4, 1e-5))
+  .add_float64_axis("Duration_B", nvbench::range(0., 1e-4, 1e-5))
+  .user_iteration_axes({"Duration_A"},
+                       [](auto... args)
+                         -> std::unique_ptr<nvbench::axis_space_base> {
+                         return std::make_unique<gauss>(args...);
+                       })
+  .user_iteration_axes({"Duration_B"},
+                       [](auto... args)
+                         -> std::unique_ptr<nvbench::axis_space_base> {
+                         return std::make_unique<gauss>(args...);
+                       });

--- a/nvbench/CMakeLists.txt
+++ b/nvbench/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(srcs
   axes_metadata.cxx
   axis_base.cxx
+  axis_iteration_space.cxx
   benchmark_base.cxx
   benchmark_manager.cxx
   blocking_kernel.cu

--- a/nvbench/axis_iteration_space.cuh
+++ b/nvbench/axis_iteration_space.cuh
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 2021 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <nvbench/detail/axes_iterator.cuh>
+
+namespace nvbench
+{
+
+struct axis_space_base
+{
+  using axes_type = std::vector<std::unique_ptr<nvbench::axis_base>>;
+  using axes_info = std::vector<detail::axis_index>;
+
+  using AdvanceSignature =
+    nvbench::detail::axis_space_iterator::AdvanceSignature;
+  using UpdateSignature = nvbench::detail::axis_space_iterator::UpdateSignature;
+
+  axis_space_base(std::vector<std::size_t> input_indices,
+                  std::vector<std::size_t> output_indices);
+  virtual ~axis_space_base();
+
+  [[nodiscard]] std::unique_ptr<axis_space_base> clone() const;
+  [[nodiscard]] std::vector<std::unique_ptr<axis_space_base>>
+  clone_as_linear() const;
+
+  [[nodiscard]] detail::axis_space_iterator iter(const axes_type &axes) const;
+  [[nodiscard]] std::size_t size(const axes_type &axes) const;
+  [[nodiscard]] std::size_t valid_count(const axes_type &axes) const;
+
+  [[nodiscard]] bool contains(std::size_t input_index) const;
+
+protected:
+  std::vector<std::size_t> m_input_indices;
+  std::vector<std::size_t> m_output_indices;
+
+  virtual std::unique_ptr<axis_space_base> do_clone() const         = 0;
+  virtual detail::axis_space_iterator do_iter(axes_info info) const = 0;
+  virtual std::size_t do_size(const axes_info &info) const          = 0;
+  virtual std::size_t do_valid_count(const axes_info &info) const   = 0;
+};
+
+struct linear_axis_space final : axis_space_base
+{
+  linear_axis_space(std::size_t in, std::size_t out);
+  ~linear_axis_space();
+
+  std::unique_ptr<axis_space_base> do_clone() const override;
+  detail::axis_space_iterator do_iter(axes_info info) const override;
+  std::size_t do_size(const axes_info &info) const override;
+  std::size_t do_valid_count(const axes_info &info) const override;
+};
+
+struct tie_axis_space final : axis_space_base
+{
+  tie_axis_space(std::vector<std::size_t> input_indices,
+      std::vector<std::size_t> output_indices);
+  ~tie_axis_space();
+
+  std::unique_ptr<axis_space_base> do_clone() const override;
+  detail::axis_space_iterator do_iter(axes_info info) const override;
+  std::size_t do_size(const axes_info &info) const override;
+  std::size_t do_valid_count(const axes_info &info) const override;
+};
+
+struct user_axis_space : axis_space_base
+{
+  user_axis_space(std::vector<std::size_t> input_indices,
+                  std::vector<std::size_t> output_indices);
+  ~user_axis_space();
+};
+
+using make_user_space_signature =
+  std::unique_ptr<axis_space_base>(std::vector<std::size_t> input_indices,
+                                   std::vector<std::size_t> output_indices);
+
+} // namespace nvbench

--- a/nvbench/axis_iteration_space.cxx
+++ b/nvbench/axis_iteration_space.cxx
@@ -1,0 +1,174 @@
+/*
+ *  Copyright 2021 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "axis_iteration_space.cuh"
+
+#include <nvbench/type_axis.cuh>
+
+namespace nvbench
+{
+
+axis_space_base::axis_space_base(std::vector<std::size_t> input_indices,
+                                 std::vector<std::size_t> output_indices)
+    : m_input_indices(std::move(input_indices))
+    , m_output_indices(std::move(output_indices))
+{}
+
+axis_space_base::~axis_space_base() = default;
+
+std::unique_ptr<axis_space_base> axis_space_base::clone() const
+{
+  auto clone = this->do_clone();
+  return clone;
+}
+
+std::vector<std::unique_ptr<axis_space_base>>
+axis_space_base::clone_as_linear() const
+{
+  std::vector<std::unique_ptr<axis_space_base>> clones;
+  clones.reserve(m_input_indices.size());
+
+  for (std::size_t i = 0; i < m_input_indices.size(); ++i)
+  {
+    clones.push_back(
+      std::make_unique<nvbench::linear_axis_space>(m_input_indices[i],
+                                                   m_output_indices[i]));
+  }
+
+  return clones;
+}
+
+namespace
+{
+nvbench::axis_space_base::axes_info
+get_axes_info(const nvbench::axis_space_base::axes_type &axes,
+              const std::vector<std::size_t> &indices)
+{
+  nvbench::axis_space_base::axes_info info;
+  info.reserve(indices.size());
+  for (auto &n : indices)
+  {
+    info.emplace_back(axes[n].get());
+  }
+  return info;
+}
+} // namespace
+
+detail::axis_space_iterator axis_space_base::iter(const axes_type &axes) const
+{
+
+  return this->do_iter(get_axes_info(axes, m_input_indices));
+}
+
+std::size_t axis_space_base::size(const axes_type &axes) const
+{
+  return this->do_size(get_axes_info(axes, m_input_indices));
+}
+std::size_t axis_space_base::valid_count(const axes_type &axes) const
+{
+  return this->do_valid_count(get_axes_info(axes, m_input_indices));
+}
+
+bool axis_space_base::contains(std::size_t in_index) const
+{
+  auto iter =
+    std::find_if(m_input_indices.cbegin(),
+                 m_input_indices.cend(),
+                 [&in_index](const auto &i) { return i == in_index; });
+  return iter != m_input_indices.end();
+}
+
+linear_axis_space::linear_axis_space(std::size_t in_index,
+                                     std::size_t out_index)
+    : axis_space_base({std::move(in_index)}, {out_index})
+{}
+
+linear_axis_space::~linear_axis_space() = default;
+
+detail::axis_space_iterator linear_axis_space::do_iter(axes_info info) const
+{
+  std::size_t loc(m_output_indices[0]);
+  auto update_func = [=](std::size_t inc_index,
+                         std::vector<detail::axis_index> &indices) {
+    indices[loc]       = info[0];
+    indices[loc].index = inc_index;
+  };
+
+  return detail::make_space_iterator(1, info[0].size, update_func);
+}
+
+std::size_t linear_axis_space::do_size(const axes_info &info) const
+{
+  return info[0].size;
+}
+
+std::size_t linear_axis_space::do_valid_count(const axes_info &info) const
+{
+  return info[0].active_size;
+}
+
+std::unique_ptr<axis_space_base> linear_axis_space::do_clone() const
+{
+  return std::make_unique<linear_axis_space>(*this);
+}
+
+tie_axis_space::tie_axis_space(std::vector<std::size_t> input_indices,
+                               std::vector<std::size_t> output_indices)
+    : axis_space_base(std::move(input_indices), std::move(output_indices))
+{}
+
+tie_axis_space::~tie_axis_space() = default;
+
+detail::axis_space_iterator tie_axis_space::do_iter(axes_info info) const
+{
+  std::vector<std::size_t> locs = m_output_indices;
+  auto update_func              = [=](std::size_t inc_index,
+                         std::vector<detail::axis_index> &indices) {
+    for (std::size_t i = 0; i < info.size(); ++i)
+    {
+      detail::axis_index temp = info[i];
+      temp.index              = inc_index;
+      indices[locs[i]]        = temp;
+    }
+  };
+
+  return detail::make_space_iterator(locs.size(), info[0].size, update_func);
+}
+
+std::size_t tie_axis_space::do_size(const axes_info &info) const
+{
+  return info[0].size;
+}
+
+std::size_t tie_axis_space::do_valid_count(const axes_info &info) const
+{
+  return info[0].active_size;
+}
+
+std::unique_ptr<axis_space_base> tie_axis_space::do_clone() const
+{
+  return std::make_unique<tie_axis_space>(*this);
+}
+
+user_axis_space::user_axis_space(std::vector<std::size_t> input_indices,
+                                 std::vector<std::size_t> output_indices)
+    : axis_space_base(std::move(input_indices), std::move(output_indices))
+{}
+user_axis_space::~user_axis_space() = default;
+
+} // namespace nvbench

--- a/nvbench/benchmark_base.cuh
+++ b/nvbench/benchmark_base.cuh
@@ -111,6 +111,21 @@ struct benchmark_base
     return *this;
   }
 
+  benchmark_base &tie_axes(std::vector<std::string> names)
+  {
+    m_axes.tie_axes(std::move(names));
+    return *this;
+  }
+
+  benchmark_base &
+  user_iteration_axes(std::vector<std::string> names,
+                      std::function<nvbench::make_user_space_signature> make)
+  {
+    m_axes.user_iteration_axes(std::move(names), std::move(make));
+    return *this;
+  }
+
+
   benchmark_base &set_devices(std::vector<int> device_ids);
 
   benchmark_base &set_devices(std::vector<nvbench::device_info> devices)

--- a/nvbench/detail/axes_iterator.cuh
+++ b/nvbench/detail/axes_iterator.cuh
@@ -1,0 +1,113 @@
+/*
+ *  Copyright 2021 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <nvbench/axis_base.cuh>
+#include <nvbench/type_axis.cuh>
+
+#include <functional>
+#include <utility>
+#include <vector>
+
+namespace nvbench
+{
+namespace detail
+{
+
+struct axis_index
+{
+  axis_index() = default;
+
+  explicit axis_index(const axis_base *axi)
+      : index(0)
+      , name(axi->get_name())
+      , type(axi->get_type())
+      , size(axi->get_size())
+      , active_size(axi->get_size())
+  {
+    if (type == nvbench::axis_type::type)
+    {
+      active_size =
+        static_cast<const nvbench::type_axis *>(axi)->get_active_count();
+    }
+  }
+  std::size_t index;
+  std::string name;
+  nvbench::axis_type type;
+  std::size_t size;
+  std::size_t active_size;
+};
+
+struct axis_space_iterator
+{
+  using AdvanceSignature = bool(std::size_t &current_index, std::size_t length);
+  using UpdateSignature  = void(std::size_t index,
+                               std::vector<axis_index> &indices);
+
+  [[nodiscard]] bool inc()
+  {
+    return this->m_advance(m_current_index, m_iteration_size);
+  }
+
+  void update_indices(std::vector<axis_index> &indices) const
+  {
+    this->m_update(m_current_index, indices);
+  }
+
+  std::size_t m_number_of_axes              = 1;
+  std::size_t m_iteration_size              = 1;
+  std::function<AdvanceSignature> m_advance = [](std::size_t &current_index,
+                                                 std::size_t length) {
+    (current_index + 1 == length) ? current_index = 0 : current_index++;
+    return (current_index == 0); // we rolled over
+  };
+  std::function<UpdateSignature> m_update = nullptr;
+
+private:
+  std::size_t m_current_index = 0;
+};
+
+inline axis_space_iterator make_space_iterator(
+  std::size_t axes_count,
+  std::size_t iter_count,
+  std::function<axis_space_iterator::AdvanceSignature> &&advance,
+  std::function<axis_space_iterator::UpdateSignature> &&update)
+{
+  axis_space_iterator iter;
+  iter.m_number_of_axes = axes_count;
+  iter.m_iteration_size = iter_count;
+  iter.m_advance        = std::move(advance);
+  iter.m_update         = std::move(update);
+  return iter;
+}
+
+inline axis_space_iterator make_space_iterator(
+  std::size_t axes_count,
+  std::size_t iter_count,
+  std::function<axis_space_iterator::UpdateSignature> &&update)
+{
+  axis_space_iterator iter;
+  iter.m_number_of_axes = axes_count;
+  iter.m_iteration_size = iter_count;
+  iter.m_update         = std::move(update);
+  return iter;
+}
+
+} // namespace detail
+} // namespace nvbench

--- a/nvbench/detail/state_generator.cuh
+++ b/nvbench/detail/state_generator.cuh
@@ -20,6 +20,7 @@
 
 #include <nvbench/axes_metadata.cuh>
 #include <nvbench/axis_base.cuh>
+#include <nvbench/detail/axes_iterator.cuh>
 #include <nvbench/state.cuh>
 
 #include <optional>
@@ -59,7 +60,7 @@ private:
 // Usage:
 // ```
 // state_iterator sg;
-// sg.add_axis(...);
+// sg.add_iteration_space(...);
 // for (sg.init(); sg.iter_valid(); sg.next())
 // {
 //   for (const auto& index : sg.get_current_indices())
@@ -73,25 +74,19 @@ private:
 // ```
 struct state_iterator
 {
-  struct axis_index
-  {
-    std::string axis;
-    nvbench::axis_type type;
-    std::size_t index;
-    std::size_t size;
-  };
+  void add_iteration_space(const nvbench::detail::axis_space_iterator &iter);
 
-  void add_axis(const nvbench::axis_base &axis);
-  void add_axis(std::string axis, nvbench::axis_type type, std::size_t size);
   [[nodiscard]] std::size_t get_number_of_states() const;
   void init();
-  [[nodiscard]] const std::vector<axis_index> &get_current_indices() const;
+  [[nodiscard]] std::vector<axis_index> get_current_indices() const;
   [[nodiscard]] bool iter_valid() const;
   void next();
 
-  std::vector<axis_index> m_indices;
-  std::size_t m_current{};
-  std::size_t m_total{};
+  std::vector<axis_space_iterator> m_space;
+  std::size_t m_axes_count        = 0;
+  std::size_t m_current_space     = 0;
+  std::size_t m_current_iteration = 0;
+  std::size_t m_max_iteration     = 1;
 };
 
 } // namespace detail

--- a/nvbench/detail/state_generator.cxx
+++ b/nvbench/detail/state_generator.cxx
@@ -32,66 +32,55 @@
 
 namespace nvbench::detail
 {
-
 // state_iterator ==============================================================
 
-void state_iterator::add_axis(const nvbench::axis_base &axis)
+void state_iterator::add_iteration_space(const nvbench::detail::axis_space_iterator &iter)
 {
-  this->add_axis(axis.get_name(), axis.get_type(), axis.get_size());
-}
+  m_axes_count += iter.m_number_of_axes;
+  m_max_iteration *= iter.m_iteration_size;
 
-void state_iterator::add_axis(std::string axis,
-                              nvbench::axis_type type,
-                              std::size_t size)
-{
-  m_indices.push_back({std::move(axis), type, std::size_t{0}, size});
+  m_space.push_back(std::move(iter));
 }
 
 [[nodiscard]] std::size_t state_iterator::get_number_of_states() const
 {
-  return nvbench::detail::transform_reduce(m_indices.cbegin(),
-                                           m_indices.cend(),
-                                           std::size_t{1},
-                                           std::multiplies<>{},
-                                           [](const axis_index &size_info) {
-                                             return size_info.size;
-                                           });
+  return this->m_max_iteration;
 }
 
 void state_iterator::init()
 {
-  m_current = 0;
-  m_total   = this->get_number_of_states();
-  for (axis_index &entry : m_indices)
-  {
-    entry.index = 0;
-  }
+  m_current_space     = 0;
+  m_current_iteration = 0;
 }
 
-[[nodiscard]] const std::vector<state_iterator::axis_index> &
-state_iterator::get_current_indices() const
+[[nodiscard]] std::vector<axis_index> state_iterator::get_current_indices() const
 {
-  return m_indices;
+  std::vector<axis_index> indices(m_axes_count);
+  for (auto &m : m_space)
+  {
+    m.update_indices(indices);
+  }
+  return indices;
 }
 
 [[nodiscard]] bool state_iterator::iter_valid() const
 {
-  return m_current < m_total;
+  return m_current_iteration < m_max_iteration;
 }
 
 void state_iterator::next()
 {
-  for (axis_index &axis_info : m_indices)
+  m_current_iteration++;
+
+  for (auto &&space : this->m_space)
   {
-    axis_info.index += 1;
-    if (axis_info.index >= axis_info.size)
+    auto rolled_over = space.inc();
+    if (rolled_over)
     {
-      axis_info.index = 0;
-      continue; // carry the addition to the next entry in m_indices
+      continue;
     }
-    break; // done
+    break;
   }
-  m_current += 1;
 }
 
 // state_generator =============================================================
@@ -103,122 +92,91 @@ state_generator::state_generator(const benchmark_base &bench)
 void state_generator::build_axis_configs()
 {
   const axes_metadata &axes = m_benchmark.get_axes();
-  const std::vector<std::unique_ptr<axis_base>> &axes_vec = axes.get_axes();
+  const auto &type_space    = axes.get_type_iteration_space();
+  const auto &value_space   = axes.get_value_iteration_space();
 
-  // Construct two state_generators:
-  // - Only type_axis objects.
-  // - Only non-type axes.
-  state_iterator type_si;
-  state_iterator non_type_si;
+  state_iterator ti;
+  state_iterator vi;
 
-  // state_iterator initialization:
+  // Reverse add type axes by index. This way the state_generator's cartesian
+  // product of the type axes values will be enumerated in the same order as
+  // nvbench::tl::cartesian_product<type_axes>. This is necessary to ensure
+  // that the correct states are passed to the corresponding benchmark
+  // instantiations.
   {
-    // stage the type axes in a vector to allow sorting:
-    std::vector<std::reference_wrapper<const type_axis>> type_axes;
-    type_axes.reserve(axes_vec.size());
-
-    // Filter all axes by into type and non-type:
-    std::for_each(axes_vec.cbegin(),
-                  axes_vec.cend(),
-                  [&non_type_si, &type_axes](const auto &axis) {
-                    if (axis->get_type() == nvbench::axis_type::type)
-                    {
-                      type_axes.push_back(
-                        std::cref(static_cast<const type_axis &>(*axis)));
-                    }
-                    else
-                    {
-                      non_type_si.add_axis(*axis);
-                    }
+    const auto &axes_vec = axes.get_axes();
+    std::for_each(type_space.crbegin(),
+                  type_space.crend(),
+                  [&ti, &axes_vec](const auto &space) {
+                    ti.add_iteration_space(space->iter(axes_vec));
                   });
-
-    // Reverse sort type axes by index. This way the state_generator's cartesian
-    // product of the type axes values will be enumerated in the same order as
-    // nvbench::tl::cartesian_product<type_axes>. This is necessary to ensure
-    // that the correct states are passed to the corresponding benchmark
-    // instantiations.
-    std::sort(type_axes.begin(),
-              type_axes.end(),
-              [](const auto &axis_1, const auto &axis_2) {
-                return axis_1.get().get_axis_index() >
-                       axis_2.get().get_axis_index();
-              });
-
-    std::for_each(type_axes.cbegin(),
-                  type_axes.cend(),
-                  [&type_si](const auto &axis) { type_si.add_axis(axis); });
+    std::for_each(value_space.begin(),
+                  value_space.end(),
+                  [&vi, &axes_vec](const auto &space) {
+                    vi.add_iteration_space(space->iter(axes_vec));
+                  });
   }
 
-  // type_axis_configs generation:
+  m_type_axis_configs.clear();
+  m_type_axis_configs.reserve(ti.get_number_of_states());
+
+  m_non_type_axis_configs.clear();
+  m_non_type_axis_configs.reserve(vi.get_number_of_states());
+
+  for (ti.init(); ti.iter_valid(); ti.next())
   {
-    m_type_axis_configs.clear();
-    m_type_axis_configs.reserve(type_si.get_number_of_states());
+    auto &[config, active_mask] = m_type_axis_configs.emplace_back(
+      std::make_pair(nvbench::named_values{}, true));
 
-    // Build type_axis_configs
-    for (type_si.init(); type_si.iter_valid(); type_si.next())
+    for (const auto &axis_info : ti.get_current_indices())
     {
-      auto &[config, active_mask] = m_type_axis_configs.emplace_back(
-        std::make_pair(nvbench::named_values{}, true));
+      const auto &axis = axes.get_type_axis(axis_info.name);
 
-      // Reverse the indices so they're once again in the same order as
-      // specified:
-      auto indices = type_si.get_current_indices();
-      std::reverse(indices.begin(), indices.end());
+      active_mask &= axis.get_is_active(axis_info.index);
 
-      for (const auto &axis_info : indices)
-      {
-        const auto &axis = axes.get_type_axis(axis_info.axis);
-        if (!axis.get_is_active(axis_info.index))
-        {
-          active_mask = false;
-        }
-
-        config.set_string(axis_info.axis,
-                          axis.get_input_string(axis_info.index));
-      }
-    } // type_si
-  }   // type_axis_config generation
-
-  // non_type_axis_config generation
+      config.set_string(axis.get_name(),
+                        axis.get_input_string(axis_info.index));
+    }
+  }
+  for (vi.init(); vi.iter_valid(); vi.next())
   {
-    m_non_type_axis_configs.clear();
-    m_non_type_axis_configs.reserve(type_si.get_number_of_states());
+    auto &config = m_non_type_axis_configs.emplace_back();
 
-    for (non_type_si.init(); non_type_si.iter_valid(); non_type_si.next())
+    // Add non-type parameters to state:
+    for (const auto &axis_info : vi.get_current_indices())
     {
-      auto &config = m_non_type_axis_configs.emplace_back();
-
-      // Add non-type parameters to state:
-      for (const auto &axis_info : non_type_si.get_current_indices())
+      switch (axis_info.type)
       {
-        switch (axis_info.type)
-        {
-          default:
-          case axis_type::type:
-            assert("unreachable." && false);
-            break;
+        default:
+        case axis_type::type:
+          assert("unreachable." && false);
+          break;
+        case axis_type::int64:
+          config.set_int64(
+            axis_info.name,
+            axes.get_int64_axis(axis_info.name).get_value(axis_info.index));
+          break;
 
-          case axis_type::int64:
-            config.set_int64(
-              axis_info.axis,
-              axes.get_int64_axis(axis_info.axis).get_value(axis_info.index));
-            break;
+        case axis_type::float64:
+          config.set_float64(
+            axis_info.name,
+            axes.get_float64_axis(axis_info.name).get_value(axis_info.index));
+          break;
 
-          case axis_type::float64:
-            config.set_float64(
-              axis_info.axis,
-              axes.get_float64_axis(axis_info.axis).get_value(axis_info.index));
-            break;
+        case axis_type::string:
+          config.set_string(
+            axis_info.name,
+            axes.get_string_axis(axis_info.name).get_value(axis_info.index));
+          break;
+      } // switch (type)
+    }   // for (axis_info : current_indices)
+  }
 
-          case axis_type::string:
-            config.set_string(
-              axis_info.axis,
-              axes.get_string_axis(axis_info.axis).get_value(axis_info.index));
-            break;
-        } // switch (type)
-      }   // for (axis_info : current_indices)
-    }     // for non_type_sg configs
-  }       // non_type_axis_config generation
+  if (m_type_axis_configs.empty())
+  {
+    m_type_axis_configs.emplace_back(
+      std::make_pair(nvbench::named_values{}, true));
+  }
 }
 
 void state_generator::build_states()
@@ -248,7 +206,6 @@ void state_generator::add_states_for_device(
   {
     const auto &[type_config,
                  axis_mask] = m_type_axis_configs[type_config_index];
-
     if (!axis_mask)
     { // Don't generate inner vector if the type config is masked out.
       continue;

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(test_srcs
   axes_metadata.cu
+  axes_iteration_space.cu
   benchmark.cu
   create.cu
   cuda_timer.cu

--- a/testing/axes_iteration_space.cu
+++ b/testing/axes_iteration_space.cu
@@ -1,0 +1,326 @@
+/*
+ *  Copyright 2021 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <nvbench/benchmark.cuh>
+
+#include <nvbench/callable.cuh>
+#include <nvbench/named_values.cuh>
+#include <nvbench/state.cuh>
+#include <nvbench/type_list.cuh>
+#include <nvbench/type_strings.cuh>
+#include <nvbench/types.cuh>
+
+#include "test_asserts.cuh"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <utility>
+#include <variant>
+#include <vector>
+
+template <typename T>
+std::vector<T> sort(std::vector<T> &&vec)
+{
+  std::sort(vec.begin(), vec.end());
+  return std::move(vec);
+}
+
+void no_op_generator(nvbench::state &state)
+{
+  fmt::memory_buffer params;
+  fmt::format_to(params, "Params:");
+  const auto &axis_values = state.get_axis_values();
+  for (const auto &name : sort(axis_values.get_names()))
+  {
+    std::visit(
+      [&params, &name](const auto &value) {
+        fmt::format_to(params, " {}: {}", name, value);
+      },
+      axis_values.get_value(name));
+  }
+
+  // Marking as skipped to signal that this state is run:
+  state.skip(fmt::to_string(std::move(params)));
+}
+NVBENCH_DEFINE_CALLABLE(no_op_generator, no_op_callable);
+
+template <typename Integer, typename Float, typename Other>
+void template_no_op_generator(nvbench::state &state,
+                              nvbench::type_list<Integer, Float, Other>)
+{
+  ASSERT(nvbench::type_strings<Integer>::input_string() ==
+         state.get_string("Integer"));
+  ASSERT(nvbench::type_strings<Float>::input_string() ==
+         state.get_string("Float"));
+  ASSERT(nvbench::type_strings<Other>::input_string() ==
+         state.get_string("Other"));
+
+  // Enum params using non-templated version:
+  no_op_generator(state);
+}
+NVBENCH_DEFINE_CALLABLE_TEMPLATE(template_no_op_generator,
+                                 template_no_op_callable);
+
+void test_tie_axes()
+{
+  using benchmark_type = nvbench::benchmark<no_op_callable>;
+  benchmark_type bench;
+  bench.add_float64_axis("F64 Axis", {0., .1, .25, .5, 1.});
+  bench.add_int64_axis("I64 Axis", {1, 3, 2, 4, 5});
+  bench.tie_axes({"F64 Axis", "I64 Axis"});
+
+  ASSERT_MSG(bench.get_config_count() == 5 * bench.get_devices().size(),
+             "Got {}",
+             bench.get_config_count());
+}
+
+void test_tie_invalid_names()
+{
+  using benchmark_type = nvbench::benchmark<no_op_callable>;
+  benchmark_type bench;
+  bench.add_float64_axis("F64 Axis", {0., .1, .25, .5, 1.});
+  bench.add_int64_axis("I64 Axis", {1, 3, 2});
+
+  ASSERT_THROWS_ANY(bench.tie_axes({"F32 Axis", "I64 Axis"}));
+  ASSERT_THROWS_ANY(bench.tie_axes({"F32 Axis"}));
+  ASSERT_THROWS_ANY(bench.tie_axes({""}));
+  ASSERT_THROWS_ANY(bench.tie_axes(std::vector<std::string>()));
+}
+
+void test_tie_unequal_length()
+{
+  using benchmark_type = nvbench::benchmark<no_op_callable>;
+  benchmark_type bench;
+  bench.add_float64_axis("F64 Axis", {0., .1, .25, .5, 1.});
+  bench.add_int64_axis("I64 Axis", {1, 3, 2});
+
+  bench.tie_axes({"I64 Axis", "F64 Axis"});
+  ASSERT_THROWS_ANY(bench.tie_axes({"F64 Axis", "I64 Axis"}));
+}
+
+void test_tie_type_axi()
+{
+  using benchmark_type =
+    nvbench::benchmark<template_no_op_callable,
+                       nvbench::type_list<nvbench::type_list<nvbench::int8_t>,
+                                          nvbench::type_list<nvbench::float32_t>,
+                                          nvbench::type_list<bool>>>;
+  benchmark_type bench;
+  bench.set_type_axes_names({"Integer", "Float", "Other"});
+  bench.add_float64_axis("F64 Axis", {0., .1, .25, .5, 1.});
+  bench.add_int64_axis("I64 Axis", {1, 3, 2});
+
+  ASSERT_THROWS_ANY(bench.tie_axes({"F64 Axis", "Float"}));
+}
+
+void test_retie_axes()
+{
+  using benchmark_type = nvbench::benchmark<no_op_callable>;
+  benchmark_type bench;
+  bench.add_int64_axis("IAxis_A", {1, 3, 2, 4, 5});
+  bench.add_int64_axis("IAxis_B", {1, 3, 2, 4, 5});
+  bench.add_float64_axis("FAxis_5", {0., .1, .25, .5, 1.});
+  bench.add_float64_axis("FAxis_2",
+                         {
+                           0.,
+                           .1,
+                         });
+
+  bench.tie_axes({"FAxis_5", "IAxis_A"});
+  bench.tie_axes({"IAxis_B", "FAxis_5", "IAxis_A"}); // re-tie
+
+  ASSERT_MSG(bench.get_config_count() == 10 * bench.get_devices().size(),
+             "Got {}",
+             bench.get_config_count());
+
+  bench.tie_axes({"FAxis_5", "IAxis_A"});
+  ASSERT_MSG(bench.get_config_count() == 50 * bench.get_devices().size(),
+             "Got {}",
+             bench.get_config_count());
+}
+
+void test_retie_axes2()
+{
+  using benchmark_type = nvbench::benchmark<no_op_callable>;
+  benchmark_type bench;
+  bench.add_int64_axis("IAxis_A", {1, 3, 2, 4, 5});
+  bench.add_int64_axis("IAxis_B", {1, 3, 2, 4, 5});
+  bench.add_int64_axis("IAxis_C", {1, 3, 2, 4, 5});
+  bench.add_float64_axis("FAxis_1", {0., .1, .25, .5, 1.});
+  bench.add_float64_axis("FAxis_2", {0., .1, .25, .5, 1.});
+  bench.add_float64_axis("FAxis_3",
+                         {
+                           0.,
+                           .1,
+                         });
+
+  bench.tie_axes({"IAxis_A", "IAxis_B", "IAxis_C"});
+  bench.tie_axes({"FAxis_1", "FAxis_2"});
+  bench.tie_axes(
+    {"IAxis_A", "IAxis_B", "IAxis_C", "FAxis_1", "FAxis_2"}); // re-tie
+
+  ASSERT_MSG(bench.get_config_count() == 10 * bench.get_devices().size(),
+             "Got {}",
+             bench.get_config_count());
+
+  bench.tie_axes({"IAxis_A", "IAxis_B", "IAxis_C"});
+  bench.tie_axes({"FAxis_1", "FAxis_2"});
+  ASSERT_MSG(bench.get_config_count() == 50 * bench.get_devices().size(),
+             "Got {}",
+             bench.get_config_count());
+}
+
+void test_tie_clone()
+{
+  using benchmark_type = nvbench::benchmark<no_op_callable>;
+  benchmark_type bench;
+  bench.set_devices(std::vector<int>{});
+  bench.add_string_axis("Strings", {"string a", "string b", "string c"});
+  bench.add_int64_power_of_two_axis("I64 POT Axis", {10, 20});
+  bench.add_int64_axis("I64 Axis", {10, 20});
+  bench.add_float64_axis("F64 Axis", {0., .1, .25});
+  bench.tie_axes({"F64 Axis", "Strings"});
+
+  const auto expected_count = bench.get_config_count();
+
+  std::unique_ptr<nvbench::benchmark_base> clone_base = bench.clone();
+  ASSERT(clone_base.get() != nullptr);
+
+  ASSERT_MSG(expected_count == clone_base->get_config_count(),
+             "Got {}",
+             clone_base->get_config_count());
+
+  auto *clone = dynamic_cast<benchmark_type *>(clone_base.get());
+  ASSERT(clone != nullptr);
+
+  ASSERT(bench.get_name() == clone->get_name());
+
+  const auto &ref_axes   = bench.get_axes().get_axes();
+  const auto &clone_axes = clone->get_axes().get_axes();
+  ASSERT(ref_axes.size() == clone_axes.size());
+  for (std::size_t i = 0; i < ref_axes.size(); ++i)
+  {
+    const nvbench::axis_base *ref_axis   = ref_axes[i].get();
+    const nvbench::axis_base *clone_axis = clone_axes[i].get();
+    ASSERT(ref_axis != nullptr);
+    ASSERT(clone_axis != nullptr);
+    ASSERT(ref_axis->get_name() == clone_axis->get_name());
+    ASSERT(ref_axis->get_type() == clone_axis->get_type());
+    ASSERT(ref_axis->get_size() == clone_axis->get_size());
+    for (std::size_t j = 0; j < ref_axis->get_size(); ++j)
+    {
+      ASSERT(ref_axis->get_input_string(j) == clone_axis->get_input_string(j));
+      ASSERT(ref_axis->get_description(j) == clone_axis->get_description(j));
+    }
+  }
+
+  ASSERT(clone->get_states().empty());
+}
+
+struct under_diag final : nvbench::user_axis_space
+{
+  under_diag(std::vector<std::size_t> input_indices,
+             std::vector<std::size_t> output_indices)
+      : nvbench::user_axis_space(std::move(input_indices), std::move(output_indices))
+  {}
+
+  mutable std::size_t x_pos   = 0;
+  mutable std::size_t y_pos   = 0;
+  mutable std::size_t x_start = 0;
+
+  nvbench::detail::axis_space_iterator do_iter(axes_info info) const
+  {
+    // generate our increment function
+    auto adv_func = [&, info](std::size_t &inc_index,
+                              std::size_t /*len*/) -> bool {
+      inc_index++;
+      x_pos++;
+      if (x_pos == info[0].size)
+      {
+        x_pos = ++x_start;
+        y_pos = x_start;
+        return true;
+      }
+      return false;
+    };
+
+    // our update function
+    std::vector<std::size_t> locs = m_output_indices;
+    auto diag_under =
+      [&, locs, info](std::size_t,
+                      std::vector<nvbench::detail::axis_index> &indices) {
+        nvbench::detail::axis_index temp = info[0];
+        temp.index                       = x_pos;
+        indices[locs[0]]                 = temp;
+
+        temp             = info[1];
+        temp.index       = y_pos;
+        indices[locs[1]] = temp;
+      };
+
+    const size_t iteration_length = ((info[0].size * (info[1].size + 1)) / 2);
+    return nvbench::detail::make_space_iterator(2,
+                                                iteration_length,
+                                                adv_func,
+                                                diag_under);
+  }
+
+  std::size_t do_size(const axes_info &info) const
+  {
+    return ((info[0].size * (info[1].size + 1)) / 2);
+  }
+
+  std::size_t do_valid_count(const axes_info &info) const
+  {
+    return ((info[0].size * (info[1].size + 1)) / 2);
+  }
+
+  std::unique_ptr<nvbench::axis_space_base> do_clone() const
+  {
+    return std::make_unique<under_diag>(*this);
+  }
+};
+
+void test_user_axes()
+{
+  using benchmark_type = nvbench::benchmark<no_op_callable>;
+  benchmark_type bench;
+  bench.add_float64_axis("F64 Axis", {0., .1, .25, .5, 1.});
+  bench.add_int64_axis("I64 Axis", {1, 3, 2, 4, 5});
+  bench.user_iteration_axes(
+    {"F64 Axis", "I64 Axis"},
+    [](auto... args) -> std::unique_ptr<nvbench::axis_space_base> {
+      return std::make_unique<under_diag>(args...);
+    });
+
+  ASSERT_MSG(bench.get_config_count() == 15 * bench.get_devices().size(),
+             "Got {}",
+             bench.get_config_count());
+}
+
+int main()
+{
+  test_tie_axes();
+  test_tie_invalid_names();
+  test_tie_unequal_length();
+  test_tie_type_axi();
+  test_retie_axes();
+  test_retie_axes2();
+  test_tie_clone();
+}

--- a/testing/benchmark.cu
+++ b/testing/benchmark.cu
@@ -296,10 +296,9 @@ void test_get_config_count()
   bench.add_float64_axis("foo", {0.4, 2.3, 4.3});                      // 3, 12
   bench.add_int64_axis("bar", {4, 6, 15});                             // 3, 36
   bench.add_string_axis("baz", {"str", "ing"});                        // 2, 72
-  bench.add_string_axis("baz", {"single"});                            // 1, 72
+  bench.add_string_axis("fez", {"single"});                            // 1, 72
 
   auto const num_devices = bench.get_devices().size();
-
   ASSERT_MSG(bench.get_config_count() == 72 * num_devices,
              "Got {}",
              bench.get_config_count());

--- a/testing/option_parser.cu
+++ b/testing/option_parser.cu
@@ -25,6 +25,8 @@
 
 #include <fmt/format.h>
 
+#include <iostream>
+
 //==============================================================================
 // Declare a couple benchmarks for testing:
 void DummyBench(nvbench::state &state) { state.skip("Skipping for testing."); }
@@ -96,6 +98,7 @@ states_to_string(const std::vector<nvbench::state> &states)
   ASSERT(bench != nullptr);
 
   bench->run();
+  std::cout << bench->get_config_count() << std::endl;
 
   return bench->get_states();
 }

--- a/testing/state_generator.cu
+++ b/testing/state_generator.cu
@@ -56,12 +56,18 @@ void test_single_state()
 {
   // one single-value axis = one state
   nvbench::detail::state_iterator sg;
-  sg.add_axis("OnlyAxis", nvbench::axis_type::string, 1);
+  nvbench::string_axis si("OnlyAxis");
+  si.set_inputs({""});
+
+  std::vector<std::unique_ptr<nvbench::axis_base>> axes;
+  axes.push_back(std::make_unique<nvbench::string_axis>(si));
+
+  sg.add_iteration_space(nvbench::linear_axis_space{0, 0}.iter(axes));
   ASSERT(sg.get_number_of_states() == 1);
   sg.init();
   ASSERT(sg.iter_valid());
   ASSERT(sg.get_current_indices().size() == 1);
-  ASSERT(sg.get_current_indices()[0].axis == "OnlyAxis");
+  ASSERT(sg.get_current_indices()[0].name == "OnlyAxis");
   ASSERT(sg.get_current_indices()[0].index == 0);
   ASSERT(sg.get_current_indices()[0].size == 1);
   ASSERT(sg.get_current_indices()[0].type == nvbench::axis_type::string);
@@ -73,10 +79,27 @@ void test_single_state()
 void test_basic()
 {
   nvbench::detail::state_iterator sg;
-  sg.add_axis("Axis1", nvbench::axis_type::string, 2);
-  sg.add_axis("Axis2", nvbench::axis_type::string, 3);
-  sg.add_axis("Axis3", nvbench::axis_type::string, 3);
-  sg.add_axis("Axis4", nvbench::axis_type::string, 2);
+
+  nvbench::string_axis si1("Axis1");
+  nvbench::string_axis si2("Axis2");
+  nvbench::string_axis si3("Axis3");
+  nvbench::string_axis si4("Axis4");
+
+  si1.set_inputs({"", ""});
+  si2.set_inputs({"", "", ""});
+  si3.set_inputs({"", "", ""});
+  si4.set_inputs({"", ""});
+
+  std::vector<std::unique_ptr<nvbench::axis_base>> axes;
+  axes.emplace_back(std::make_unique<nvbench::string_axis>(si1));
+  axes.emplace_back(std::make_unique<nvbench::string_axis>(si2));
+  axes.emplace_back(std::make_unique<nvbench::string_axis>(si3));
+  axes.emplace_back(std::make_unique<nvbench::string_axis>(si4));
+
+  sg.add_iteration_space(nvbench::linear_axis_space{0, 0}.iter(axes));
+  sg.add_iteration_space(nvbench::linear_axis_space{1, 1}.iter(axes));
+  sg.add_iteration_space(nvbench::linear_axis_space{2, 2}.iter(axes));
+  sg.add_iteration_space(nvbench::linear_axis_space{3, 3}.iter(axes));
 
   ASSERT_MSG(sg.get_number_of_states() == (2 * 3 * 3 * 2),
              "Actual: {} Expected: {}",
@@ -95,7 +118,7 @@ void test_basic()
       ASSERT(axis_index.type == nvbench::axis_type::string);
       fmt::format_to(line,
                      " | {}: {}/{}",
-                     axis_index.axis,
+                     axis_index.name,
                      axis_index.index,
                      axis_index.size);
     }


### PR DESCRIPTION
Changes in the work include:
- [x] Internally use linear_space for iterating
- [x] Simplify type and value iteration in `state_iterator::build_axis_configs`
- [x] Store the iteration space in `axes_metadata`
- [x] Expose `tie` and `user` spaces to user
- [x] Add tests for `linear`, `tie`, and `user`
- [x] Add examples for `tie` and `user`

Fixes #68 