### PR TITLE
Update json and fmt projects to latest versions

### DIFF
--- a/cmake/NVBenchDependencies.cmake
+++ b/cmake/NVBenchDependencies.cmake
@@ -8,11 +8,11 @@ if(NOT BUILD_SHARED_LIBS AND NVBench_ENABLE_INSTALL_RULES)
   set(install_fmt ON)
 endif()
 
-rapids_cpm_find(fmt 11.1.4 ${export_set_details}
+rapids_cpm_find(fmt 11.2.0 ${export_set_details}
   GLOBAL_TARGETS fmt::fmt fmt::fmt-header-only
   CPM_ARGS
     GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"
-    GIT_TAG "11.1.4"
+    GIT_TAG "11.2.0"
     OPTIONS
       # Force static to keep fmt internal.
       "BUILD_SHARED_LIBS OFF"
@@ -33,10 +33,10 @@ endif()
 # Following recipe from
 # http://github.com/cpm-cmake/CPM.cmake/blob/master/examples/json/CMakeLists.txt
 # Download the zips because the repo takes an excessively long time to clone.
-rapids_cpm_find(nlohmann_json 3.11.3
+rapids_cpm_find(nlohmann_json 3.12.0
   CPM_ARGS
-    URL https://github.com/nlohmann/json/releases/download/v3.11.3/include.zip
-    URL_HASH SHA256=a22461d13119ac5c78f205d3df1db13403e58ce1bb1794edc9313677313f4a9d
+    URL https://github.com/nlohmann/json/releases/download/v3.12.0/include.zip
+    URL_HASH SHA256=b8cb0ef2dd7f57f18933997c9934bb1fa962594f701cd5a8d3c2c80541559372
   PATCH_COMMAND
     ${CMAKE_COMMAND}
       -D "CUDA_VERSION=${CMAKE_CUDA_COMPILER_VERSION}"


### PR DESCRIPTION
This PR modifies cmake scripts to update versions of `fmt` and `nlohmann_json` dependencies. 

I found that running configuration step `CUDACXX=/usr/local/cuda/bin/nvcc cmake -B build --preset=nvbench-dev`  emits deprecation warnings coming from use of `FetchContent_Populate` by CPM v0.40.0, which is pulled by `rapids-cmake` project.

I opened feature request https://github.com/rapidsai/rapids-cmake/issues/851 to update to CPM v0.42.0 .

I verified that updating to v0.42.0 resolves these warnings by executing 

```sh
rm -rf build
wget https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.42.0/CPM.cmake
CUDACXX=/usr/local/cuda/bin/nvcc cmake -B build --preset=nvbench-dev -DCPM_DOWNLOAD_LOCATION=CPM.cmake .
```