### PR TITLE
Discard measurements while GPU is throttling

### DIFF
--- a/docs/cli_help.md
+++ b/docs/cli_help.md
@@ -133,11 +133,6 @@
   * Applies to the most recent `--benchmark`, or all benchmarks if specified
     before any `--benchmark` arguments.
 
-* `--discard-on-throttle`
-  * Discard measurements if the GPU is throttled.
-  * Applies to the most recent `--benchmark`, or all benchmarks if specified
-    before any `--benchmark` arguments.
-
 * `--throttle-threshold <value>`
   * Set the GPU throttle threshold as percentage of the peak clock rate.
   * Default is 75%.

--- a/docs/cli_help.md
+++ b/docs/cli_help.md
@@ -140,13 +140,13 @@
 
 * `--throttle-threshold <value>`
   * Set the GPU throttle threshold as percentage of the peak clock rate.
-  * Default is 0.75 (75%).
+  * Default is 75%.
   * Applies to the most recent `--benchmark`, or all benchmarks if specified
     before any `--benchmark` arguments.
 
 * `--throttle-recovery-delay <value>`
   * Set the GPU throttle recovery delay in seconds.
-  * Default is 0.5 seconds.
+  * Default is 0.05 seconds.
   * Applies to the most recent `--benchmark`, or all benchmarks if specified
     before any `--benchmark` arguments.
 

--- a/docs/cli_help.md
+++ b/docs/cli_help.md
@@ -133,6 +133,23 @@
   * Applies to the most recent `--benchmark`, or all benchmarks if specified
     before any `--benchmark` arguments.
 
+* `--discard-on-throttle`
+  * Discard measurements if the GPU is throttled.
+  * Applies to the most recent `--benchmark`, or all benchmarks if specified
+    before any `--benchmark` arguments.
+
+* `--throttle-threshold <value>`
+  * Set the GPU throttle threshold as percentage of the peak clock rate.
+  * Default is 0.75 (75%).
+  * Applies to the most recent `--benchmark`, or all benchmarks if specified
+    before any `--benchmark` arguments.
+
+* `--throttle-recovery-delay <value>`
+  * Set the GPU throttle recovery delay in seconds.
+  * Default is 0.5 seconds.
+  * Applies to the most recent `--benchmark`, or all benchmarks if specified
+    before any `--benchmark` arguments.
+
 * `--run-once`
   * Only run the benchmark once, skipping any warmup runs and batched
     measurements.

--- a/nvbench/CMakeLists.txt
+++ b/nvbench/CMakeLists.txt
@@ -29,6 +29,8 @@ set(srcs
   detail/measure_hot.cu
   detail/state_generator.cxx
   detail/stdrel_criterion.cxx
+  detail/gpu_frequency.cxx
+  detail/timestamps_kernel.cu
 
   internal/nvml.cxx
 )

--- a/nvbench/benchmark_base.cuh
+++ b/nvbench/benchmark_base.cuh
@@ -309,8 +309,8 @@ protected:
   nvbench::float64_t m_skip_time{-1.};
   nvbench::float64_t m_timeout{15.};
 
-  nvbench::float32_t m_throttle_threshold{0.75f};     // [% of peak SM clock rate]
-  nvbench::float32_t m_throttle_recovery_delay{0.0f}; // [seconds]
+  nvbench::float32_t m_throttle_threshold{0.75f};      // [% of peak SM clock rate]
+  nvbench::float32_t m_throttle_recovery_delay{0.05f}; // [seconds]
   bool m_discard_on_throttle{false};
 
   nvbench::criterion_params m_criterion_params;

--- a/nvbench/benchmark_base.cuh
+++ b/nvbench/benchmark_base.cuh
@@ -247,12 +247,39 @@ struct benchmark_base
   }
   /// @}
 
-  [[nodiscard]] nvbench::criterion_params& get_criterion_params() { return m_criterion_params; }
-  [[nodiscard]] const nvbench::criterion_params& get_criterion_params() const { return m_criterion_params; }
+  [[nodiscard]] nvbench::float32_t get_throttle_threshold() const { return m_throttle_threshold; }
+
+  void set_throttle_threshold(nvbench::float32_t throttle_threshold)
+  {
+    m_throttle_threshold = throttle_threshold;
+  }
+
+  [[nodiscard]] nvbench::float32_t get_throttle_recovery_delay() const
+  {
+    return m_throttle_recovery_delay;
+  }
+
+  void set_throttle_recovery_delay(nvbench::float32_t throttle_recovery_delay)
+  {
+    m_throttle_recovery_delay = throttle_recovery_delay;
+  }
+
+  [[nodiscard]] bool get_discard_on_throttle() const { return m_discard_on_throttle; }
+
+  void set_discard_on_throttle(bool discard_on_throttle)
+  {
+    m_discard_on_throttle = discard_on_throttle;
+  }
+
+  [[nodiscard]] nvbench::criterion_params &get_criterion_params() { return m_criterion_params; }
+  [[nodiscard]] const nvbench::criterion_params &get_criterion_params() const
+  {
+    return m_criterion_params;
+  }
 
   /// Control the stopping criterion for the measurement loop.
   /// @{
