### PR TITLE
nvbench::state::set_stopping_criterion now also sets criterion params

### DIFF
--- a/nvbench/state.cuh
+++ b/nvbench/state.cuh
@@ -151,10 +151,7 @@ struct state
   /// Control the stopping criterion for the measurement loop.
   /// @{
   [[nodiscard]] const std::string &get_stopping_criterion() const { return m_stopping_criterion; }
-  void set_stopping_criterion(std::string criterion)
-  {
-    m_stopping_criterion = std::move(criterion);
-  }
+  void set_stopping_criterion(std::string criterion);
   /// @}
 
   /// If true, the benchmark is only run once, skipping all warmup runs and only

--- a/nvbench/state.cxx
+++ b/nvbench/state.cxx
@@ -16,6 +16,7 @@
  *  limitations under the License.
  */
 #include <nvbench/benchmark_base.cuh>
+#include <nvbench/criterion_manager.cuh>
 #include <nvbench/detail/throw.cuh>
 #include <nvbench/state.cuh>
 #include <nvbench/types.cuh>
@@ -298,6 +299,12 @@ void state::add_buffer_size(std::size_t num_bytes,
   {
     summ.set_string("description", std::move(description));
   }
+}
+
+void state::set_stopping_criterion(std::string criterion)
+{
+  m_stopping_criterion = std::move(criterion);
+  m_criterion_params   = criterion_manager::get().get_criterion(m_stopping_criterion).get_params();
 }
 
 } // namespace nvbench


### PR DESCRIPTION
Closes #255

This change closes gh-255 by aligning the implementation of ``nvbench::state::set_stopping_criterion`` with that of
``nvbench::benchmark_base::set_stopping_criterion``.