### PR TITLE
NVBench now supports not installing itself

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ option(NVBench_ENABLE_DEVICE_TESTING
   OFF
 )
 option(NVBench_ENABLE_EXAMPLES "Build NVBench examples." OFF)
+option(NVBench_ENABLE_INSTALL_RULES "Install NVBench." ${NVBench_TOPLEVEL_PROJECT})
 
 include(cmake/NVBenchConfigTarget.cmake)
 include(cmake/NVBenchDependentDlls.cmake)

--- a/cmake/NVBenchDependencies.cmake
+++ b/cmake/NVBenchDependencies.cmake
@@ -2,7 +2,7 @@
 # fmtlib/fmt
 include("${rapids-cmake-dir}/cpm/fmt.cmake")
 
-if(NOT BUILD_SHARED_LIBS)
+if(NOT BUILD_SHARED_LIBS AND NVBench_ENABLE_INSTALL_RULES)
 set(export_set_details BUILD_EXPORT_SET nvbench-targets
                        INSTALL_EXPORT_SET nvbench-targets)
 endif()

--- a/cmake/NVBenchExports.cmake
+++ b/cmake/NVBenchExports.cmake
@@ -1,37 +1,39 @@
 macro(nvbench_generate_exports)
-  set(nvbench_build_export_code_block "")
-  set(nvbench_install_export_code_block "")
+  if(NVBench_ENABLE_INSTALL_RULES)
+    set(nvbench_build_export_code_block "")
+    set(nvbench_install_export_code_block "")
 
