### PR TITLE
Add min/max timings, new "summaries" example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ various NVBench features and usecases:
 - [Reporting item/sec and byte/sec throughput statistics](examples/throughput.cu)
 - [Skipping benchmark configurations](examples/skip.cu)
 - [Benchmarking on a specific stream](examples/stream.cu)
+- [Adding / hiding columns (summaries) in markdown output](examples/summaries.cu)
 - [Benchmarks that sync CUDA devices: `nvbench::exec_tag::sync`](examples/exec_tag_sync.cu)
 - [Manual timing: `nvbench::exec_tag::timer`](examples/exec_tag_timer.cu)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,6 +8,7 @@ set(example_srcs
   exec_tag_timer.cu
   skip.cu
   stream.cu
+  summaries.cu
   throughput.cu
 )
 

--- a/examples/summaries.cu
+++ b/examples/summaries.cu
@@ -1,0 +1,70 @@
+/*
+ *  Copyright 2025 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <nvbench/nvbench.cuh>
+
+// Grab some testing kernels from NVBench:
+#include <nvbench/test_kernels.cuh>
+
+// #define PRINT_DEFAULT_SUMMARY_TAGS
+
+void summary_example(nvbench::state &state)
+{
+  // Fetch parameters and compute duration in seconds:
+  const auto ms = static_cast<nvbench::float64_t>(state.get_int64("ms"));
+  const auto us = static_cast<nvbench::float64_t>(state.get_int64("us"));
+  const auto duration = ms * 1e-3 + us * 1e-6;
+
+  // Add a new column to the summary table with the derived duration used by the benchmark.
+  // See the documentation in nvbench/summary.cuh for more details.
+  {
+    nvbench::summary &summary = state.add_summary("duration");
+    summary.set_string("name", "Duration (s)");
+    summary.set_string("description", "The duration of the kernel execution.");
+    summary.set_string("hint", "duration");
+    summary.set_float64("value", duration);
+  }
+
+  // Run the measurements:
+  state.exec([duration](nvbench::launch &launch) {
+    nvbench::sleep_kernel<<<1, 1, 0, launch.get_stream()>>>(duration);
+  });
+
+#ifdef PRINT_DEFAULT_SUMMARY_TAGS
+  // The default summary tags can be found by inspecting the state after calling
+  // state.exec.
+  // They can also be found by looking at the json output (--json <filename>)
+  for (const auto &summary : state.get_summaries())
+  {
+    std::cout << summary.get_tag() << std::endl;
+  }
+#endif
+
+  // Default summary columns can be shown/hidden in the markdown output tables by adding/removing
+  // the "hide" key. Modify this benchmark to show the minimum and maximum times, but hide the
+  // means.
+  state.get_summary("nv/cold/time/gpu/min").remove_value("hide");
+  state.get_summary("nv/cold/time/gpu/max").remove_value("hide");
+  state.get_summary("nv/cold/time/gpu/mean").set_string("hide", "");
+  state.get_summary("nv/cold/time/cpu/min").remove_value("hide");
+  state.get_summary("nv/cold/time/cpu/max").remove_value("hide");
+  state.get_summary("nv/cold/time/cpu/mean").set_string("hide", "");
+}
+NVBENCH_BENCH(summary_example)
+  .add_int64_axis("ms", nvbench::range(10, 50, 20))
+  .add_int64_axis("us", nvbench::range(100, 500, 200));

--- a/nvbench/detail/measure_cold.cuh
+++ b/nvbench/detail/measure_cold.cuh
@@ -98,9 +98,14 @@ protected:
   nvbench::float64_t m_timeout{};
 
   nvbench::int64_t m_total_samples{};
+
+  nvbench::float64_t m_min_cuda_time{};
+  nvbench::float64_t m_max_cuda_time{};
   nvbench::float64_t m_total_cuda_time{};
+
+  nvbench::float64_t m_min_cpu_time{};
+  nvbench::float64_t m_max_cpu_time{};
   nvbench::float64_t m_total_cpu_time{};
-  nvbench::float64_t m_cpu_noise{}; // rel stdev
 
   std::vector<nvbench::float64_t> m_cuda_times;
   std::vector<nvbench::float64_t> m_cpu_times;

--- a/nvbench/detail/measure_cpu_only.cuh
+++ b/nvbench/detail/measure_cpu_only.cuh
@@ -76,8 +76,10 @@ protected:
   nvbench::float64_t m_timeout{};
 
   nvbench::int64_t m_total_samples{};
+
+  nvbench::float64_t m_min_cpu_time{};
+  nvbench::float64_t m_max_cpu_time{};
   nvbench::float64_t m_total_cpu_time{};
-  nvbench::float64_t m_cpu_noise{}; // rel stdev
 
   std::vector<nvbench::float64_t> m_cpu_times;
 


### PR DESCRIPTION
Output from the new example (without locked clocks on a shared GPU, so ignore the numbers...):

| ms | us  | Duration (s) | Samples | Min CPU Time | Max CPU Time |  Noise  | Min GPU Time | Max GPU Time | Noise | Samples | Batch GPU |
|----|-----|--------------|---------|--------------|--------------|---------|--------------|--------------|-------|---------|-----------|
| 10 | 100 |    10.100 ms |     50x |     9.659 ms |     9.918 ms |   0.46% |    10.103 ms |    10.215 ms | 0.16% |     52x | 10.107 ms |
| 30 | 100 |    30.100 ms |     17x |    28.759 ms |    28.831 ms |   0.08% |    30.103 ms |    30.107 ms | 0.00% |     18x | 30.103 ms |
| 50 | 100 |    50.100 ms |     11x |    47.863 ms |      1.991 s | 260.91% |    50.102 ms |    50.104 ms | 0.00% |     12x | 50.103 ms |
| 10 | 300 |    10.300 ms |     49x |     9.854 ms |    10.063 ms |   0.38% |    10.302 ms |    10.309 ms | 0.01% |     51x | 10.303 ms |
| 30 | 300 |    30.300 ms |     17x |    29.024 ms |    29.210 ms |   0.19% |    30.302 ms |    30.484 ms | 0.17% |     18x | 30.312 ms |
| 50 | 300 |    50.300 ms |     11x |    48.170 ms |    48.347 ms |   0.10% |    50.303 ms |    50.443 ms | 0.08% |     12x | 50.318 ms |
| 10 | 500 |    10.500 ms |     48x |    10.072 ms |    10.287 ms |   0.33% |    10.502 ms |    10.575 ms | 0.10% |     50x | 10.502 ms |
| 30 | 500 |    30.500 ms |     17x |    29.213 ms |    29.267 ms |   0.06% |    30.503 ms |    30.507 ms | 0.00% |     18x | 30.503 ms |
| 50 | 500 |    50.500 ms |     11x |    48.361 ms |    48.389 ms |   0.03% |    50.503 ms |    50.506 ms | 0.00% |     12x | 50.514 ms |