### PR TITLE
Diff device sections on mismatch in nvbench_compare.py

### DIFF
--- a/scripts/nvbench_compare.py
+++ b/scripts/nvbench_compare.py
@@ -5,6 +5,7 @@ import math
 import os
 import sys
 
+import jsondiff
 import tabulate
 from colorama import Fore
 from nvbench_json import reader
@@ -371,9 +372,13 @@ def main():
         global all_devices
         all_devices = cmp_root["devices"]
 
-        # This is blunt but works for now:
         if ref_root["devices"] != cmp_root["devices"]:
             print("Device sections do not match.")
+            print(
+                jsondiff.diff(
+                    ref_root["devices"], cmp_root["devices"], syntax="symmetric"
+                )
+            )
             sys.exit(1)
 
         compare_benches(


### PR DESCRIPTION
For the device sections
```
[{'id': 0, 'name': 'NVIDIA H100 NVL', 'sm_version': 900, 'ptx_version': 750, 'sm_default_clock_rate': 1785000000, 'number_of_sms': 132, 'max_blocks_per_sm': 32, 'max_threads_per_sm': 2048, 'max_threads_per_block': 1024, 'registers_per_sm': 65536, 'registers_per_block': 65536, 'global_memory_size': 99949805568, 'global_memory_bus_peak_clock_rate': 2619000000, 'global_memory_bus_width': 6016, 'global_memory_bus_bandwidth': 3938976000000, 'l2_cache_size': 62914560, 'shared_memory_per_sm': 233472, 'shared_memory_per_block': 49152, 'ecc_state': True}]
```
and
```
[{'id': 0, 'name': 'NVIDIA H100 NVL', 'sm_version': 900, 'ptx_version': 900, 'sm_default_clock_rate': 1785000000, 'number_of_sms': 132, 'max_blocks_per_sm': 32, 'max_threads_per_sm': 2048, 'max_threads_per_block': 1024, 'registers_per_sm': 65536, 'registers_per_block': 65536, 'global_memory_size': 99949805568, 'global_memory_bus_peak_clock_rate': 2619000000, 'global_memory_bus_width': 6016, 'global_memory_bus_bandwidth': 3938976000000, 'l2_cache_size': 62914560, 'shared_memory_per_sm': 233472, 'shared_memory_per_block': 49152, 'ecc_state': True}]
```
would print:
```
Device sections do not match.
{0: {'ptx_version': [750, 900]}}
```