### PR TITLE
Fix throttle setter return values and update customization example

### DIFF
--- a/examples/custom_criterion.cu
+++ b/examples/custom_criterion.cu
@@ -74,4 +74,4 @@ void throughput_bench(nvbench::state &state)
       num_values);
   });
 }
-NVBENCH_BENCH(throughput_bench).set_stopping_criterion("fixed").set_throttle_threshold(0.8f);
+NVBENCH_BENCH(throughput_bench).set_stopping_criterion("fixed");

--- a/examples/custom_criterion.cu
+++ b/examples/custom_criterion.cu
@@ -74,4 +74,4 @@ void throughput_bench(nvbench::state &state)
       num_values);
   });
 }
-NVBENCH_BENCH(throughput_bench).set_stopping_criterion("fixed");
+NVBENCH_BENCH(throughput_bench).set_stopping_criterion("fixed").set_throttle_threshold(0.8f);

--- a/nvbench/benchmark_base.cuh
+++ b/nvbench/benchmark_base.cuh
@@ -249,9 +249,10 @@ struct benchmark_base
 
   [[nodiscard]] nvbench::float32_t get_throttle_threshold() const { return m_throttle_threshold; }
 
-  void set_throttle_threshold(nvbench::float32_t throttle_threshold)
+  benchmark_base &set_throttle_threshold(nvbench::float32_t throttle_threshold)
   {
     m_throttle_threshold = throttle_threshold;
+    return *this;
   }
 
   [[nodiscard]] nvbench::float32_t get_throttle_recovery_delay() const
@@ -259,9 +260,10 @@ struct benchmark_base
     return m_throttle_recovery_delay;
   }
 
-  void set_throttle_recovery_delay(nvbench::float32_t throttle_recovery_delay)
+  benchmark_base &set_throttle_recovery_delay(nvbench::float32_t throttle_recovery_delay)
   {
     m_throttle_recovery_delay = throttle_recovery_delay;
+    return *this;
   }
 
   [[nodiscard]] nvbench::criterion_params &get_criterion_params() { return m_criterion_params; }


### PR DESCRIPTION
This PR fixes a bug where the benchmark throttle setters were incorrectly returning void instead of the updated benchmark settings. It also updates the example to demonstrate how to customize the throttle threshold.