### PR TITLE
Update nvbench default fmt to be built to be 9.1.0

### DIFF
--- a/cmake/NVBenchDependencies.cmake
+++ b/cmake/NVBenchDependencies.cmake
@@ -1,9 +1,9 @@
 ################################################################################
 # fmtlib/fmt
-rapids_cpm_find(fmt 7.1.3
+rapids_cpm_find(fmt 9.1.0
   CPM_ARGS
     GITHUB_REPOSITORY fmtlib/fmt
-    GIT_TAG 7.1.3
+    GIT_TAG 9.1.0
     GIT_SHALLOW TRUE
     OPTIONS
       # Force static to keep fmt internal.


### PR DESCRIPTION
The formatting of `{}` can be incorrect under 7.X when given doubles and compiled with the latest conda toolchain. While both fmt 8 and 9 don't show this issue move to the latest version to leverage all the improvements in fmt 9.

Fixes #103