### PR TITLE
Extend `nvbench_compare.py` with `--plot`, axis/benchmark filtering, and dark mode

### DIFF
--- a/python/scripts/nvbench_compare.py
+++ b/python/scripts/nvbench_compare.py
@@ -79,6 +79,12 @@ def format_axis_value(axis_name, axis_value, axes):
         return format_string_axis_value(axis_name, axis_value, axes)
 
 
+def make_display(name: str, display_values: [list[str]]) -> str:
+    open_bracket, close_bracket = ("[", "]") if len(display_values) > 1 else ("", "")
+    display_values = ",".join(display_values)
+    return f"{name}={open_bracket}{display_values}{close_bracket}"
+
+
 def parse_axis_filters(axis_args):
     filters = []
     for axis_arg in axis_args:
@@ -91,7 +97,6 @@ def parse_axis_filters(axis_args):
             raise ValueError("Axis filter must be NAME=VALUE: {}".format(axis_arg))
 
         values = []
-        display_values = []
         if value.startswith("[") and value.endswith("]"):
             inner = value[1:-1].strip()
             values = [
@@ -121,10 +126,7 @@ def parse_axis_filters(axis_args):
                 "Axis filter must specify at least one value: {}".format(axis_arg)
             )
 
-        if len(display_values) == 1:
-            display = "{}={}".format(name, display_values[0])
-        else:
-            display = "{}=[{}]".format(name, ",".join(display_values))
+        display = make_display(name, display_values)
         filters.append(
             {
                 "name": name,


### PR DESCRIPTION
Builds on top of #314. Entirely vibe-coded as well.

Example comparing with axis filter:
```
python python/scripts/nvbench_compare.py -a T{ct}=[F32,F16] -a Elements{io}[pow2]=28 --plot ./pytorch_ublkcpy_B200.json ./pytorch_unroll_2_bif_100.json --dark
```
<img width="1276" height="804" alt="image" src="https://github.com/user-attachments/assets/abb6263c-f9e4-48eb-b188-f8513440fbb9" />

With threshold diff and no dark mode:
```
python python/scripts/nvbench_compare.py -a T{ct}=[F32,F16] -a Elements{io}[pow2]=28 --plot --threshold-diff 0.1 ./pytorch_ublkcpy_B200.json ./pytorch_unroll_2_bif_100.json 
```
<img width="980" height="431" alt="image" src="https://github.com/user-attachments/assets/5e7164da-0780-4f01-97e8-2f798a9cbdc1" />

No filters:
```
python python/scripts/nvbench_compare.py --plot ./pytorch_ublkcpy_B200.json ./pytorch_unroll_2_bif_100.json 
```
<img width="2584" height="1325" alt="image" src="https://github.com/user-attachments/assets/81a41a21-f65c-4661-b319-1ee1ef2c00c2" />


