### PR TITLE
Use a reproducible seed in test rng.

### DIFF
--- a/testing/stdrel_criterion.cu
+++ b/testing/stdrel_criterion.cu
@@ -41,8 +41,8 @@ void test_const()
 
 std::vector<double> generate(double mean, double rel_std_dev, int size)
 {
-  std::random_device rd;
-  std::mt19937 gen(rd());
+  static std::mt19937::result_type seed = 0;
+  std::mt19937 gen(seed++);
   std::vector<nvbench::float64_t> v(static_cast<std::size_t>(size));
   std::normal_distribution<nvbench::float64_t> dist(mean, mean * rel_std_dev);
   std::generate(v.begin(), v.end(), [&]{ return dist(gen); });


### PR DESCRIPTION
This test is failing intermittently depending on seed chosen, as
some random sample patterns don't exceed the stdrel threshold.