### PR TITLE
Add --disable-blocking-kernel and --profile options.

### DIFF
--- a/docs/cli_help.md
+++ b/docs/cli_help.md
@@ -131,3 +131,15 @@
   * Intended for use with external profiling tools.
   * Applies to the most recent `--benchmark`, or all benchmarks if specified
     before any `--benchmark` arguments.
+
+* `--disable-blocking-kernel`
+  * Don't use the `blocking_kernel`.
+  * Intended for use with external profiling tools.
+  * Applies to the most recent `--benchmark`, or all benchmarks if specified
+    before any `--benchmark` arguments.
+
+* `--profile`
+  * Implies `--run-once` and `--disable-blocking-kernel`.
+  * Intended for use with external profiling tools.
+  * Applies to the most recent `--benchmark`, or all benchmarks if specified
+    before any `--benchmark` arguments.

--- a/nvbench/benchmark_base.cuh
+++ b/nvbench/benchmark_base.cuh
@@ -193,6 +193,16 @@ struct benchmark_base
   }
   /// @}
 
+  /// If true, the benchmark does not use the blocking_kernel. This is intended 
+  /// for use with external profiling tools. @{
+  [[nodiscard]] bool get_no_block() const { return m_no_block; }
+  benchmark_base &set_no_block(bool v)
+  {
+    m_no_block = v;
+    return *this;
+  }
+  /// @}
+
   /// Accumulate at least this many seconds of timing data per measurement. @{
   [[nodiscard]] nvbench::float64_t get_min_time() const { return m_min_time; }
   benchmark_base &set_min_time(nvbench::float64_t min_time)
@@ -256,6 +266,7 @@ protected:
   optional_ref<nvbench::printer_base> m_printer;
 
   bool m_run_once{false};
+  bool m_no_block{false};
 
   nvbench::int64_t m_min_samples{10};
   nvbench::float64_t m_min_time{0.5};

--- a/nvbench/blocking_kernel.cu
+++ b/nvbench/blocking_kernel.cu
@@ -83,6 +83,13 @@ __global__ void block_stream(const volatile nvbench::int32_t *flag,
       "The current timeout is set to %0.5g seconds.\n"
       "\n"
       "For more information, see the 'Benchmarks that sync' section of the\n"
+      "NVBench documentation.\n"
+      "\n"
+      "If this happens while profiling with an external tool,\n"
+      "pass the `--disable-blocking-kernel` flag or the `--profile` flag\n"
+      "(to also only run the benchmark once) to the executable.\n"
+      "\n"
+      "For more information, see the 'Benchmark Properties' section of the\n"
       "NVBench documentation.\n\n",
       timeout);
   }

--- a/nvbench/detail/measure_cold.cu
+++ b/nvbench/detail/measure_cold.cu
@@ -41,6 +41,7 @@ measure_cold_base::measure_cold_base(state &exec_state)
     : m_state{exec_state}
     , m_launch{m_state.get_cuda_stream()}
     , m_run_once{exec_state.get_run_once()}
+    , m_no_block{exec_state.get_no_block()}
     , m_min_samples{exec_state.get_min_samples()}
     , m_max_noise{exec_state.get_max_noise()}
     , m_min_time{exec_state.get_min_time()}

--- a/nvbench/detail/measure_cold.cuh
+++ b/nvbench/detail/measure_cold.cuh
@@ -91,6 +91,7 @@ protected:
   nvbench::blocking_kernel m_blocker;
 
   bool m_run_once{false};
+  bool m_no_block{false};
 
   nvbench::int64_t m_min_samples{};
   nvbench::float64_t m_max_noise{}; // rel stdev

--- a/nvbench/detail/state_exec.cuh
+++ b/nvbench/detail/state_exec.cuh
@@ -64,6 +64,13 @@ void state::exec(ExecTags tags, KernelLauncher &&kernel_launcher)
     return;
   }
 