-  [[nodiscard]] const std::string& get_stopping_criterion() const { return m_stopping_criterion; }
+  [[nodiscard]] const std::string &get_stopping_criterion() const { return m_stopping_criterion; }
   benchmark_base &set_stopping_criterion(std::string criterion)
   {
     m_stopping_criterion = std::move(criterion);
@@ -281,6 +308,10 @@ protected:
 
   nvbench::float64_t m_skip_time{-1.};
   nvbench::float64_t m_timeout{15.};
+
+  nvbench::float32_t m_throttle_threshold{0.75f};     // [% of peak SM clock rate]
+  nvbench::float32_t m_throttle_recovery_delay{0.0f}; // [seconds]
+  bool m_discard_on_throttle{false};
 
   nvbench::criterion_params m_criterion_params;
   std::string m_stopping_criterion{"stdrel"};

--- a/nvbench/benchmark_base.cuh
+++ b/nvbench/benchmark_base.cuh
@@ -264,13 +264,6 @@ struct benchmark_base
     m_throttle_recovery_delay = throttle_recovery_delay;
   }
 
-  [[nodiscard]] bool get_discard_on_throttle() const { return m_discard_on_throttle; }
-
-  void set_discard_on_throttle(bool discard_on_throttle)
-  {
-    m_discard_on_throttle = discard_on_throttle;
-  }
-
   [[nodiscard]] nvbench::criterion_params &get_criterion_params() { return m_criterion_params; }
   [[nodiscard]] const nvbench::criterion_params &get_criterion_params() const
   {
@@ -311,7 +304,6 @@ protected:
 
   nvbench::float32_t m_throttle_threshold{0.75f};      // [% of peak SM clock rate]
   nvbench::float32_t m_throttle_recovery_delay{0.05f}; // [seconds]
-  bool m_discard_on_throttle{false};
 
   nvbench::criterion_params m_criterion_params;
   std::string m_stopping_criterion{"stdrel"};

--- a/nvbench/benchmark_base.cxx
+++ b/nvbench/benchmark_base.cxx
@@ -47,7 +47,6 @@ std::unique_ptr<benchmark_base> benchmark_base::clone() const
   result->m_criterion_params        = m_criterion_params;
   result->m_throttle_threshold      = m_throttle_threshold;
   result->m_throttle_recovery_delay = m_throttle_recovery_delay;
-  result->m_discard_on_throttle     = m_discard_on_throttle;
 
   result->m_stopping_criterion = m_stopping_criterion;
 

--- a/nvbench/benchmark_base.cxx
+++ b/nvbench/benchmark_base.cxx
@@ -17,7 +17,6 @@
  */
 
 #include <nvbench/benchmark_base.cuh>
-
 #include <nvbench/detail/transform_reduce.cuh>
 
 namespace nvbench
@@ -45,7 +44,11 @@ std::unique_ptr<benchmark_base> benchmark_base::clone() const
   result->m_skip_time = m_skip_time;
   result->m_timeout   = m_timeout;
 
-  result->m_criterion_params   = m_criterion_params;
+  result->m_criterion_params        = m_criterion_params;
+  result->m_throttle_threshold      = m_throttle_threshold;
+  result->m_throttle_recovery_delay = m_throttle_recovery_delay;
+  result->m_discard_on_throttle     = m_discard_on_throttle;
+
   result->m_stopping_criterion = m_stopping_criterion;
 
   return result;

--- a/nvbench/detail/gpu_frequency.cuh
+++ b/nvbench/detail/gpu_frequency.cuh
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2025 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <nvbench/detail/timestamps_kernel.cuh>
+#include <nvbench/types.cuh>
+
+namespace nvbench::detail
+{
+
+struct cuda_stream;
+
+struct gpu_frequency
+{
+  gpu_frequency() = default;
+
+  // move-only
+  gpu_frequency(const gpu_frequency &)            = delete;
+  gpu_frequency(gpu_frequency &&)                 = default;
+  gpu_frequency &operator=(const gpu_frequency &) = delete;
+  gpu_frequency &operator=(gpu_frequency &&)      = default;
+
+  void start(const nvbench::cuda_stream &stream) { m_start.record(stream); }
+
+  void stop(const nvbench::cuda_stream &stream) { m_stop.record(stream); }
+
+  [[nodiscard]] bool has_throttled(nvbench::float32_t peak_sm_clock_rate_hz,
+                                   nvbench::float32_t throttle_threshold);
+
+  [[nodiscard]] nvbench::float32_t get_clock_frequency();
+
+private:
+  nvbench::detail::timestamps_kernel m_start;
+  nvbench::detail::timestamps_kernel m_stop;
+};
+
+} // namespace nvbench::detail

--- a/nvbench/detail/gpu_frequency.cxx
+++ b/nvbench/detail/gpu_frequency.cxx
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2025 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <nvbench/detail/gpu_frequency.cuh>
+
+#include <iostream>
+
+namespace nvbench::detail
+{
+
+nvbench::float32_t gpu_frequency::get_clock_frequency()
+{
+  nvbench::uint64_t elapsed_ns     = m_stop.m_host_timestamps[0] - m_start.m_host_timestamps[0];
+  nvbench::uint64_t elapsed_clocks = m_stop.m_host_timestamps[1] - m_start.m_host_timestamps[1];
+  nvbench::float32_t clock_rate    = float(elapsed_clocks) / float(elapsed_ns) * 1000000000.f;
+  return clock_rate;
+}
+
+bool gpu_frequency::has_throttled(nvbench::float32_t peak_sm_clock_rate_hz,
+                                  nvbench::float32_t throttle_threshold)
+{
+  float threshold = peak_sm_clock_rate_hz * throttle_threshold;
+
+  if (this->get_clock_frequency() < threshold)
+  {
+    return true;
+  }
+
+  return false;
+}
+
+} // namespace nvbench::detail

--- a/nvbench/detail/measure_cold.cu
+++ b/nvbench/detail/measure_cold.cu
@@ -26,8 +26,8 @@
 #include <nvbench/summary.cuh>
 
 #include <algorithm>
-#include <limits>
 #include <chrono>
+#include <limits>
 #include <thread>
 
 #include <fmt/format.h>
@@ -48,7 +48,6 @@ measure_cold_base::measure_cold_base(state &exec_state)
     , m_timeout{exec_state.get_timeout()}
     , m_throttle_threshold(exec_state.get_throttle_threshold())
     , m_throttle_recovery_delay(exec_state.get_throttle_recovery_delay())
-    , m_discard_on_throttle(exec_state.get_discard_on_throttle())
 {
   if (m_min_samples > 0)
   {
@@ -96,7 +95,6 @@ void measure_cold_base::record_measurements()
   if (!m_run_once)
   {
     auto peak_clock_rate = static_cast<float>(m_state.get_device()->get_sm_default_clock_rate());
-    m_sm_clock_rates.push_back(peak_clock_rate);
 
     if (m_gpu_frequency.has_throttled(peak_clock_rate, m_throttle_threshold))
     {
@@ -106,14 +104,13 @@ void measure_cold_base::record_measurements()
         auto &printer           = printer_opt_ref.value().get();
         printer.log(nvbench::log_level::warn,
                     fmt::format("GPU throttled below threshold ({:0.2f} MHz / {:0.2f} MHz) "
-                                "({:0.0f}% < {:0.0f}%) on sample {}. {} previous sample and "
-                                "pausing for {}s.",
+                                "({:0.0f}% < {:0.0f}%) on sample {}. Discarding previous sample "
+                                "and pausing for {}s.",
                                 current_clock_rate / 1000000.0f,
                                 peak_clock_rate / 1000000.0f,
                                 100.0f * (current_clock_rate / peak_clock_rate),
                                 100.0f * m_throttle_threshold,
                                 m_total_samples,
-                                m_discard_on_throttle ? "Discarding" : "Keeping",
                                 m_throttle_recovery_delay));
       }
 
@@ -122,11 +119,11 @@ void measure_cold_base::record_measurements()
         std::this_thread::sleep_for(std::chrono::duration<float>(m_throttle_recovery_delay));
       }
 
-      if (m_discard_on_throttle)
-      { // ignore this measurement
-        return;
-      }
+      // ignore this measurement
+      return;
     }
+
+    m_sm_clock_rates.push_back(peak_clock_rate);
   }
 
   // Update and record timers and counters:
@@ -348,8 +345,9 @@ void measure_cold_base::generate_summaries()
     summ.set_string("hint", "frequency");
     summ.set_string("description", "Mean SM clock rate");
     summ.set_string("hide", "Hidden by default.");
-    summ.set_float64("value", nvbench::detail::statistics::compute_mean(m_sm_clock_rates.cbegin(), 
-                                                                        m_sm_clock_rates.cend()));
+    summ.set_float64("value",
+                     nvbench::detail::statistics::compute_mean(m_sm_clock_rates.cbegin(),
+                                                               m_sm_clock_rates.cend()));
   }
 
   // Log if a printer exists:

