### PR TITLE
Suppress cmplr flag check diagn. msgs if NVBench used a dependency

### DIFF
--- a/cmake/NVBenchConfigTarget.cmake
+++ b/cmake/NVBenchConfigTarget.cmake
@@ -23,6 +23,9 @@ set_target_properties(nvbench.build_interface PROPERTIES
 
 function(nvbench_add_cxx_flag target_name type flag)
   string(MAKE_C_IDENTIFIER "NVBench_CXX_FLAG_${flag}" var)
+  if (NOT ${NVBench_TOPLEVEL_PROJECT})
+    set(CMAKE_REQUIRED_QUIET ON)
+  endif()
   check_cxx_compiler_flag(${flag} ${var})
 
   if (${${var}})

--- a/cmake/NVBenchConfigTarget.cmake
+++ b/cmake/NVBenchConfigTarget.cmake
@@ -23,7 +23,7 @@ set_target_properties(nvbench.build_interface PROPERTIES
 
 function(nvbench_add_cxx_flag target_name type flag)
   string(MAKE_C_IDENTIFIER "NVBench_CXX_FLAG_${flag}" var)
-  if (NOT ${NVBench_TOPLEVEL_PROJECT})
+  if (NOT NVBench_TOPLEVEL_PROJECT)
     set(CMAKE_REQUIRED_QUIET ON)
   endif()
   check_cxx_compiler_flag(${flag} ${var})


### PR DESCRIPTION
Closes #235

Suppress compiler flag check diagnostic messages if NVBench is used as a dependency.

When NVBench is used as a dependency, e.g., via `CPMAddPackage`, suppress diagnostic messages emitted by `check_cxx_compiler_flags` per #235