### PR TITLE
Distinguish slower, same and faster comparisons

### DIFF
--- a/scripts/nvbench_compare.py
+++ b/scripts/nvbench_compare.py
@@ -218,10 +218,13 @@ def compare_benches(ref_benches, cmp_benches, threshold):
                     status = Fore.YELLOW + "????" + Fore.RESET
                 elif abs(frac_diff) <= min_noise:
                     pass_count += 1
-                    status = Fore.GREEN + "PASS" + Fore.RESET
+                    status = Fore.BLUE + "SAME" + Fore.RESET
+                elif diff < 0:
+                    failure_count += 1
+                    status = Fore.GREEN + "FAST" + Fore.RESET
                 else:
                     failure_count += 1
-                    status = Fore.RED + "FAIL" + Fore.RESET
+                    status = Fore.RED + "SLOW" + Fore.RESET
 
                 if abs(frac_diff) >= threshold:
                     row.append(format_duration(ref_time))


### PR DESCRIPTION
Fixes: #178

Example output:

![image](https://github.com/user-attachments/assets/cdb8bce0-7e42-4071-8933-6283a7ad560e)


Pasted as text:

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|------------|---------|----------|
|   U32   |    2^16    |  10.914 us |       3.53% |  10.089 us |       7.95% |  -0.824 us |  -7.55% |   FAST   |
|   U32   |    2^20    |  15.033 us |       2.14% |  15.964 us |       2.06% |   0.931 us |   6.19% |   SLOW   |
|   U32   |    2^24    |  88.112 us |       1.84% |  85.886 us |       0.52% |  -2.227 us |  -2.53% |   FAST   |
|   U32   |    2^28    |   1.244 ms |       0.07% |   1.180 ms |       0.44% | -64.276 us |  -5.17% |   FAST   |
|   U64   |    2^16    |  10.957 us |       2.52% |  10.885 us |       3.39% |  -0.072 us |  -0.66% |   SAME   |
|   U64   |    2^20    |  16.175 us |       4.56% |  24.370 us |       1.75% |   8.195 us |  50.67% |   SLOW   |
|   U64   |    2^24    | 101.057 us |       0.44% | 208.507 us |       0.40% | 107.451 us | 106.33% |   SLOW   |
|   U64   |    2^28    |   1.448 ms |       0.16% |   3.156 ms |       0.09% |   1.708 ms | 117.94% |   SLOW   |