### PR TITLE
Fix obvious typo in getter for device_manager singleton docstring

### DIFF
--- a/nvbench/device_manager.cuh
+++ b/nvbench/device_manager.cuh
@@ -33,7 +33,7 @@ struct device_manager
   using device_info_vector = std::vector<nvbench::device_info>;
 
   /**
-   * @return The singleton benchmark_manager instance.
+   * @return The singleton device_manager instance.
    */
   [[nodiscard]] static device_manager &get();
 


### PR DESCRIPTION
Fixed likely copy-paste typo in docstring of `nvbench::device_manager::get`.