### PR TITLE
Handle use case where we are in a conda env but with a static fmt lib

### DIFF
--- a/cmake/NVBenchDependencies.cmake
+++ b/cmake/NVBenchDependencies.cmake
@@ -10,6 +10,9 @@ rapids_cpm_find(fmt 9.1.0
       "BUILD_SHARED_LIBS OFF"
       "CMAKE_POSITION_INDEPENDENT_CODE ON"
 )
+if(NOT fmt_ADDED)
+  set(fmt_is_external TRUE)
+endif()
 
 if(TARGET fmt::fmt AND NOT TARGET fmt)
   add_library(fmt ALIAS fmt::fmt)

--- a/nvbench/CMakeLists.txt
+++ b/nvbench/CMakeLists.txt
@@ -89,8 +89,17 @@ if(TARGET conda_env)
   #
   # Since we could be using a shared library version of fmt we need
   # it on the final link line of consumers
-  target_link_libraries(nvbench PRIVATE $<BUILD_INTERFACE:conda_env>
-                        PUBLIC fmt::fmt)
+  target_link_libraries(nvbench PRIVATE $<BUILD_INTERFACE:conda_env>)
+endif()
+
+
+# When we are inside a conda env the linker will be set to
+# `ld.bfd` which will try to resolve all undefined symbols at link time.
+#
+# Since we could be using a shared library version of fmt we need
+# it on the final link line of consumers
+if(TARGET conda_env AND fmt_is_external)
+  target_link_libraries(nvbench PUBLIC fmt::fmt)
 else()
   target_link_libraries(nvbench PRIVATE fmt::fmt)
 endif()


### PR DESCRIPTION
Previously we presumed that a conda env meant we had a shared library version of fmt which isn't always the case. As a developer could be in a conda env that doesn't have the fmt package installed.