### PR TITLE
Set underlying type for enum class exec_tag to uint16_t

### DIFF
--- a/nvbench/exec_tag.cuh
+++ b/nvbench/exec_tag.cuh
@@ -20,13 +20,15 @@
 
 #include <nvbench/flags.cuh>
 
+#include <cuda/std/cstdint>
+
 #include <type_traits>
 
 namespace nvbench::detail
 {
 
 // See the similarly named tags in nvbench::exec_tag:: for documentation.
-enum class exec_flag
+enum class exec_flag : ::cuda::std::uint16_t
 {
   none = 0x0,
 


### PR DESCRIPTION
Set underlying type for `enum class exec_tag` to `::cuda::std::uint16_t`, rather than the 32-bit default integral type.

This change reduces size of exec_tag instance from 4 bytes to 2 bytes, it also makes it more explicit what underlying type exec_tag is using.