### PR TITLE
Support users which want static builds of nvbench

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-# 3.20.1 required for rapids-cmake
+# 3.23.1 required for rapids-cmake
 # 3.21.0 required for NVBench_ADD_DEPENDENT_DLLS_TO_* (MSVC only)
-cmake_minimum_required(VERSION 3.20.1)
+cmake_minimum_required(VERSION 3.23.1)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CUDA_STANDARD 17)
@@ -28,6 +28,8 @@ set(cupti_default ON)
 if (${CUDAToolkit_VERSION} VERSION_LESS 11.3)
   set(cupti_default OFF)
 endif()
+
+option(BUILD_SHARED_LIBS "Build NVBench as a shared library" ON)
 
 option(NVBench_ENABLE_NVML "Build with NVML support from the Cuda Toolkit." ON)
 option(NVBench_ENABLE_CUPTI "Build NVBench with CUPTI." ${cupti_default})

--- a/cmake/NVBenchDependencies.cmake
+++ b/cmake/NVBenchDependencies.cmake
@@ -1,21 +1,21 @@
 ################################################################################
 # fmtlib/fmt
-rapids_cpm_find(fmt 9.1.0
+include("${rapids-cmake-dir}/cpm/fmt.cmake")
+
+if(NOT BUILD_SHARED_LIBS)
+set(export_set_details BUILD_EXPORT_SET nvbench-targets
+                       INSTALL_EXPORT_SET nvbench-targets)
+endif()
+
+rapids_cpm_fmt(${export_set_details}
   CPM_ARGS
-    GITHUB_REPOSITORY fmtlib/fmt
-    GIT_TAG 9.1.0
-    GIT_SHALLOW TRUE
     OPTIONS
       # Force static to keep fmt internal.
       "BUILD_SHARED_LIBS OFF"
-      "CMAKE_POSITION_INDEPENDENT_CODE ON"
 )
+
 if(NOT fmt_ADDED)
   set(fmt_is_external TRUE)
-endif()
-
-if(TARGET fmt::fmt AND NOT TARGET fmt)
-  add_library(fmt ALIAS fmt::fmt)
 endif()
 
 ################################################################################

--- a/cmake/NVBenchDependentDlls.cmake
+++ b/cmake/NVBenchDependentDlls.cmake
@@ -12,14 +12,6 @@ else()
   set(NVBench_ADD_DEPENDENT_DLLS_TO_BUILD OFF)
 endif()
 
-if (NVBench_ADD_DEPENDENT_DLLS_TO_BUILD)
-  message(STATUS
-    "CMake 3.21.0 is required when NVBench_ADD_DEPENDENT_DLLS_TO_BUILD "
-    "is enabled."
-  )
-  cmake_minimum_required(VERSION 3.21.0)
-endif()
-
 function(nvbench_setup_dep_dlls target_name)
   # The custom command below fails when there aren't any runtime DLLs to copy,
   # so only enable it when a relevant dependency is enabled:

--- a/cmake/NVBenchRapidsCMake.cmake
+++ b/cmake/NVBenchRapidsCMake.cmake
@@ -2,7 +2,7 @@
 macro(nvbench_load_rapids_cmake)
   if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/NVBENCH_RAPIDS.cmake")
     file(DOWNLOAD
-      https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-22.08/RAPIDS.cmake
+      https://raw.githubusercontent.com/rapidsai/rapids-cmake/branch-23.12/RAPIDS.cmake
       "${CMAKE_CURRENT_BINARY_DIR}/NVBENCH_RAPIDS.cmake"
     )
   endif()

--- a/nvbench/CMakeLists.txt
+++ b/nvbench/CMakeLists.txt
@@ -65,7 +65,7 @@ nvbench_write_config_header(config.cuh.in
 )
 
 # nvbench (nvbench::nvbench)
-add_library(nvbench SHARED ${srcs})
+add_library(nvbench ${srcs})
 nvbench_config_target(nvbench)
 target_include_directories(nvbench PUBLIC
   "$<BUILD_INTERFACE:${NVBench_SOURCE_DIR}>"
@@ -76,8 +76,8 @@ target_link_libraries(nvbench
   PUBLIC
     ${ctk_libraries}
   PRIVATE
+    fmt::fmt
     nvbench_json
-    nvbench_git_revision
 )
 
 # ##################################################################################################
@@ -90,18 +90,15 @@ if(TARGET conda_env)
   # Since we could be using a shared library version of fmt we need
   # it on the final link line of consumers
   target_link_libraries(nvbench PRIVATE $<BUILD_INTERFACE:conda_env>)
-endif()
 
-
-# When we are inside a conda env the linker will be set to
-# `ld.bfd` which will try to resolve all undefined symbols at link time.
-#
-# Since we could be using a shared library version of fmt we need
-# it on the final link line of consumers
-if(TARGET conda_env AND fmt_is_external)
-  target_link_libraries(nvbench PUBLIC fmt::fmt)
-else()
-  target_link_libraries(nvbench PRIVATE fmt::fmt)
+  # When we are inside a conda env the linker will be set to
+  # `ld.bfd` which will try to resolve all undefined symbols at link time.
+  #
+  # Since we could be using a shared library version of fmt we need
+  # it on the final link line of consumers
+  if(fmt_is_external)
+    target_link_libraries(nvbench PUBLIC fmt::fmt)
+  endif()
 endif()
 
 target_compile_features(nvbench PUBLIC cuda_std_17 PRIVATE cxx_std_17)
@@ -130,4 +127,15 @@ if (json_is_cu)
     # (the end of the function in hash.hpp(114) is unreachable)
     $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:-Xcudafe=--diag_suppress=940>
   )
+endif()
+
+# Use `nvbench_git_revision` but don't expose it as part of our export information
+# In CMake 3.27 this is easily done with $<COMPILE_ONLY>, before that we have to
+# manual copy the include path
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
+  target_link_libraries(nvbench PRIVATE $<COMPILE_ONLY:nvbench_git_revision>)
+else()
+  add_dependencies(nvbench nvbench_git_revision)
+  get_target_property(_include_dir nvbench_git_revision INTERFACE_INCLUDE_DIRECTORIES)
+  target_include_directories(nvbench PRIVATE "$<BUILD_INTERFACE:${_include_dir}>")
 endif()


### PR DESCRIPTION
Enables static builds of nvbench. To do this we needed to move to the latest version of rapids-cmake and bump our minimum cmake version.