### PR TITLE
Include host work of benched fn in CPU time when using blocking kernel

### DIFF
--- a/nvbench/detail/measure_cold.cuh
+++ b/nvbench/detail/measure_cold.cuh
@@ -153,10 +153,9 @@ struct measure_cold_base::kernel_launch_timer
       m_measure.gpu_frequency_start();
     }
     m_measure.m_cuda_timer.start(m_measure.m_launch.get_stream());
-    if (m_disable_blocking_kernel)
-    {
-      m_measure.m_cpu_timer.start();
-    }
+    // start CPU timer irrespective of use of blocking kernel
+    // Ref: https://github.com/NVIDIA/nvbench/issues/249
+    m_measure.m_cpu_timer.start();
   }
 
   __forceinline__ void stop()
@@ -164,7 +163,6 @@ struct measure_cold_base::kernel_launch_timer
     m_measure.m_cuda_timer.stop(m_measure.m_launch.get_stream());
     if (!m_disable_blocking_kernel)
     {
-      m_measure.m_cpu_timer.start();
       m_measure.unblock_stream();
     }
     if (m_measure.m_check_throttling)


### PR DESCRIPTION
Closes gh-249

Include host activity of benched fn in CPU time when blocking kernel is used

Based on findings of https://github.com/NVIDIA/nvbench/issues/249, m_cpu_timer.start() is being called from kernel_launcher_timer.start() method.

Previously it was called from kernel_launcher_timer.stop() just before unblock_stream() call with the intention to hone in time to execute GPU work, but this excluded any host work performed by the benched function from CPU time.