### PR TITLE
fmt::memory_buffer is no longer an iterator.

### DIFF
--- a/cmake/NVBenchDependencies.cmake
+++ b/cmake/NVBenchDependencies.cmake
@@ -11,6 +11,10 @@ rapids_cpm_find(fmt 7.1.3
       "CMAKE_POSITION_INDEPENDENT_CODE ON"
 )
 
+if(TARGET fmt::fmt AND NOT TARGET fmt)
+  add_library(fmt ALIAS fmt::fmt)
+endif()
+
 ################################################################################
 # nlohmann/json
 #

--- a/cmake/NVBenchDependencies.cmake
+++ b/cmake/NVBenchDependencies.cmake
@@ -1,9 +1,9 @@
 ################################################################################
 # fmtlib/fmt
-rapids_cpm_find(fmt 9.1.0
+rapids_cpm_find(fmt 7.1.3
   CPM_ARGS
     GITHUB_REPOSITORY fmtlib/fmt
-    GIT_TAG 9.1.0
+    GIT_TAG 7.1.3
     GIT_SHALLOW TRUE
     OPTIONS
       # Force static to keep fmt internal.

--- a/cmake/NVBenchDependencies.cmake
+++ b/cmake/NVBenchDependencies.cmake
@@ -1,9 +1,9 @@
 ################################################################################
 # fmtlib/fmt
-rapids_cpm_find(fmt 7.1.3
+rapids_cpm_find(fmt 9.1.0
   CPM_ARGS
     GITHUB_REPOSITORY fmtlib/fmt
-    GIT_TAG 7.1.3
+    GIT_TAG 9.1.0
     GIT_SHALLOW TRUE
     OPTIONS
       # Force static to keep fmt internal.

--- a/nvbench/csv_printer.cu
+++ b/nvbench/csv_printer.cu
@@ -161,9 +161,9 @@ void csv_printer::do_print_benchmark_results(const benchmark_vector &benches)
     std::size_t remaining = table.m_columns.size();
     for (const auto &col : table.m_columns)
     {
-      fmt::format_to(buffer, "{}{}", col.header, (--remaining == 0) ? "" : ",");
+      fmt::format_to(std::back_inserter(buffer), "{}{}", col.header, (--remaining == 0) ? "" : ",");
     }
-    fmt::format_to(buffer, "\n");
+    fmt::format_to(std::back_inserter(buffer), "\n");
   }
 
   { // Rows
@@ -172,9 +172,9 @@ void csv_printer::do_print_benchmark_results(const benchmark_vector &benches)
       std::size_t remaining = table.m_columns.size();
       for (const auto &col : table.m_columns)
       {
-        fmt::format_to(buffer, "{}{}", col.rows[i], (--remaining == 0) ? "" : ",");
+        fmt::format_to(std::back_inserter(buffer), "{}{}", col.rows[i], (--remaining == 0) ? "" : ",");
       }
-      fmt::format_to(buffer, "\n");
+      fmt::format_to(std::back_inserter(buffer), "\n");
     }
   }
 

--- a/nvbench/cupti_profiler.cxx
+++ b/nvbench/cupti_profiler.cxx
@@ -53,7 +53,7 @@ void nvpw_call(const NVPA_Status status)
 {
   if (status != NVPA_STATUS_SUCCESS)
   {
-    NVBENCH_THROW(std::runtime_error, "NVPW call returned error: {}", status);
+    NVBENCH_THROW(std::runtime_error, "NVPW call returned error: {}", static_cast<int>(status));
   }
 }
 

--- a/nvbench/cupti_profiler.cxx
+++ b/nvbench/cupti_profiler.cxx
@@ -31,6 +31,7 @@
 #include <fmt/format.h>
 
 #include <stdexcept>
+#include <type_traits>
 
 namespace nvbench::detail
 {
@@ -53,7 +54,7 @@ void nvpw_call(const NVPA_Status status)
 {
   if (status != NVPA_STATUS_SUCCESS)
   {
-    NVBENCH_THROW(std::runtime_error, "NVPW call returned error: {}", static_cast<int>(status));
+    NVBENCH_THROW(std::runtime_error, "NVPW call returned error: {}", static_cast<std::underlying_type_t<NVPA_Status>>(status));
   }
 }
 

--- a/nvbench/markdown_printer.cu
+++ b/nvbench/markdown_printer.cu
@@ -41,7 +41,7 @@ namespace nvbench
 void markdown_printer::do_print_device_info()
 {
   fmt::memory_buffer buffer;
-  fmt::format_to(buffer, "# Devices\n\n");
+  fmt::format_to(std::back_inserter(buffer), "# Devices\n\n");
 
   const auto &device_mgr = nvbench::device_manager::get();
   const auto &devices = device_mgr.get_number_of_used_devices() > 0 ? device_mgr.get_used_devices()
@@ -50,40 +50,40 @@ void markdown_printer::do_print_device_info()
   {
     const auto [gmem_free, gmem_used] = device.get_global_memory_usage();
 
-    fmt::format_to(buffer, "## [{}] `{}`\n", device.get_id(), device.get_name());
-    fmt::format_to(buffer,
+    fmt::format_to(std::back_inserter(buffer), "## [{}] `{}`\n", device.get_id(), device.get_name());
+    fmt::format_to(std::back_inserter(buffer),
                    "* SM Version: {} (PTX Version: {})\n",
                    device.get_sm_version(),
                    device.get_ptx_version());
-    fmt::format_to(buffer, "* Number of SMs: {}\n", device.get_number_of_sms());
-    fmt::format_to(buffer,
+    fmt::format_to(std::back_inserter(buffer), "* Number of SMs: {}\n", device.get_number_of_sms());
+    fmt::format_to(std::back_inserter(buffer),
                    "* SM Default Clock Rate: {} MHz\n",
                    device.get_sm_default_clock_rate() / 1000 / 1000);
-    fmt::format_to(buffer,
+    fmt::format_to(std::back_inserter(buffer),
                    "* Global Memory: {} MiB Free / {} MiB Total\n",
                    gmem_free / 1024 / 1024,
                    gmem_used / 1024 / 1024);
-    fmt::format_to(buffer,
+    fmt::format_to(std::back_inserter(buffer),
                    "* Global Memory Bus Peak: {} GB/sec ({}-bit DDR @{}MHz)\n",
                    device.get_global_memory_bus_bandwidth() / 1000 / 1000 / 1000,
                    device.get_global_memory_bus_width(),
                    device.get_global_memory_bus_peak_clock_rate() / 1000 / 1000);
-    fmt::format_to(buffer,
+    fmt::format_to(std::back_inserter(buffer),
                    "* Max Shared Memory: {} KiB/SM, {} KiB/Block\n",
                    device.get_shared_memory_per_sm() / 1024,
                    device.get_shared_memory_per_block() / 1024);
-    fmt::format_to(buffer, "* L2 Cache Size: {} KiB\n", device.get_l2_cache_size() / 1024);
-    fmt::format_to(buffer, "* Maximum Active Blocks: {}/SM\n", device.get_max_blocks_per_sm());
-    fmt::format_to(buffer,
+    fmt::format_to(std::back_inserter(buffer), "* L2 Cache Size: {} KiB\n", device.get_l2_cache_size() / 1024);
+    fmt::format_to(std::back_inserter(buffer), "* Maximum Active Blocks: {}/SM\n", device.get_max_blocks_per_sm());
+    fmt::format_to(std::back_inserter(buffer),
                    "* Maximum Active Threads: {}/SM, {}/Block\n",
                    device.get_max_threads_per_sm(),
                    device.get_max_threads_per_block());
-    fmt::format_to(buffer,
+    fmt::format_to(std::back_inserter(buffer),
                    "* Available Registers: {}/SM, {}/Block\n",
                    device.get_registers_per_sm(),
                    device.get_registers_per_block());
-    fmt::format_to(buffer, "* ECC Enabled: {}\n", device.get_ecc_state() ? "Yes" : "No");
-    fmt::format_to(buffer, "\n");
+    fmt::format_to(std::back_inserter(buffer), "* ECC Enabled: {}\n", device.get_ecc_state() ? "Yes" : "No");
+    fmt::format_to(std::back_inserter(buffer), "\n");
   }
   m_ostream << fmt::to_string(buffer);
 }
@@ -156,20 +156,20 @@ void markdown_printer::do_print_benchmark_list(const printer_base::benchmark_vec
   }
 
   fmt::memory_buffer buffer;
-  fmt::format_to(buffer, "# Benchmarks\n\n");
+  fmt::format_to(std::back_inserter(buffer), "# Benchmarks\n\n");
   std::size_t benchmark_id{0};
   for (const auto &bench_ptr : benches)
   {
     const auto &axes              = bench_ptr->get_axes().get_axes();
     const std::size_t num_configs = bench_ptr->get_config_count();
 
-    fmt::format_to(buffer,
+    fmt::format_to(std::back_inserter(buffer),
                    "## [{}] `{}` ({} configurations)\n\n",
                    benchmark_id++,
                    bench_ptr->get_name(),
                    num_configs);
 
-    fmt::format_to(buffer, "### Axes\n\n");
+    fmt::format_to(std::back_inserter(buffer), "### Axes\n\n");
     for (const auto &axis_ptr : axes)
     {
       std::string flags_str(axis_ptr->get_flags_as_string());
@@ -177,7 +177,7 @@ void markdown_printer::do_print_benchmark_list(const printer_base::benchmark_vec
       {
         flags_str = fmt::format(" [{}]", flags_str);
       }
-      fmt::format_to(buffer,
+      fmt::format_to(std::back_inserter(buffer),
                      "* `{}` : {}{}\n",
                      axis_ptr->get_name(),
                      axis_ptr->get_type_as_string(),
@@ -191,10 +191,10 @@ void markdown_printer::do_print_benchmark_list(const printer_base::benchmark_vec
         {
           desc = fmt::format(" ({})", desc);
         }
-        fmt::format_to(buffer, "  * `{}`{}\n", axis_ptr->get_input_string(i), desc);
+        fmt::format_to(std::back_inserter(buffer), "  * `{}`{}\n", axis_ptr->get_input_string(i), desc);
       } // end foreach value
     }   // end foreach axis
-    fmt::format_to(buffer, "\n");
+    fmt::format_to(std::back_inserter(buffer), "\n");
   } // end foreach bench
 
   m_ostream << fmt::to_string(buffer);
@@ -222,7 +222,7 @@ void markdown_printer::do_print_benchmark_results(const printer_base::benchmark_
 
   // Start printing benchmarks
   fmt::memory_buffer buffer;
-  fmt::format_to(buffer, "# Benchmark Results\n");
+  fmt::format_to(std::back_inserter(buffer), "# Benchmark Results\n");
 
   for (const auto &bench_ptr : benches)
   {
@@ -230,7 +230,7 @@ void markdown_printer::do_print_benchmark_results(const printer_base::benchmark_
     const auto &devices = bench.get_devices();
     const auto &axes    = bench.get_axes();
 
-    fmt::format_to(buffer, "\n## {}\n", bench.get_name());
+    fmt::format_to(std::back_inserter(buffer), "\n## {}\n", bench.get_name());
 
     // Do a single pass when no devices are specified. This happens for
     // benchmarks with `cpu` exec_tags.
@@ -243,7 +243,7 @@ void markdown_printer::do_print_benchmark_results(const printer_base::benchmark_
 
       if (device)
       {
-        fmt::format_to(buffer, "\n### [{}] {}\n\n", device->get_id(), device->get_name());
+        fmt::format_to(std::back_inserter(buffer), "\n### [{}] {}\n\n", device->get_id(), device->get_name());
       }
 
       std::size_t row = 0;
@@ -320,7 +320,7 @@ void markdown_printer::do_print_benchmark_results(const printer_base::benchmark_
       }
 
       auto table_str = table.to_string();
-      fmt::format_to(buffer,
+      fmt::format_to(std::back_inserter(buffer),
                      "{}",
                      table_str.empty() ? "No data -- check log.\n" : std::move(table_str));
     } // end foreach device_pass

--- a/nvbench/state.cxx
+++ b/nvbench/state.cxx
@@ -185,7 +185,7 @@ std::string state::get_axis_values_as_string(bool color) const
       constexpr auto key_format   = fmt::emphasis::italic;
       constexpr auto value_format = fmt::emphasis::bold;
 
-      fmt::format_to(buffer,
+      fmt::format_to(std::back_inserter(buffer),
                      "{}{}={}",
                      buffer.size() == 0 ? "" : " ",
                      fmt::format(style(key_format), "{}", key),

--- a/testing/axes_metadata.cu
+++ b/testing/axes_metadata.cu
@@ -129,13 +129,13 @@ void test_type_axes()
   fmt::memory_buffer buffer;
   for (const auto &axis : axes.get_axes())
   {
-    fmt::format_to(buffer, "Axis: {}\n", axis->get_name());
+    fmt::format_to(std::back_inserter(buffer), "Axis: {}\n", axis->get_name());
     const auto num_values = axis->get_size();
     for (std::size_t i = 0; i < num_values; ++i)
     {
       auto input_string = axis->get_input_string(i);
       auto description  = axis->get_description(i);
-      fmt::format_to(buffer,
+      fmt::format_to(std::back_inserter(buffer),
                      " - {}{}\n",
                      input_string,
                      description.empty() ? ""

--- a/testing/benchmark.cu
+++ b/testing/benchmark.cu
@@ -44,13 +44,13 @@ std::vector<T> sort(std::vector<T> &&vec)
 void no_op_generator(nvbench::state &state)
 {
   fmt::memory_buffer params;
-  fmt::format_to(params, "Params:");
+  fmt::format_to(std::back_inserter(params), "Params:");
   const auto &axis_values = state.get_axis_values();
   for (const auto &name : sort(axis_values.get_names()))
   {
     std::visit(
       [&params, &name](const auto &value) {
-        fmt::format_to(params, " {}: {}", name, value);
+        fmt::format_to(std::back_inserter(params), " {}: {}", name, value);
       },
       axis_values.get_value(name));
   }
@@ -101,13 +101,13 @@ void test_type_axes()
   const auto &axes = bench.get_axes().get_axes();
   for (const auto &axis : axes)
   {
-    fmt::format_to(buffer, "Axis: {}\n", axis->get_name());
+    fmt::format_to(std::back_inserter(buffer), "Axis: {}\n", axis->get_name());
     const auto num_values = axis->get_size();
     for (std::size_t i = 0; i < num_values; ++i)
     {
       auto input_string = axis->get_input_string(i);
       auto description  = axis->get_description(i);
-      fmt::format_to(buffer,
+      fmt::format_to(std::back_inserter(buffer),
                      " - {}{}\n",
                      input_string,
                      description.empty() ? ""
@@ -148,7 +148,7 @@ void test_type_configs()
       using Integer = nvbench::tl::get<0, Conf>;
       using Float   = nvbench::tl::get<1, Conf>;
       using Other   = nvbench::tl::get<2, Conf>;
-      fmt::format_to(buffer,
+      fmt::format_to(std::back_inserter(buffer),
                      "type_configs[{:2d}] = <{:>3}, {:>3}, {:>4}>\n",
                      idx++,
                      nvbench::type_strings<Integer>::input_string(),

--- a/testing/create.cu
+++ b/testing/create.cu
@@ -44,13 +44,13 @@ std::vector<T> sort(std::vector<T> &&vec)
 void no_op_generator(nvbench::state &state)
 {
   fmt::memory_buffer params;
-  fmt::format_to(params, "Params:");
+  fmt::format_to(std::back_inserter(params), "Params:");
   const auto &axis_values = state.get_axis_values();
   for (const auto &name : sort(axis_values.get_names()))
   {
     std::visit(
       [&params, &name](const auto &value) {
-        fmt::format_to(params, " {}: {}", name, value);
+        fmt::format_to(std::back_inserter(params), " {}: {}", name, value);
       },
       axis_values.get_value(name));
   }
@@ -109,7 +109,7 @@ std::string run_and_get_state_string(nvbench::benchmark_base &bench,
   for (const auto &state : states)
   {
     ASSERT(state.is_skipped());
-    fmt::format_to(buffer, "{}\n", state.get_skip_reason());
+    fmt::format_to(std::back_inserter(buffer), "{}\n", state.get_skip_reason());
   }
   return fmt::to_string(buffer);
 }

--- a/testing/option_parser.cu
+++ b/testing/option_parser.cu
@@ -57,8 +57,8 @@ states_to_string(const std::vector<nvbench::state> &states)
   std::string table_format = "| {:^5} | {:^10} | {:^4} | {:^4} | {:^4} "
                              "| {:^4} | {:^6} | {:^8} |\n";
 
-  fmt::format_to(buffer, "\n");
-  fmt::format_to(buffer,
+  fmt::format_to(std::back_inserter(buffer), "\n");
+  fmt::format_to(std::back_inserter(buffer),
                  table_format,
                  "State",
                  "TypeConfig",
@@ -72,7 +72,7 @@ states_to_string(const std::vector<nvbench::state> &states)
   std::size_t config = 0;
   for (const auto &state : states)
   {
-    fmt::format_to(buffer,
+    fmt::format_to(std::back_inserter(buffer),
                    table_format,
                    config++,
                    state.get_type_config_index(),

--- a/testing/runner.cu
+++ b/testing/runner.cu
@@ -43,13 +43,13 @@ std::vector<T> sort(std::vector<T> &&vec)
 void no_op_generator(nvbench::state &state)
 {
   fmt::memory_buffer params;
-  fmt::format_to(params, "Params:");
+  fmt::format_to(std::back_inserter(params), "Params:");
   const auto &axis_values = state.get_axis_values();
   for (const auto &name : sort(axis_values.get_names()))
   {
     std::visit(
       [&params, &name](const auto &value) {
-        fmt::format_to(params, " {}: {}", name, value);
+        fmt::format_to(std::back_inserter(params), " {}: {}", name, value);
       },
       axis_values.get_value(name));
   }
@@ -124,7 +124,7 @@ void test_non_types()
   for (const auto &state : bench.get_states())
   {
     ASSERT(state.is_skipped() == true);
-    fmt::format_to(buffer, "{}\n", state.get_skip_reason());
+    fmt::format_to(std::back_inserter(buffer), "{}\n", state.get_skip_reason());
   }
 
   const std::string ref = R"expected(Params: Float: 11 Int: 1 String: One
@@ -184,7 +184,7 @@ void test_types()
   for (const auto &state : bench.get_states())
   {
     ASSERT(state.is_skipped() == true);
-    fmt::format_to(buffer, "{}\n", state.get_skip_reason());
+    fmt::format_to(std::back_inserter(buffer), "{}\n", state.get_skip_reason());
   }
 
   const std::string ref = R"expected(Params: FloatT: F32 IntT: I32 MiscT: bool
@@ -228,7 +228,7 @@ void test_both()
   for (const auto &state : bench.get_states())
   {
     ASSERT(state.is_skipped() == true);
-    fmt::format_to(buffer, "{}\n", state.get_skip_reason());
+    fmt::format_to(std::back_inserter(buffer), "{}\n", state.get_skip_reason());
   }
 
   const std::string ref =

--- a/testing/state_generator.cu
+++ b/testing/state_generator.cu
@@ -89,17 +89,17 @@ void test_basic()
   for (sg.init(); sg.iter_valid(); sg.next())
   {
     line.clear();
-    fmt::format_to(line, "| {:^2}", line_num++);
+    fmt::format_to(std::back_inserter(line), "| {:^2}", line_num++);
     for (auto &axis_index : sg.get_current_indices())
     {
       ASSERT(axis_index.type == nvbench::axis_type::string);
-      fmt::format_to(line,
+      fmt::format_to(std::back_inserter(line),
                      " | {}: {}/{}",
                      axis_index.axis,
                      axis_index.index,
                      axis_index.size);
     }
-    fmt::format_to(buffer, "{} |\n", fmt::to_string(line));
+    fmt::format_to(std::back_inserter(buffer), "{} |\n", fmt::to_string(line));
   }
 
   const std::string ref =
@@ -166,8 +166,8 @@ void test_create()
   const std::string table_format =
     "| {:^5} | {:^10} | {:^7} | {:^7} | {:^9} | {:^9} |\n";
 
-  fmt::format_to(buffer, "\n");
-  fmt::format_to(buffer,
+  fmt::format_to(std::back_inserter(buffer), "\n");
+  fmt::format_to(std::back_inserter(buffer),
                  table_format,
                  "State",
                  "TypeConfig",
@@ -179,7 +179,7 @@ void test_create()
   std::size_t config = 0;
   for (const auto &state : states)
   {
-    fmt::format_to(buffer,
+    fmt::format_to(std::back_inserter(buffer),
                    table_format,
                    config++,
                    state.get_type_config_index(),
@@ -258,8 +258,8 @@ void test_create_with_types()
   std::string table_format = "| {:^5} | {:^10} | {:^6} | {:^4} | {:^4} | {:^7} "
                              "| {:^7} | {:^9} | {:^9} |\n";
 
-  fmt::format_to(buffer, "\n");
-  fmt::format_to(buffer,
+  fmt::format_to(std::back_inserter(buffer), "\n");
+  fmt::format_to(std::back_inserter(buffer),
                  table_format,
                  "State",
                  "TypeConfig",
@@ -274,7 +274,7 @@ void test_create_with_types()
   std::size_t config = 0;
   for (const auto &state : states)
   {
-    fmt::format_to(buffer,
+    fmt::format_to(std::back_inserter(buffer),
                    table_format,
                    config++,
                    state.get_type_config_index(),
@@ -607,8 +607,8 @@ void test_create_with_masked_types()
   std::string table_format = "| {:^5} | {:^10} | {:^6} | {:^4} | {:^4} | {:^7} "
                              "| {:^7} | {:^9} | {:^9} |\n";
 
-  fmt::format_to(buffer, "\n");
-  fmt::format_to(buffer,
+  fmt::format_to(std::back_inserter(buffer), "\n");
+  fmt::format_to(std::back_inserter(buffer),
                  table_format,
                  "State",
                  "TypeConfig",
@@ -623,7 +623,7 @@ void test_create_with_masked_types()
   std::size_t config = 0;
   for (const auto &state : states)
   {
-    fmt::format_to(buffer,
+    fmt::format_to(std::back_inserter(buffer),
                    table_format,
                    config++,
                    state.get_type_config_index(),
@@ -737,13 +737,13 @@ void test_devices()
   fmt::memory_buffer buffer;
   const std::string table_format = "| {:^5} | {:^6} | {:^5} | {:^3} |\n";
 
-  fmt::format_to(buffer, "\n");
-  fmt::format_to(buffer, table_format, "State", "Device", "S", "I");
+  fmt::format_to(std::back_inserter(buffer), "\n");
+  fmt::format_to(std::back_inserter(buffer), table_format, "State", "Device", "S", "I");
 
   std::size_t config = 0;
   for (const auto &state : states)
   {
-    fmt::format_to(buffer,
+    fmt::format_to(std::back_inserter(buffer),
                    table_format,
                    config++,
                    state.get_device()->get_id(),


### PR DESCRIPTION
This change retains compatibility with older versions of fmt while enabling usage with newer versions. I did not update the version in `cmake/NVBenchDependencies.cmake`, but I can do so if a version bump is desired. I did find that with the newer library the `fmt` target did not reliably exist, so I added a new `ALIAS` target manually for tests to compile.