+  if (!(modifier_tags & no_block) && this->get_no_block())
+  {
+    constexpr auto no_block_tags = modifier_tags | no_block;
+    this->exec(no_block_tags, std::forward<KernelLauncher>(kernel_launcher));
+    return;
+  }
+
   // If no measurements selected, pick some defaults based on the modifiers:
   if constexpr (!measure_tags)
   {

--- a/nvbench/option_parser.cu
+++ b/nvbench/option_parser.cu
@@ -443,6 +443,17 @@ void option_parser::parse_range(option_parser::arg_iterator_t first,
       this->enable_run_once();
       first += 1;
     }
+    else if (arg == "--disable-blocking-kernel")
+    {
+      this->disable_blocking_kernel();
+      first += 1;
+    }
+    else if (arg == "--profile")
+    {
+      this->enable_run_once();
+      this->disable_blocking_kernel();
+      first += 1;
+    }
     else if (arg == "--quiet" | arg == "-q")
     {
       // Setting this flag prevents the default stdout printer from being
@@ -708,6 +719,19 @@ void option_parser::enable_run_once()
 
   benchmark_base &bench = *m_benchmarks.back();
   bench.set_run_once(true);
+}
+
+void option_parser::disable_blocking_kernel()
+{
+  // If no active benchmark, save args as global.
+  if (m_benchmarks.empty())
+  {
+    m_global_benchmark_args.push_back("--disable-blocking-kernel");
+    return;
+  }
+
+  benchmark_base &bench = *m_benchmarks.back();
+  bench.set_no_block(true);
 }
 
 void option_parser::add_benchmark(const std::string &name)

--- a/nvbench/option_parser.cuh
+++ b/nvbench/option_parser.cuh
@@ -94,6 +94,7 @@ private:
   void lock_gpu_clocks(const std::string &rate);
 
   void enable_run_once();
+  void disable_blocking_kernel();
 
   void add_benchmark(const std::string &name);
   void replay_global_args();

--- a/nvbench/state.cuh
+++ b/nvbench/state.cuh
@@ -167,6 +167,12 @@ struct state
   void set_run_once(bool v) { m_run_once = v; }
   /// @}
 
+  /// If true, the benchmark does not use the blocking_kernel. This is intended
+  /// for use with external profiling tools. @{
+  [[nodiscard]] bool get_no_block() const { return m_no_block; }
+  void set_no_block(bool v) { m_no_block = v; }
+  /// @}
+
   /// Accumulate at least this many seconds of timing data per measurement. @{
   [[nodiscard]] nvbench::float64_t get_min_time() const { return m_min_time; }
   void set_min_time(nvbench::float64_t min_time) { m_min_time = min_time; }
@@ -322,6 +328,7 @@ private:
   std::size_t m_type_config_index{};
 
   bool m_run_once{false};
+  bool m_no_block{false};
 
   nvbench::int64_t m_min_samples;
   nvbench::float64_t m_min_time;

--- a/nvbench/state.cxx
+++ b/nvbench/state.cxx
@@ -35,6 +35,7 @@ namespace nvbench
 state::state(const benchmark_base &bench)
     : m_benchmark{bench}
     , m_run_once{bench.get_run_once()}
+    , m_no_block{bench.get_no_block()}
     , m_min_samples{bench.get_min_samples()}
     , m_min_time{bench.get_min_time()}
     , m_max_noise{bench.get_max_noise()}
@@ -51,6 +52,7 @@ state::state(const benchmark_base &bench,
     , m_device{std::move(device)}
     , m_type_config_index{type_config_index}
     , m_run_once{bench.get_run_once()}
+    , m_no_block{bench.get_no_block()}
     , m_min_samples{bench.get_min_samples()}
     , m_min_time{bench.get_min_time()}
     , m_max_noise{bench.get_max_noise()}


### PR DESCRIPTION
Closes #45.
Adds a mode that forces a benchmark not to use the `blocking_kernel`, simplifying
profiling usecases. This can be enabled by any of the following methods:
- Passing `--disable-blocking-kernel` on the command line
- `NVBENCH_CREATE(...).set_no_block(true)` when declaring a benchmark
- `state.set_no_block(true)` from within the benchmark implementation.
Also adds the `--profile` flag which implies `--run-once` and `--disable-blocking-kernel`.