### PR TITLE
Do not use blocking kernel in warmup run of measure_cold

### DIFF
--- a/nvbench/detail/measure_cold.cuh
+++ b/nvbench/detail/measure_cold.cuh
@@ -135,6 +135,11 @@ struct measure_cold_base::kernel_launch_timer
       , m_disable_blocking_kernel{measure.m_disable_blocking_kernel}
   {}
 
+  explicit kernel_launch_timer(measure_cold_base &measure, bool disable_blocking_kernel)
+      : m_measure{measure}
+      , m_disable_blocking_kernel{disable_blocking_kernel}
+  {}
+
   __forceinline__ void start()
   {
     m_measure.flush_device_l2();
@@ -206,7 +211,10 @@ private:
       return;
     }
 
-    kernel_launch_timer timer(*this);
+    // disable use of blocking kernel for warm-up run
+    // see https://github.com/NVIDIA/nvbench/issues/240
+    constexpr bool disable_blocking_kernel = true;
+    kernel_launch_timer timer(*this, disable_blocking_kernel);
 
     this->launch_kernel(timer);
     this->check_skip_time(m_cuda_timer.get_duration());


### PR DESCRIPTION
Implements suggestion https://github.com/NVIDIA/nvbench/issues/240

Adding this change of top of changes in #237 fixes the deadlock reported in #240.