--- a/nvbench/detail/measure_cold.cuh
+++ b/nvbench/detail/measure_cold.cuh
@@ -36,6 +36,7 @@
 
 #include <utility>
 #include <vector>
+#include "nvbench/types.cuh"
 
 namespace nvbench
 {
@@ -117,6 +118,7 @@ protected:
 
   std::vector<nvbench::float64_t> m_cuda_times;
   std::vector<nvbench::float64_t> m_cpu_times;
+  std::vector<nvbench::float32_t> m_sm_clock_rates;
 
   bool m_max_time_exceeded{};
 };

--- a/nvbench/detail/measure_cold.cuh
+++ b/nvbench/detail/measure_cold.cuh
@@ -18,24 +18,24 @@
 
 #pragma once
 
+#include <cuda_runtime.h>
+
 #include <nvbench/blocking_kernel.cuh>
 #include <nvbench/cpu_timer.cuh>
 #include <nvbench/cuda_call.cuh>
 #include <nvbench/cuda_timer.cuh>
+#include <nvbench/detail/gpu_frequency.cuh>
+#include <nvbench/detail/kernel_launcher_timer_wrapper.cuh>
+#include <nvbench/detail/l2flush.cuh>
+#include <nvbench/detail/statistics.cuh>
 #include <nvbench/device_info.cuh>
 #include <nvbench/exec_tag.cuh>
 #include <nvbench/launch.cuh>
 #include <nvbench/stopping_criterion.cuh>
 
