### PR TITLE
Fix typo: updaring->updating

### DIFF
--- a/nvbench/stopping_criterion.cuh
+++ b/nvbench/stopping_criterion.cuh
@@ -111,7 +111,7 @@ public:
 
 protected:
   /**
-   * Initialize the criterion after updaring the parameters
+   * Initialize the criterion after updating the parameters
    */
   virtual void do_initialize() = 0;
 


### PR DESCRIPTION
Fix for a typo in code comment in `"nvbench/stopping_criterion.cuh"`: "after updaring" -> "after updating".