### PR TITLE
Use the new(ish) PREFIX option of rapids-cmake version, git revision header utils.

### DIFF
--- a/cmake/NVBenchRapidsCMake.cmake
+++ b/cmake/NVBenchRapidsCMake.cmake
@@ -20,6 +20,9 @@ endmacro()
 # Called after project(...)
 macro(nvbench_init_rapids_cmake)
   rapids_cmake_build_type(Release)
-  rapids_cmake_write_version_file("${NVBench_BINARY_DIR}/nvbench/detail/version.cuh")
+  rapids_cmake_write_version_file(
+    "${NVBench_BINARY_DIR}/nvbench/detail/version.cuh"
+    PREFIX "NVBENCH"
+  )
   rapids_cpm_init()
 endmacro()

--- a/nvbench/CMakeLists.txt
+++ b/nvbench/CMakeLists.txt
@@ -139,6 +139,7 @@ endif()
 rapids_cmake_write_git_revision_file(
   nvbench_git_revision
   "${NVBench_BINARY_DIR}/nvbench/detail/git_revision.cuh"
+  PREFIX "NVBENCH"
 )
 target_link_libraries(nvbench PRIVATE nvbench_git_revision)
 

--- a/nvbench/git_revision.cuh
+++ b/nvbench/git_revision.cuh
@@ -18,12 +18,5 @@
 
 #pragma once
 
+// Include the auto-generated git revision header:
 #include <nvbench/detail/git_revision.cuh>
-
-// WAR issue rapidsai/rapids-cmake#99:
-#define NVBENCH_GIT_BRANCH NVBench_GIT_BRANCH
-#define NVBENCH_GIT_SHA1 NVBench_GIT_SHA1
-#define NVBENCH_GIT_VERSION NVBench_GIT_VERSION
-#ifdef NVBench_GIT_IS_DIRTY
-#define NVBENCH_GIT_IS_DIRTY
-#endif

--- a/nvbench/version.cuh
+++ b/nvbench/version.cuh
@@ -18,12 +18,8 @@
 
 #pragma once
 
+// Include the auto-generated version header:
 #include <nvbench/detail/version.cuh>
-
-// WAR issue rapidsai/rapids-cmake#99
-#define NVBENCH_VERSION_MAJOR NVBench_VERSION_MAJOR
-#define NVBENCH_VERSION_MINOR NVBench_VERSION_MINOR
-#define NVBENCH_VERSION_PATCH NVBench_VERSION_PATCH
 
 // clang-format off
 


### PR DESCRIPTION
Generate macros prefixed with NVBENCH instead of redefining them from NVBench.

And by "new," I mean four years old 😄