-#include <nvbench/detail/kernel_launcher_timer_wrapper.cuh>
-#include <nvbench/detail/l2flush.cuh>
-#include <nvbench/detail/statistics.cuh>
-#include <nvbench/detail/gpu_frequency.cuh>
-
-#include <cuda_runtime.h>
-
 #include <utility>
 #include <vector>
+
 #include "nvbench/types.cuh"
 
 namespace nvbench
@@ -91,7 +91,7 @@ protected:
   nvbench::blocking_kernel m_blocker;
 
   nvbench::criterion_params m_criterion_params;
-  nvbench::stopping_criterion_base& m_stopping_criterion;
+  nvbench::stopping_criterion_base &m_stopping_criterion;
   nvbench::detail::gpu_frequency m_gpu_frequency;
 
   bool m_disable_blocking_kernel{false};
@@ -102,8 +102,8 @@ protected:
   nvbench::float64_t m_skip_time{};
   nvbench::float64_t m_timeout{};
 
-  nvbench::float32_t m_throttle_threshold{0.75f};     // [% of peak SM clock rate]
-  nvbench::float32_t m_throttle_recovery_delay{0.0f}; // [seconds]
+  nvbench::float32_t m_throttle_threshold;      // [% of peak SM clock rate]
+  nvbench::float32_t m_throttle_recovery_delay; // [seconds]
   bool m_discard_on_throttle{false};
 
   nvbench::int64_t m_total_samples{};

--- a/nvbench/detail/measure_cold.cuh
+++ b/nvbench/detail/measure_cold.cuh
@@ -104,7 +104,6 @@ protected:
 
   nvbench::float32_t m_throttle_threshold;      // [% of peak SM clock rate]
   nvbench::float32_t m_throttle_recovery_delay; // [seconds]
-  bool m_discard_on_throttle{false};
 
   nvbench::int64_t m_total_samples{};
 

