### PR TITLE
No batch tag

### DIFF
--- a/nvbench/exec_tag.cuh
+++ b/nvbench/exec_tag.cuh
@@ -38,8 +38,8 @@ enum class exec_flag
   modifier_mask = timer | no_block | sync | run_once,
 
   // Measurement types:
-  cold         = 0x0100, // measure_hot
-  hot          = 0x0200, // measure_cold
+  cold         = 0x0100, // measure_cold
+  hot          = 0x0200, // measure_hot
   measure_mask = cold | hot
 };
 
@@ -121,5 +121,8 @@ constexpr inline auto timer = nvbench::exec_tag::impl::timer;
 /// Modifier used to indicate that the KernelGenerator will perform CUDA
 /// synchronizations. Without this flag such benchmarks will deadlock.
 constexpr inline auto sync = nvbench::exec_tag::impl::no_block | nvbench::exec_tag::impl::sync;
+
+/// Modifier used to indicate that batched measurements should be disabled
+constexpr inline auto no_batch = nvbench::exec_tag::impl::cold;
 
 } // namespace nvbench::exec_tag


### PR DESCRIPTION
NVBench always collects batch measurements:

| NumElements |  DataSize  | Samples |  CPU Time  | Noise  |  GPU Time  | Noise | Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------------|------------|---------|------------|--------|------------|-------|---------|--------------|--------|---------|------------|
|    16777216 | 64.000 MiB |   2624x | 200.347 us | 16.22% | 190.839 us | 2.91% | 87.913G | 703.303 GB/s | 73.25% |   3059x | 174.476 us |


In some cases, batch measurements are not required. By providing a way to disable batch measurements, we can speedup benchmarking. This PR introduces a new tag:

```c++
state.exec(nvbench::exec_tag::no_batch, [&](nvbench::launch &launch) {
/// ...
```

leads to absence of `Samples` and `Batch GPU` columns:

| NumElements |  DataSize  | Samples |  CPU Time  | Noise  |  GPU Time  | Noise | Elem/s  | GlobalMem BW | BWUtil |
|-------------|------------|---------|------------|--------|------------|-------|---------|--------------|--------|
|    16777216 | 64.000 MiB |   2656x | 197.683 us | 16.99% | 188.337 us | 2.55% | 89.081G | 712.645 GB/s | 74.23% |
