### PR TITLE
write_git_revision_file must be used in same CMakeLists as consumer

### DIFF
--- a/cmake/NVBenchRapidsCMake.cmake
+++ b/cmake/NVBenchRapidsCMake.cmake
@@ -21,9 +21,5 @@ endmacro()
 macro(nvbench_init_rapids_cmake)
   rapids_cmake_build_type(Release)
   rapids_cmake_write_version_file("${NVBench_BINARY_DIR}/nvbench/detail/version.cuh")
-  rapids_cmake_write_git_revision_file(
-    nvbench_git_revision
-    "${NVBench_BINARY_DIR}/nvbench/detail/git_revision.cuh"
-  )
   rapids_cpm_init()
 endmacro()

--- a/nvbench/CMakeLists.txt
+++ b/nvbench/CMakeLists.txt
@@ -132,12 +132,20 @@ endif()
 # Use `nvbench_git_revision` but don't expose it as part of our export information
 # In CMake 3.27 this is easily done with $<COMPILE_ONLY>, before that we have to
 # manual copy the include path
+#
+# The call to `rapids_cmake_write_git_revision_file` must be in the same
+# CMakeLists.txt as the consumer ( nvbench ) for CMake to get the dependency
+# graph correct.
+rapids_cmake_write_git_revision_file(
+    nvbench_git_revision
+    "${NVBench_BINARY_DIR}/nvbench/detail/git_revision.cuh"
+  )
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
   target_link_libraries(nvbench PRIVATE $<COMPILE_ONLY:nvbench_git_revision>)
 else()
   # Need to add dependencies on the internal implementation targets from rapids-cmake
   # so that we generate the git header before using it
-  add_dependencies(nvbench nvbench_git_revision nvbench_git_revision_compute_git_info)
+  add_dependencies(nvbench nvbench_git_revision_compute_git_info)
   get_target_property(_include_dir nvbench_git_revision INTERFACE_INCLUDE_DIRECTORIES)
   target_include_directories(nvbench PRIVATE "$<BUILD_INTERFACE:${_include_dir}>")
 endif()

--- a/nvbench/CMakeLists.txt
+++ b/nvbench/CMakeLists.txt
@@ -137,9 +137,9 @@ endif()
 # CMakeLists.txt as the consumer ( nvbench ) for CMake to get the dependency
 # graph correct.
 rapids_cmake_write_git_revision_file(
-    nvbench_git_revision
-    "${NVBench_BINARY_DIR}/nvbench/detail/git_revision.cuh"
-  )
+  nvbench_git_revision
+  "${NVBench_BINARY_DIR}/nvbench/detail/git_revision.cuh"
+)
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
   target_link_libraries(nvbench PRIVATE $<COMPILE_ONLY:nvbench_git_revision>)
 else()


### PR DESCRIPTION
So we can't have this in the rapids-cmake init function.