--- a/nvbench/detail/timestamps_kernel.cu
+++ b/nvbench/detail/timestamps_kernel.cu
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2025 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <cuda_runtime.h>
+
+#include <nvbench/cuda_call.cuh>
+#include <nvbench/cuda_stream.cuh>
+#include <nvbench/detail/timestamps_kernel.cuh>
+#include <nvbench/types.cuh>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace
+{
+
+__global__ void get_timestamps_kernel(nvbench::uint64_t *global_timestamp,
+                                      nvbench::uint64_t *sm0_timestamp)
+{
+  nvbench::uint32_t smid;
+  asm volatile("mov.u32 %0, %%smid;" : "=r"(smid));
+  if (smid == 0)
+  {
+    nvbench::uint64_t gts, lts;
+    asm volatile("mov.u64 %0, %%globaltimer;" : "=l"(gts));
+    lts = clock64();
+
+    *global_timestamp = gts;
+    *sm0_timestamp    = lts;
+  }
+}
+
+} // namespace
+
+namespace nvbench::detail
+{
+
+timestamps_kernel::timestamps_kernel()
+{
+  NVBENCH_CUDA_CALL(
+    cudaHostRegister(&m_host_timestamps, sizeof(nvbench::uint64_t) * 2, cudaHostRegisterMapped));
+  NVBENCH_CUDA_CALL(cudaHostGetDevicePointer(&m_device_timestamps, &m_host_timestamps, 0));
+}
+
+timestamps_kernel::~timestamps_kernel()
+{
+  NVBENCH_CUDA_CALL_NOEXCEPT(cudaHostUnregister(&m_host_timestamps));
+}
+
+void timestamps_kernel::record(const nvbench::cuda_stream &stream)
+{
+  m_host_timestamps[0] = 0;
+  m_host_timestamps[1] = 0;
+
+  int device_id = 0;
+  int num_sms   = 0;
+
+  NVBENCH_CUDA_CALL(cudaGetDevice(&device_id));
+  NVBENCH_CUDA_CALL(
+    cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, device_id));
+
+  get_timestamps_kernel<<<static_cast<unsigned int>(num_sms), 1, 0, stream.get_stream()>>>(
+    m_device_timestamps,
+    m_device_timestamps + 1);
+}
+
+} // namespace nvbench

--- a/nvbench/detail/timestamps_kernel.cuh
+++ b/nvbench/detail/timestamps_kernel.cuh
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2025 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <nvbench/types.cuh>
+
+namespace nvbench
+{
+
+struct cuda_stream;
+
+namespace detail
+{
+
+struct timestamps_kernel
+{
+  timestamps_kernel();
+  ~timestamps_kernel();
+
+  void record(const nvbench::cuda_stream &stream);
+
+  // move-only
+  timestamps_kernel(const timestamps_kernel &)            = delete;
+  timestamps_kernel(timestamps_kernel &&)                 = default;
+  timestamps_kernel &operator=(const timestamps_kernel &) = delete;
+  timestamps_kernel &operator=(timestamps_kernel &&)      = default;
+
+  nvbench::uint64_t m_host_timestamps[2];
+  nvbench::uint64_t *m_device_timestamps{};
+};
+
+} // namespace detail
+
+} // namespace nvbench

--- a/nvbench/device_info.cuh
+++ b/nvbench/device_info.cuh
@@ -18,16 +18,17 @@
 
 #pragma once
 
+#include <cuda_runtime_api.h>
+
 #include <nvbench/config.cuh>
 #include <nvbench/cuda_call.cuh>
 #include <nvbench/detail/device_scope.cuh>
 
-#include <cuda_runtime_api.h>
-
 #include <cstdint> // CHAR_BIT
 #include <stdexcept>
-#include <string_view>
 #include <utility>
+
+#include <string_view>
 
 // forward declare this for internal storage
 struct nvmlDevice_st;

--- a/nvbench/device_info.cuh
+++ b/nvbench/device_info.cuh
@@ -109,7 +109,7 @@ struct device_info
   /// @return The default clock rate of the SM in Hz.
   [[nodiscard]] std::size_t get_sm_default_clock_rate() const
   { // kHz -> Hz
-    return static_cast<std::size_t>(m_prop.clockRate * 1000);
+    return static_cast<std::size_t>(m_prop.clockRate) * 1000;
   }
 
   /// @return The number of physical streaming multiprocessors on this device.

