### PR TITLE
Replace direct calls to CUDA drver with calls to cuda::__driver

### DIFF
--- a/nvbench/device_info.cu
+++ b/nvbench/device_info.cu
@@ -23,6 +23,9 @@
 #include <nvbench/internal/nvml.cuh>
 
 #include <cuda_runtime_api.h>
+#ifdef NVBENCH_HAS_CUPTI
+#include <cuda/__driver/driver_api.h>
+#endif
 
 #define UNUSED(x) (void)(x)
 
@@ -165,9 +168,7 @@ catch (nvml::call_failed &e)
     NVBENCH_THROW(std::runtime_error, "{}", "get_context is called for inactive device");
   }
 
-  CUcontext cu_context;
-  NVBENCH_DRIVER_API_CALL(cuCtxGetCurrent(&cu_context));
-  return cu_context;
+  return cuda::__driver::__ctxGetCurrent();
 }
 #endif
 

--- a/nvbench/main.cuh
+++ b/nvbench/main.cuh
@@ -25,6 +25,10 @@
 #include <nvbench/option_parser.cuh>
 #include <nvbench/printer_base.cuh>
 
+#ifdef NVBENCH_HAS_CUPTI
+#include <cuda/__driver/driver_api.h>
+#endif
+
 #include <cstdlib>
 #include <iostream>
 
@@ -175,7 +179,8 @@ inline void main_initialize(int, char **)
 {
   // Initialize CUDA driver API if needed:
 #ifdef NVBENCH_HAS_CUPTI
-  NVBENCH_DRIVER_API_CALL(cuInit(0));
+  static auto __get_proc_addr_fn      = ::cuda::__driver::__getProcAddressFn();
+  [[maybe_unused]] static auto __init = ::cuda::__driver::__init(__get_proc_addr_fn);
 #endif
 
   // Initialize the benchmarks *after* setting up the CUDA environment:


### PR DESCRIPTION
Closes #292

This PR replaces direct calls to CUDA driver API (made only if compiled with CUPTI support) with calls to `cuda::__driver` functions.  The `cuCtxGetCurrent(&ctx);` is replaced with `ctx = cuda::__driver::__ctxGetCurrent();`.

The `cuInit(0)` was replaced with a call to `cuda::__driver::__init`.