### PR TITLE
Add `--no-color` flag to nvbench_compare.py which can be use for github issues and PRs

### DIFF
--- a/python/scripts/nvbench_compare.py
+++ b/python/scripts/nvbench_compare.py
@@ -285,7 +285,7 @@ def compare_benches(
     dark,
     axis_filters,
     benchmark_filters,
-    markdown=False,
+    no_color,
 ):
     if plot_along:
         import matplotlib.pyplot as plt
@@ -453,28 +453,28 @@ def compare_benches(
                 if not min_noise:
                     unknown_count += 1
                     status_label = "????"
-                    if markdown:
+                    if no_color:
                         status = f"\U0001f7e1 {status_label}"
                     else:
                         status = f"{Fore.YELLOW}{status_label}{Fore.RESET}"
                 elif abs(frac_diff) <= min_noise:
                     pass_count += 1
                     status_label = "SAME"
-                    if markdown:
+                    if no_color:
                         status = f"\U0001f535 {status_label}"
                     else:
                         status = f"{Fore.BLUE}{status_label}{Fore.RESET}"
                 elif diff < 0:
                     failure_count += 1
                     status_label = "FAST"
-                    if markdown:
+                    if no_color:
                         status = f"\U0001f7e2 {status_label}"
                     else:
                         status = f"{Fore.GREEN}{status_label}{Fore.RESET}"
                 else:
                     failure_count += 1
                     status_label = "SLOW"
-                    if markdown:
+                    if no_color:
                         status = f"\U0001f534 {status_label}"
                     else:
                         status = f"{Fore.RED}{status_label}{Fore.RESET}"
@@ -608,9 +608,8 @@ def main():
         help="Use dark theme (black background, white text)",
     )
     parser.add_argument(
-        "--markdown",
-        dest="markdown",
-        default=False,
+        "--no-color",
+        dest="no_color",
         action="store_true",
         help="Use emoji instead of ANSI color codes (useful for GitHub issues/PRs)",
     )
@@ -670,7 +669,7 @@ def main():
         all_cmp_devices = cmp_root["devices"]
 
         if ref_root["devices"] != cmp_root["devices"]:
-            if args.markdown:
+            if args.no_color:
                 print("Device sections do not match:")
             else:
                 print(
@@ -695,7 +694,7 @@ def main():
             args.dark,
             axis_filters,
             args.benchmark,
-            markdown=args.markdown,
+            args.no_color,
         )
 
     print("# Summary\n")

--- a/python/scripts/nvbench_compare.py
+++ b/python/scripts/nvbench_compare.py
@@ -285,6 +285,7 @@ def compare_benches(
     dark,
     axis_filters,
     benchmark_filters,
+    markdown=False,
 ):
     if plot_along:
         import matplotlib.pyplot as plt
@@ -452,19 +453,31 @@ def compare_benches(
                 if not min_noise:
                     unknown_count += 1
                     status_label = "????"
-                    status = Fore.YELLOW + status_label + Fore.RESET
+                    if markdown:
+                        status = f"\U0001f7e1 {status_label}"
+                    else:
+                        status = f"{Fore.YELLOW}{status_label}{Fore.RESET}"
                 elif abs(frac_diff) <= min_noise:
                     pass_count += 1
                     status_label = "SAME"
-                    status = Fore.BLUE + status_label + Fore.RESET
+                    if markdown:
+                        status = f"\U0001f535 {status_label}"
+                    else:
+                        status = f"{Fore.BLUE}{status_label}{Fore.RESET}"
                 elif diff < 0:
                     failure_count += 1
                     status_label = "FAST"
-                    status = Fore.GREEN + status_label + Fore.RESET
+                    if markdown:
+                        status = f"\U0001f7e2 {status_label}"
+                    else:
+                        status = f"{Fore.GREEN}{status_label}{Fore.RESET}"
                 else:
                     failure_count += 1
                     status_label = "SLOW"
-                    status = Fore.RED + status_label + Fore.RESET
+                    if markdown:
+                        status = f"\U0001f534 {status_label}"
+                    else:
+                        status = f"{Fore.RED}{status_label}{Fore.RESET}"
 
                 if abs(frac_diff) >= threshold:
                     row.append(format_duration(ref_time))
@@ -595,6 +608,13 @@ def main():
         help="Use dark theme (black background, white text)",
     )
     parser.add_argument(
+        "--markdown",
+        dest="markdown",
+        default=False,
+        action="store_true",
+        help="Use emoji instead of ANSI color codes (useful for GitHub issues/PRs)",
+    )
+    parser.add_argument(
         "-a",
         "--axis",
         action="append",
@@ -650,11 +670,14 @@ def main():
         all_cmp_devices = cmp_root["devices"]
 
         if ref_root["devices"] != cmp_root["devices"]:
-            print(
-                (Fore.YELLOW if args.ignore_devices else Fore.RED)
-                + "Device sections do not match:"
-                + Fore.RESET
-            )
+            if args.markdown:
+                print("Device sections do not match:")
+            else:
+                print(
+                    (Fore.YELLOW if args.ignore_devices else Fore.RED)
+                    + "Device sections do not match:"
+                    + Fore.RESET
+                )
             print(
                 jsondiff.diff(
                     ref_root["devices"], cmp_root["devices"], syntax="symmetric"
@@ -672,6 +695,7 @@ def main():
             args.dark,
             axis_filters,
             args.benchmark,
+            markdown=args.markdown,
         )
 
     print("# Summary\n")


### PR DESCRIPTION
Update: renamed the flag to `--no-color`

The status column in the markdown table generated by `nvbench_compare.py` currently color codes the output (e.g., green for FAST). This does not get formatted well in github issues and PRs. For example, in a recent CCCL benchmakr CI run (https://github.com/NVIDIA/cccl/actions/runs/23866054665, scroll down and expand either the CUB or Python comparison reports), the output appears as �[34mSAME�[39m

This PR adds a flag which color codes the status column using an emoji:

|   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|------------|-------------|------------|-------------|-----------|---------|----------|
|   1.003 ms |       0.06% |   1.003 ms |       0.05% | -0.071 us |  -0.01% | 🔵 SAME  |
|   1.003 ms |       0.03% |   1.003 ms |       0.03% |  0.049 us |   0.00% | 🔵 SAME  |