--- a/nvbench/markdown_printer.cu
+++ b/nvbench/markdown_printer.cu
@@ -294,6 +294,10 @@ void markdown_printer::do_print_benchmark_results(const printer_base::benchmark_
             {
               table.add_cell(row, tag, header, this->do_format_item_rate(summ));
             }
+            else if (hint == "frequency")
+            {
+              table.add_cell(row, tag, header, this->do_format_frequency(summ));
+            }
             else if (hint == "bytes")
             {
               table.add_cell(row, tag, header, this->do_format_bytes(summ));
@@ -396,6 +400,27 @@ std::string markdown_printer::do_format_item_rate(const summary &data)
   else
   {
     return fmt::format("{:0.3f}", items_per_second);
+  }
+}
+
+std::string markdown_printer::do_format_frequency(const nvbench::summary &data)
+{
+  const auto frequency_hz = data.get_float64("value");
+  if (frequency_hz >= 1e9)
+  {
+    return fmt::format("{:0.3f} GHz", frequency_hz * 1e-9);
+  }
+  else if (frequency_hz >= 1e6)
+  {
+    return fmt::format("{:0.3f} MHz", frequency_hz * 1e-6);
+  }
+  else if (frequency_hz >= 1e3)
+  {
+    return fmt::format("{:0.3f} KHz", frequency_hz * 1e-3);
+  }
+  else
+  {
+    return fmt::format("{:0.3f} Hz", frequency_hz);
   }
 }
 

--- a/nvbench/markdown_printer.cuh
+++ b/nvbench/markdown_printer.cuh
@@ -64,6 +64,7 @@ protected:
   virtual std::string do_format_default(const nvbench::summary &data);
   virtual std::string do_format_duration(const nvbench::summary &seconds);
   virtual std::string do_format_item_rate(const nvbench::summary &items_per_sec);
+  virtual std::string do_format_frequency(const nvbench::summary &frequency_hz);
   virtual std::string do_format_bytes(const nvbench::summary &bytes);
   virtual std::string do_format_byte_rate(const nvbench::summary &bytes_per_sec);
   virtual std::string do_format_sample_size(const nvbench::summary &count);

--- a/nvbench/option_parser.cu
+++ b/nvbench/option_parser.cu
@@ -1071,7 +1071,7 @@ try
   }
   else if (prop_arg == "--throttle-threshold")
   {
-    bench.set_throttle_threshold(static_cast<nvbench::float32_t>(value));
+    bench.set_throttle_threshold(static_cast<nvbench::float32_t>(value) / 100.0f);
   }
   else if (prop_arg == "--throttle-recovery-delay")
   {

--- a/nvbench/option_parser.cu
+++ b/nvbench/option_parser.cu
@@ -431,11 +431,6 @@ void option_parser::parse_range(option_parser::arg_iterator_t first,
       this->lock_gpu_clocks(first[1]);
       first += 2;
     }
-    else if (arg == "--discard-on-throttle")
-    {
-      this->enable_discard_on_throttle();
-      first += 1;
-    }
     else if (arg == "--run-once")
     {
       this->enable_run_once();
@@ -729,18 +724,6 @@ void option_parser::enable_run_once()
 
   benchmark_base &bench = *m_benchmarks.back();
   bench.set_run_once(true);
-}
-
-void option_parser::enable_discard_on_throttle()
-{
-  if (m_benchmarks.empty())
-  {
-    m_global_benchmark_args.push_back("--discard-on-throttle");
-    return;
-  }
-
-  benchmark_base &bench = *m_benchmarks.back();
-  bench.set_discard_on_throttle(true);
 }
 
 void option_parser::set_stopping_criterion(const std::string &criterion)

--- a/nvbench/option_parser.cuh
+++ b/nvbench/option_parser.cuh
@@ -89,7 +89,6 @@ private:
 
   void set_stopping_criterion(const std::string &criterion);
   void enable_run_once();
-  void enable_discard_on_throttle();
   void disable_blocking_kernel();
 
   void add_benchmark(const std::string &name);

--- a/nvbench/option_parser.cuh
+++ b/nvbench/option_parser.cuh
@@ -80,7 +80,7 @@ private:
   std::ostream &printer_spec_to_ostream(const std::string &spec);
 
   void print_version() const;
-  void print_list(printer_base& printer) const;
+  void print_list(printer_base &printer) const;
   void print_help() const;
   void print_help_axis() const;
 
@@ -89,6 +89,7 @@ private:
 
   void set_stopping_criterion(const std::string &criterion);
   void enable_run_once();
+  void enable_discard_on_throttle();
   void disable_blocking_kernel();
 
   void add_benchmark(const std::string &name);

--- a/nvbench/state.cuh
+++ b/nvbench/state.cuh
@@ -220,13 +220,6 @@ struct state
     m_throttle_recovery_delay = throttle_recovery_delay;
   }
 
-  [[nodiscard]] bool get_discard_on_throttle() const { return m_discard_on_throttle; }
-
-  void set_discard_on_throttle(bool discard_on_throttle)
-  {
-    m_discard_on_throttle = discard_on_throttle;
-  }
-
   /// If a `KernelLauncher` syncs and `nvbench::exec_tag::sync` is not passed
   /// to `state.exec(...)`, a deadlock may occur. If a `blocking_kernel` blocks
   /// for more than `blocking_kernel_timeout` seconds, an error will be printed
@@ -340,7 +333,6 @@ private:
 
   nvbench::float32_t m_throttle_threshold;      // [% of peak SM clock rate]
   nvbench::float32_t m_throttle_recovery_delay; // [seconds]
-  bool m_discard_on_throttle{false};
 
   // Deadlock protection. See blocking_kernel's class doc for details.
   nvbench::float64_t m_blocking_kernel_timeout{30.0};

--- a/nvbench/state.cuh
+++ b/nvbench/state.cuh
@@ -338,8 +338,8 @@ private:
   nvbench::float64_t m_skip_time;
   nvbench::float64_t m_timeout;
 
