### PR TITLE
Introduce machine-readable version of --list

### DIFF
--- a/examples/exec_tag_sync.cu
+++ b/examples/exec_tag_sync.cu
@@ -27,6 +27,9 @@
 // Used to initialize input data:
 #include <thrust/sequence.h>
 
+// Used to run the benchmark on a CUDA stream
+#include <thrust/execution_policy.h>
+
 // `sequence_bench` measures the execution time of `thrust::sequence`. Since
 // algorithms in `thrust::` implicitly sync the CUDA device, the
 // `nvbench::exec_tag::sync` must be passed to `state.exec(...)`.

--- a/examples/exec_tag_timer.cu
+++ b/examples/exec_tag_timer.cu
@@ -23,6 +23,7 @@
 
 // Thrust simplifies memory management, etc:
 #include <thrust/copy.h>
+#include <thrust/execution_policy.h>
 #include <thrust/device_vector.h>
 #include <thrust/sequence.h>
 

--- a/nvbench/json_printer.cuh
+++ b/nvbench/json_printer.cuh
@@ -68,6 +68,7 @@ protected:
                                     const std::string &hint,
                                     const std::vector<nvbench::float64_t> &data) override;
   void do_print_benchmark_results(const benchmark_vector &benches) override;
+  void do_print_benchmark_list(const benchmark_vector &) override;
 
   bool m_enable_binary_output{false};
   std::size_t m_num_jsonbin_files{};

--- a/nvbench/option_parser.cu
+++ b/nvbench/option_parser.cu
@@ -585,7 +585,6 @@ void option_parser::print_list() const
   const auto &bench_mgr = nvbench::benchmark_manager::get();
 
   nvbench::markdown_printer printer{std::cout};
-  printer.print_device_info();
   printer.print_benchmark_list(bench_mgr.get_benchmarks());
 }
 

--- a/nvbench/option_parser.cu
+++ b/nvbench/option_parser.cu
@@ -399,7 +399,14 @@ void option_parser::parse_range(option_parser::arg_iterator_t first,
     }
     else if (arg == "--list" || arg == "-l")
     {
-      this->print_list();
+      nvbench::markdown_printer printer{std::cout};
+      this->print_list(printer);
+      std::exit(0);
+    }
+    else if (arg == "--jsonlist" || arg == "-l")
+    {
+      nvbench::json_printer printer{std::cout};
+      this->print_list(printer);
       std::exit(0);
     }
     else if (arg == "--persistence-mode" || arg == "--pm")
@@ -580,11 +587,9 @@ void option_parser::print_version() const
              NVBENCH_GIT_VERSION);
 }
 
-void option_parser::print_list() const
+void option_parser::print_list(printer_base& printer) const
 {
   const auto &bench_mgr = nvbench::benchmark_manager::get();
-
-  nvbench::markdown_printer printer{std::cout};
   printer.print_benchmark_list(bench_mgr.get_benchmarks());
 }
 

--- a/nvbench/option_parser.cuh
+++ b/nvbench/option_parser.cuh
@@ -79,7 +79,7 @@ private:
   std::ostream &printer_spec_to_ostream(const std::string &spec);
 
   void print_version() const;
-  void print_list() const;
+  void print_list(printer_base& printer) const;
   void print_help() const;
   void print_help_axis() const;
 

--- a/nvbench/printer_base.cuh
+++ b/nvbench/printer_base.cuh
@@ -22,6 +22,7 @@
 
 #include <iosfwd>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -191,7 +192,12 @@ protected:
                                             const std::string &,
                                             const std::string &,
                                             const std::vector<nvbench::float64_t> &){};
-  virtual void do_print_benchmark_list(const benchmark_vector &) {}
+
+  virtual void do_print_benchmark_list(const benchmark_vector &) 
+  {
+    throw std::runtime_error{"nvbench::do_print_benchmark_list is not supported by this printer."};
+  }
+
   virtual void do_print_benchmark_results(const benchmark_vector &) {}
 
   virtual void do_set_completed_state_count(std::size_t states);


### PR DESCRIPTION
[CUB tuning infrastructure](https://github.com/NVIDIA/cub/issues/631) needs a machine-readable format for `--list`. This PR introduces `--jsonlist` option and fixes a compilation issues for a few examples. 