### PR TITLE
Correct description/hint entries for summaries with name "Noise"

### DIFF
--- a/nvbench/detail/measure_cold.cu
+++ b/nvbench/detail/measure_cold.cu
@@ -245,7 +245,7 @@ void measure_cold_base::generate_summaries()
   {
     auto &summ = m_state.add_summary("nv/cold/time/cpu/stdev/absolute");
     summ.set_string("name", "Noise");
-    summ.set_string("hint", "percentage");
+    summ.set_string("hint", "duration");
     summ.set_string("description", "Standard deviation of isolated CPU times");
     summ.set_float64("value", cpu_stdev);
     summ.set_string("hide", "Hidden by default.");
@@ -299,8 +299,8 @@ void measure_cold_base::generate_summaries()
   {
     auto &summ = m_state.add_summary("nv/cold/time/gpu/stdev/absolute");
     summ.set_string("name", "Noise");
-    summ.set_string("hint", "percentage");
-    summ.set_string("description", "Relative standard deviation of isolated GPU times");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "Standard deviation of isolated GPU times");
     summ.set_float64("value", cuda_stdev);
     summ.set_string("hide", "Hidden by default.");
   }

--- a/nvbench/detail/measure_cpu_only.cxx
+++ b/nvbench/detail/measure_cpu_only.cxx
@@ -158,8 +158,8 @@ void measure_cpu_only_base::generate_summaries()
   {
     auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/stdev/absolute");
     summ.set_string("name", "Noise");
-    summ.set_string("hint", "percentage");
-    summ.set_string("description", "Relative standard deviation of isolated CPU times");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "Standard deviation of isolated CPU times");
     summ.set_float64("value", cpu_stdev);
     summ.set_string("hide", "Hidden by default.");
   }


### PR DESCRIPTION
Closes #334

Corrected description associated with summaries recording raw values of standard deviation of run-times.

`'hint'` record is changed from `'percentage'` to `'duration'` so that when absolute deviation record is displayed, it would have units printed next to it.