-  nvbench::float32_t m_throttle_threshold{0.75f};     // [% of peak SM clock rate]
-  nvbench::float32_t m_throttle_recovery_delay{0.0f}; // [seconds]
+  nvbench::float32_t m_throttle_threshold;      // [% of peak SM clock rate]
+  nvbench::float32_t m_throttle_recovery_delay; // [seconds]
   bool m_discard_on_throttle{false};
 
   // Deadlock protection. See blocking_kernel's class doc for details.

--- a/nvbench/state.cuh
+++ b/nvbench/state.cuh
@@ -22,9 +22,9 @@
 #include <nvbench/device_info.cuh>
 #include <nvbench/exec_tag.cuh>
 #include <nvbench/named_values.cuh>
+#include <nvbench/stopping_criterion.cuh>
 #include <nvbench/summary.cuh>
 #include <nvbench/types.cuh>
-#include <nvbench/stopping_criterion.cuh>
 
 #include <functional>
 #include <optional>
@@ -136,8 +136,11 @@ struct state
 
   /// Control the stopping criterion for the measurement loop.
   /// @{
-  [[nodiscard]] const std::string& get_stopping_criterion() const { return m_stopping_criterion; }
-  void set_stopping_criterion(std::string criterion) { m_stopping_criterion = std::move(criterion); }
+  [[nodiscard]] const std::string &get_stopping_criterion() const { return m_stopping_criterion; }
+  void set_stopping_criterion(std::string criterion)
+  {
+    m_stopping_criterion = std::move(criterion);
+  }
   /// @}
 
   /// If true, the benchmark is only run once, skipping all warmup runs and only
@@ -199,6 +202,30 @@ struct state
   [[nodiscard]] nvbench::float64_t get_timeout() const { return m_timeout; }
   void set_timeout(nvbench::float64_t timeout) { m_timeout = timeout; }
   /// @}
+
+  [[nodiscard]] nvbench::float32_t get_throttle_threshold() const { return m_throttle_threshold; }
+
+  void set_throttle_threshold(nvbench::float32_t throttle_threshold)
+  {
+    m_throttle_threshold = throttle_threshold;
+  }
+
+  [[nodiscard]] nvbench::float32_t get_throttle_recovery_delay() const
+  {
+    return m_throttle_recovery_delay;
+  }
+
+  void set_throttle_recovery_delay(nvbench::float32_t throttle_recovery_delay)
+  {
+    m_throttle_recovery_delay = throttle_recovery_delay;
+  }
+
+  [[nodiscard]] bool get_discard_on_throttle() const { return m_discard_on_throttle; }
+
+  void set_discard_on_throttle(bool discard_on_throttle)
+  {
+    m_discard_on_throttle = discard_on_throttle;
+  }
 
   /// If a `KernelLauncher` syncs and `nvbench::exec_tag::sync` is not passed
   /// to `state.exec(...)`, a deadlock may occur. If a `blocking_kernel` blocks
@@ -310,6 +337,10 @@ private:
 
   nvbench::float64_t m_skip_time;
   nvbench::float64_t m_timeout;
+
+  nvbench::float32_t m_throttle_threshold{0.75f};     // [% of peak SM clock rate]
+  nvbench::float32_t m_throttle_recovery_delay{0.0f}; // [seconds]
+  bool m_discard_on_throttle{false};
 
   // Deadlock protection. See blocking_kernel's class doc for details.
   nvbench::float64_t m_blocking_kernel_timeout{30.0};

--- a/nvbench/state.cxx
+++ b/nvbench/state.cxx
@@ -15,10 +15,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-#include <nvbench/state.cuh>
-
 #include <nvbench/benchmark_base.cuh>
 #include <nvbench/detail/throw.cuh>
+#include <nvbench/state.cuh>
 #include <nvbench/types.cuh>
 
 #include <algorithm>
@@ -43,7 +42,6 @@ state::state(const benchmark_base &bench)
     , m_timeout{bench.get_timeout()}
     , m_throttle_threshold{bench.get_throttle_threshold()}
     , m_throttle_recovery_delay{bench.get_throttle_recovery_delay()}
