### PR TITLE
Remove coverage for 11.8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ features:
 # Supported Compilers and Tools
 
 - CMake > 3.30.4
-- CUDA Toolkit + nvcc: 11.8 and above
+- CUDA Toolkit + nvcc: 12.0 and above
 - g++: 7 -> 14
 - clang++: 14 -> 19
 - Headers are tested with C++17 -> C++20.

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -38,7 +38,6 @@ llvm19: &llvm19 { name: 'llvm', version: '19', exe: 'clang++' }
 # Configurations that will run for every PR
 pull_request:
   nvcc:
-    - {cuda: *cuda_prev_max, os: 'ubuntu22.04', cpu: 'amd64', compiler: *gcc11    }
     - {cuda: *cuda_curr_min, os: 'ubuntu20.04', cpu: 'amd64', compiler: *gcc7     }
     - {cuda: *cuda_curr_min, os: 'ubuntu20.04', cpu: 'amd64', compiler: *gcc8     }
     - {cuda: *cuda_curr_min, os: 'ubuntu20.04', cpu: 'amd64', compiler: *gcc9     }


### PR DESCRIPTION
We're going to be dropping these devcontainers soon in CCCL, and they're causing issues with our pre-commit hooks.