### PR TITLE
Add 89-real to list of architectures built for cuda-bench

### DIFF
--- a/ci/build_cuda_bench_wheel_for_cuda.sh
+++ b/ci/build_cuda_bench_wheel_for_cuda.sh
@@ -34,13 +34,13 @@ if [[ -z "${CUDAARCHS:-}" ]]; then
   }
 
   if version_ge "${cuda_version}" "13.0"; then
-    CUDAARCHS="75-real;80-real;86-real;90a-real;100f-real;120a-real;120-virtual"
+    CUDAARCHS="75-real;80-real;86-real;89-real;90a-real;100f-real;120a-real;120-virtual"
   elif version_ge "${cuda_version}" "12.9"; then
-    CUDAARCHS="70-real;75-real;80-real;86-real;90a-real;100f-real;120a-real;120-virtual"
+    CUDAARCHS="70-real;75-real;80-real;86-real;89-real;90a-real;100f-real;120a-real;120-virtual"
   else
-    CUDAARCHS="70-real;75-real;80-real;86-real;90a-real;90-virtual"
+    CUDAARCHS="70-real;75-real;80-real;86-real;89-real;90a-real;90-virtual"
     if version_ge "${cuda_version}" "12.8"; then
-      CUDAARCHS="70-real;75-real;80-real;86-real;90a-real;100-real;120a-real;120-virtual"
+      CUDAARCHS="70-real;75-real;80-real;86-real;89-real;90a-real;100-real;120a-real;120-virtual"
     fi
   fi
 fi


### PR DESCRIPTION
When building python wheels, we mistakenly left out compiling for `sm_89`. This PR adds this to the compilation script.