-  if (NVBench_ENABLE_NVML)
-    string(APPEND nvbench_build_export_code_block
-      "include(\"${NVBench_SOURCE_DIR}/cmake/NVBenchNVML.cmake\")\n"
+    if (NVBench_ENABLE_NVML)
+      string(APPEND nvbench_build_export_code_block
+        "include(\"${NVBench_SOURCE_DIR}/cmake/NVBenchNVML.cmake\")\n"
+      )
+      string(APPEND nvbench_install_export_code_block
+        "include(\"\${CMAKE_CURRENT_LIST_DIR}/NVBenchNVML.cmake\")\n"
+      )
+    endif()
+
+    if (NVBench_ENABLE_CUPTI)
+      string(APPEND nvbench_build_export_code_block
+        "include(\"${NVBench_SOURCE_DIR}/cmake/NVBenchCUPTI.cmake\")\n"
+      )
+      string(APPEND nvbench_install_export_code_block
+        "include(\"\${CMAKE_CURRENT_LIST_DIR}/NVBenchCUPTI.cmake\")\n"
+      )
+    endif()
+
+    rapids_export(BUILD NVBench
+      EXPORT_SET nvbench-targets
+      NAMESPACE "nvbench::"
+      GLOBAL_TARGETS nvbench main ctl internal_build_interface
+      LANGUAGES CUDA CXX
+      FINAL_CODE_BLOCK nvbench_build_export_code_block
     )
-    string(APPEND nvbench_install_export_code_block
-      "include(\"\${CMAKE_CURRENT_LIST_DIR}/NVBenchNVML.cmake\")\n"
+    rapids_export(INSTALL NVBench
+      EXPORT_SET nvbench-targets
+      NAMESPACE "nvbench::"
+      GLOBAL_TARGETS nvbench main ctl internal_build_interface
+      LANGUAGES CUDA CXX
+      FINAL_CODE_BLOCK nvbench_install_export_code_block
     )
   endif()
-
-  if (NVBench_ENABLE_CUPTI)
-    string(APPEND nvbench_build_export_code_block
-      "include(\"${NVBench_SOURCE_DIR}/cmake/NVBenchCUPTI.cmake\")\n"
-    )
-    string(APPEND nvbench_install_export_code_block
-      "include(\"\${CMAKE_CURRENT_LIST_DIR}/NVBenchCUPTI.cmake\")\n"
-    )
-  endif()
-
-  rapids_export(BUILD NVBench
-    EXPORT_SET nvbench-targets
-    NAMESPACE "nvbench::"
-    GLOBAL_TARGETS nvbench main ctl internal_build_interface
-    LANGUAGES CUDA CXX
-    FINAL_CODE_BLOCK nvbench_build_export_code_block
-  )
-  rapids_export(INSTALL NVBench
-    EXPORT_SET nvbench-targets
-    NAMESPACE "nvbench::"
-    GLOBAL_TARGETS nvbench main ctl internal_build_interface
-    LANGUAGES CUDA CXX
-    FINAL_CODE_BLOCK nvbench_install_export_code_block
-  )
 endmacro()

--- a/cmake/NVBenchInstallRules.cmake
+++ b/cmake/NVBenchInstallRules.cmake
@@ -1,61 +1,69 @@
-include(GNUInstallDirs)
-rapids_cmake_install_lib_dir(NVBench_INSTALL_LIB_DIR)
 
-# in-source public headers:
-install(DIRECTORY "${NVBench_SOURCE_DIR}/nvbench"
-  TYPE INCLUDE
-  FILES_MATCHING
-    PATTERN "*.cuh"
-    PATTERN "internal" EXCLUDE
-)
+if(NVBench_ENABLE_INSTALL_RULES)
 
-# generated headers from build dir:
-install(
-  FILES
-    "${NVBench_BINARY_DIR}/nvbench/config.cuh"
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/nvbench"
-)
-install(
-  FILES
-    "${NVBench_BINARY_DIR}/nvbench/detail/version.cuh"
-    "${NVBench_BINARY_DIR}/nvbench/detail/git_revision.cuh"
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/nvbench/detail"
-)
+  include(GNUInstallDirs)
+  rapids_cmake_install_lib_dir(NVBench_INSTALL_LIB_DIR)
 
-#
-# Install CMake files needed by consumers to locate dependencies:
-#
+  # in-source public headers:
+  install(DIRECTORY "${NVBench_SOURCE_DIR}/nvbench"
+    TYPE INCLUDE
+    FILES_MATCHING
+      PATTERN "*.cuh"
+      PATTERN "internal" EXCLUDE
+  )
 
-# Borrowing this logic from rapids_cmake's export logic to make sure these end
-# up in the same location as nvbench-config.cmake:
-rapids_cmake_install_lib_dir(config_install_location)
-set(config_install_location "${config_install_location}/cmake/nvbench")
-
-if (NVBench_ENABLE_NVML)
+  # generated headers from build dir:
   install(
     FILES
-      "${NVBench_SOURCE_DIR}/cmake/NVBenchNVML.cmake"
-    DESTINATION "${config_install_location}"
+      "${NVBench_BINARY_DIR}/nvbench/config.cuh"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/nvbench"
   )
-endif()
-
-if (NVBench_ENABLE_CUPTI)
   install(
     FILES
-      "${NVBench_SOURCE_DIR}/cmake/NVBenchCUPTI.cmake"
-    DESTINATION "${config_install_location}"
+      "${NVBench_BINARY_DIR}/nvbench/detail/version.cuh"
+      "${NVBench_BINARY_DIR}/nvbench/detail/git_revision.cuh"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/nvbench/detail"
   )
+
+  #
+  # Install CMake files needed by consumers to locate dependencies:
+  #
+
+  # Borrowing this logic from rapids_cmake's export logic to make sure these end
+  # up in the same location as nvbench-config.cmake:
+  rapids_cmake_install_lib_dir(config_install_location)
+  set(config_install_location "${config_install_location}/cmake/nvbench")
+
+  if (NVBench_ENABLE_NVML)
+    install(
+      FILES
+        "${NVBench_SOURCE_DIR}/cmake/NVBenchNVML.cmake"
+      DESTINATION "${config_install_location}"
+    )
+  endif()
+
+  if (NVBench_ENABLE_CUPTI)
+    install(
+      FILES
+        "${NVBench_SOURCE_DIR}/cmake/NVBenchCUPTI.cmake"
+      DESTINATION "${config_install_location}"
+    )
+  endif()
 endif()
 
 # Call with a list of library targets to generate install rules:
 function(nvbench_install_libraries)
-  install(TARGETS ${ARGN}
-    DESTINATION "${NVBench_INSTALL_LIB_DIR}"
-    EXPORT nvbench-targets
-  )
+  if(NVBench_ENABLE_INSTALL_RULES)
+    install(TARGETS ${ARGN}
+      DESTINATION "${NVBench_INSTALL_LIB_DIR}"
+      EXPORT nvbench-targets
+    )
+  endif()
 endfunction()
 
 # Call with a list of executables to generate install rules:
 function(nvbench_install_executables)
-  install(TARGETS ${ARGN} EXPORT nvbench-targets)
+  if(NVBench_ENABLE_INSTALL_RULES)
+    install(TARGETS ${ARGN} EXPORT nvbench-targets)
+  endif()
 endfunction()


### PR DESCRIPTION
Switches nvbench to only default to having install rules when it is the parent project. That ensures that consumers of nvbench via CPM will not have install rules. They can explicitly optin via the `NVBench_ENABLE_INSTALL_RULES` variable