### PR TITLE
Run once disables blocking kernel

### DIFF
--- a/nvbench/detail/measure_cold.cuh
+++ b/nvbench/detail/measure_cold.cuh
@@ -222,7 +222,10 @@ private:
 
   void run_trials()
   {
-    kernel_launch_timer timer(*this);
+    // do not use blocking kernel if benchmark is only run once, e.g., when profiling
+    // ref: https://github.com/NVIDIA/nvbench/issue/242
+    const bool disable_blocking_kernel = m_run_once || m_disable_blocking_kernel;
+    kernel_launch_timer timer(*this, disable_blocking_kernel);
     do
     {
       this->launch_kernel(timer);

--- a/nvbench/detail/measure_hot.cuh
+++ b/nvbench/detail/measure_hot.cuh
@@ -106,19 +106,10 @@ private:
   // measurement.
   void run_warmup()
   {
-    if (!m_disable_blocking_kernel)
-    {
-      this->block_stream();
-    }
-
     m_cuda_timer.start(m_launch.get_stream());
     this->launch_kernel();
     m_cuda_timer.stop(m_launch.get_stream());
 
-    if (!m_disable_blocking_kernel)
-    {
-      this->unblock_stream();
-    }
     this->sync_stream();
 
     this->check_skip_time(m_cuda_timer.get_duration());

--- a/nvbench/main.cuh
+++ b/nvbench/main.cuh
@@ -172,20 +172,8 @@
 namespace nvbench::detail
 {
 
-inline void set_env(const char *name, const char *value)
-{
-#ifdef _MSC_VER
-  _putenv_s(name, value);
-#else
-  setenv(name, value, 1);
-#endif
-}
-
 inline void main_initialize(int, char **)
 {
-  // See NVIDIA/NVBench#136 for CUDA_MODULE_LOADING
-  set_env("CUDA_MODULE_LOADING", "EAGER");
-
   // Initialize CUDA driver API if needed:
 #ifdef NVBENCH_HAS_CUPTI
   NVBENCH_DRIVER_API_CALL(cuInit(0));


### PR DESCRIPTION
Per #240 and #242, the first launcher run should not use blocking kernel to avoid possibility of a deadlock caused by module loading.

For normal runs, the first call is the warm-up call. The #241 disabled use of blocking-kernel is warm-up call of measure_cold. This PR disables its used in warm-up call of measure_hot as well (although it appears that measure hot is always run after measure cold, and it is not run at all when ``--run-once`` or ``--profile`` is used).

For single runs, i.e., when `--run-once` or `--profile` CLI arguments are specified, the warm-up call is not made, and this PR makes the change for measure_cold::run_trials to override value of `m_disable_blocking_kernel` and use values `m_run_onces || m_disable_block_kernel` when deciding whether to use blocking kernel.

This fixes the remaining issues noted in #240.

Also this change allows to forgo setting of `CUDA_MODULE_LOADING=EAGER` in "nvbench/main.cuh". The axes example, noted as needing the variable in #136, no longer deadlocks.

