### PR TITLE
Fix wrongly defaulted move assignment operators

### DIFF
--- a/nvbench/launch.cuh
+++ b/nvbench/launch.cuh
@@ -45,7 +45,7 @@ struct launch
   launch(const launch &)            = delete;
   launch(launch &&)                 = default;
   launch &operator=(const launch &) = delete;
-  launch &operator=(launch &&)      = default;
+  launch &operator=(launch &&)      = delete;
 
   /**
    * @return a CUDA stream that all kernels and other stream-ordered CUDA work

--- a/nvbench/printer_base.cuh
+++ b/nvbench/printer_base.cuh
@@ -79,7 +79,7 @@ struct printer_base
   printer_base(const printer_base &)            = delete;
   printer_base(printer_base &&)                 = default;
   printer_base &operator=(const printer_base &) = delete;
-  printer_base &operator=(printer_base &&)      = default;
+  printer_base &operator=(printer_base &&)      = delete;
 
   /*!
    * Called once with the command line arguments used to invoke the current


### PR DESCRIPTION
Found because -Wdefaulted-function-deleted complained.