### PR TITLE
remove pynvjitlink references in examples

### DIFF
--- a/python/examples/cccl_cooperative_block_reduce.py
+++ b/python/examples/cccl_cooperative_block_reduce.py
@@ -21,7 +21,6 @@ import cuda.cccl.cooperative.experimental as coop
 import numba
 import numpy as np
 from numba import cuda
-from pynvjitlink import patch
 
 
 class BitsetRing:
@@ -90,8 +89,6 @@ def multi_block_bench(state: bench.State):
 
 
 if __name__ == "__main__":
-    patch.patch_numba_linker(lto=True)
-
     b = bench.register(multi_block_bench)
     b.add_int64_axis("ThreadsPerBlock", [64, 128, 192, 256])
     b.add_int64_power_of_two_axis("NumBlocks", [10, 11, 12, 14, 16])


### PR DESCRIPTION
Towards https://github.com/rapidsai/build-planning/issues/210

Based on the information from [this comment on the pynvjitlink repo](https://github.com/rapidsai/pynvjitlink/pull/129#issuecomment-3004822494) and this [section of the numba-cuda docs](https://nvidia.github.io/numba-cuda/reference/kernel.html#kernel-declaration), it looks like both the linker and LTO are already configured as desired in the newer `numba-cuda` versions. 

So it should be fine to just remove the references to `pynvjitlink` without altering anything else