### PR TITLE
Fix axes metadata

### DIFF
--- a/nvbench/axes_metadata.cxx
+++ b/nvbench/axes_metadata.cxx
@@ -63,7 +63,7 @@ try
   for (std::size_t i = 0; i < names.size(); ++i)
   {
     auto &axis = *m_axes[i];
-    assert(axis.get_type() != nvbench::axis_type::type);
+    assert(axis.get_type() == nvbench::axis_type::type);
     axis.set_name(std::move(names[i]));
   }
 }


### PR DESCRIPTION
PR #192 introduced a typo that causes type axes to not work anymore. This PR fixes that.

**Before**

A benchmark defined like this:
```
NVBENCH_BENCH_TYPES(bench, NVBENCH_TYPE_AXES(precision_list))
  .set_type_axes_names({"precision"})
  .add_int64_axis("FDL", {1})
  .add_int64_axis("M", {2})
```

Would crash like this:
```$ ./build/bench
LowLatencyBench: /home/../projects/.../build/_deps/nvbench-src/nvbench/axes_metadata.cxx:66: void nvbench::axes_metadata::set_type_axes_names(std::vector<std::__cxx11::basic_string<char> >): Assertion `axis.get_type() != nvbench::axis
_type::type' failed.
```

**After**

Everything works fine again.