-    , m_discard_on_throttle{bench.get_discard_on_throttle()}
 {}
 
 state::state(const benchmark_base &bench,
@@ -64,7 +62,6 @@ state::state(const benchmark_base &bench,
     , m_timeout{bench.get_timeout()}
     , m_throttle_threshold{bench.get_throttle_threshold()}
     , m_throttle_recovery_delay{bench.get_throttle_recovery_delay()}
-    , m_discard_on_throttle{bench.get_discard_on_throttle()}
 {}
 
 nvbench::int64_t state::get_int64(const std::string &axis_name) const

--- a/nvbench/state.cxx
+++ b/nvbench/state.cxx
@@ -15,19 +15,18 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 #include <nvbench/state.cuh>
 
 #include <nvbench/benchmark_base.cuh>
 #include <nvbench/detail/throw.cuh>
 #include <nvbench/types.cuh>
 
-#include <fmt/color.h>
-#include <fmt/format.h>
-
 #include <algorithm>
 #include <stdexcept>
 #include <string>
+
+#include <fmt/color.h>
+#include <fmt/format.h>
 
 namespace nvbench
 {
@@ -42,6 +41,9 @@ state::state(const benchmark_base &bench)
     , m_min_samples{bench.get_min_samples()}
     , m_skip_time{bench.get_skip_time()}
     , m_timeout{bench.get_timeout()}
+    , m_throttle_threshold{bench.get_throttle_threshold()}
+    , m_throttle_recovery_delay{bench.get_throttle_recovery_delay()}
+    , m_discard_on_throttle{bench.get_discard_on_throttle()}
 {}
 
 state::state(const benchmark_base &bench,
@@ -60,6 +62,9 @@ state::state(const benchmark_base &bench,
     , m_min_samples{bench.get_min_samples()}
     , m_skip_time{bench.get_skip_time()}
     , m_timeout{bench.get_timeout()}
+    , m_throttle_threshold{bench.get_throttle_threshold()}
+    , m_throttle_recovery_delay{bench.get_throttle_recovery_delay()}
+    , m_discard_on_throttle{bench.get_discard_on_throttle()}
 {}
 
 nvbench::int64_t state::get_int64(const std::string &axis_name) const


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/nvbench/issues/193

This PR adds a few options:
1. `--throttle-threshold 0.8` (80%) - sets percentage of peak frequency that's considered throttling. If SM frequency drops below this value, warning is issued. 
2. `--throttle-recovery-delay 5.0` - waits for 5 seconds to let GPU cool down if throttling took place. 
3. `--discard-on-throttle` - discards measurements taken while GPU was throttling. 

These end up having positive effect on the benchmarks. For `select.if` benchmark, upstream NVBench yields:

| T{ct} | OffsetT{ct} | InPlace{ct} |   Elements{io}   | Entropy | Samples | CPU Time | Noise | GPU Time | Noise |  Elem/s  | GlobalMem BW | BWUtil |
|-------|-------------|-------------|------------------|---------|---------|----------|-------|----------|-------|----------|--------------|--------|
|    I8 |         I64 |        true | 2^28 = 268435456 |   1.000 |  10000x | 1.068 ms | 5.34% | 1.056 ms | 3.22% | 254.310G | 507.628 GB/s | 52.87% |

With `--throttle-threshold 0.8 --throttle-recovery-delay 5.0 --discard-on-throttle` resulting noise twice as low and the resulting kernel perf is much higher:

| T{ct} | OffsetT{ct} | InPlace{ct} |   Elements{io}   | Entropy | Samples |  CPU Time  | Noise |  GPU Time  | Noise |  Elem/s  | GlobalMem BW | BWUtil |
|-------|-------------|-------------|------------------|---------|---------|------------|-------|------------|-------|----------|--------------|--------|
|    I8 |         I64 |        true | 2^28 = 268435456 |   1.000 |  10000x | 985.749 us | 4.85% | 972.956 us | 1.54% | 275.897G | 550.716 GB/s | 57.36% |

Further increasing the throttle threshold to 90% yields even lower noise and higher perf:

| T{ct} | OffsetT{ct} | InPlace{ct} |   Elements{io}   | Entropy | Samples |  CPU Time  | Noise |  GPU Time  | Noise |  Elem/s  | GlobalMem BW | BWUtil |
|-------|-------------|-------------|------------------|---------|---------|------------|-------|------------|-------|----------|--------------|--------|
|    I8 |         I64 |        true | 2^28 = 268435456 |   1.000 |  10000x | 965.393 us | 4.31% | 953.132 us | 1.02% | 281.635G | 562.171 GB/s | 58.55% |

The effect can be seen on underlying distributions, we get faster kernels that are not affected by throttling caused by NVBench invoking the kernel thousand times:

![distributions](https://github.com/user-attachments/assets/c3f89c4a-6c62-4d50-bacc-929d305e06db)

Comparison of frequencies and temperatures with / without throttling control:

![frequency](https://github.com/user-attachments/assets/f37e0050-2356-40a3-baf2-e19f2ddd389b)

![temperature](https://github.com/user-attachments/assets/93b8eae5-b6de-4213-b851-a05ba83ab2a0)

