### PR TITLE
Removed extraneous break statements that caused nvc++ to give warnings

### DIFF
--- a/nvbench/axis_base.cuh
+++ b/nvbench/axis_base.cuh
@@ -91,16 +91,12 @@ inline std::string_view axis_type_to_string(axis_type type)
   {
     case axis_type::type:
       return "type";
-      break;
     case axis_type::int64:
       return "int64";
-      break;
     case axis_type::float64:
       return "float64";
-      break;
     case axis_type::string:
       return "string";
-      break;
   }
   throw std::runtime_error{"nvbench::axis_type_to_string Invalid axis_type."};
 }


### PR DESCRIPTION
nvc++ used as a host compiler for nvcc gives warnings with `-Wall` on relating to using a `break` statement following a `return` inside of a `case`. This removes the `break` statements.