### PR TITLE
Create directories for output files

### DIFF
--- a/nvbench/json_printer.cu
+++ b/nvbench/json_printer.cu
@@ -49,7 +49,7 @@ namespace fs = std::filesystem;
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
 #else
-static_assert(false, "No <filesystem> or <experimental/filesystem> found.");
+#error "No <filesystem> or <experimental/filesystem> found."
 #endif
 
 #if NVBENCH_CPP_DIALECT >= 2020

--- a/nvbench/option_parser.cu
+++ b/nvbench/option_parser.cu
@@ -135,22 +135,7 @@ void create_output_parent_directories(const std::string &spec)
     return;
   }
 
-  std::error_code ec;
-  fs::create_directories(parent_path, ec);
-  if (ec)
-  {
-    NVBENCH_THROW(std::runtime_error,
-                  "Failed to create output directory `{}`: {}",
-                  parent_path.string(),
-                  ec.message());
-  }
-
-  if (!fs::is_directory(parent_path, ec) || ec)
-  {
-    NVBENCH_THROW(std::runtime_error,
-                  "Output path parent `{}` is not a directory.",
-                  parent_path.string());
-  }
+  fs::create_directories(parent_path);
 }
 
 // Parses a list of values "<val1>, <val2>, <val3>, ..." into a vector:

--- a/nvbench/option_parser.cu
+++ b/nvbench/option_parser.cu
@@ -59,7 +59,7 @@ namespace fs = std::filesystem;
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
 #else
-static_assert(false, "No <filesystem> or <experimental/filesystem> found.");
+#error "No <filesystem> or <experimental/filesystem> found."
 #endif
 
 namespace

--- a/nvbench/option_parser.cu
+++ b/nvbench/option_parser.cu
@@ -48,8 +48,19 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <tuple>
 #include <vector>
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+static_assert(false, "No <filesystem> or <experimental/filesystem> found.");
+#endif
 
 namespace
 {
@@ -114,6 +125,33 @@ catch (const std::exception &)
 }
 
 void parse(std::string_view input, std::string &val) { val = input; }
+
+void create_output_parent_directories(const std::string &spec)
+{
+  const fs::path output_path{spec};
+  const fs::path parent_path = output_path.parent_path();
+  if (parent_path.empty())
+  {
+    return;
+  }
+
+  std::error_code ec;
+  fs::create_directories(parent_path, ec);
+  if (ec)
+  {
+    NVBENCH_THROW(std::runtime_error,
+                  "Failed to create output directory `{}`: {}",
+                  parent_path.string(),
+                  ec.message());
+  }
+
+  if (!fs::is_directory(parent_path, ec) || ec)
+  {
+    NVBENCH_THROW(std::runtime_error,
+                  "Output path parent `{}` is not a directory.",
+                  parent_path.string());
+  }
+}
 
 // Parses a list of values "<val1>, <val2>, <val3>, ..." into a vector:
 template <typename T>
@@ -622,6 +660,8 @@ std::ostream &option_parser::printer_spec_to_ostream(const std::string &spec)
   }
   else // spec is a filename:
   {
+    ::create_output_parent_directories(spec);
+
     auto file_stream = std::make_unique<std::ofstream>();
     // Throw if file can't open
     file_stream->exceptions(file_stream->exceptions() | std::ios::failbit);

--- a/testing/option_parser.cu
+++ b/testing/option_parser.cu
@@ -22,6 +22,21 @@
 
 #include <fmt/format.h>
 
+#include <chrono>
+#include <iostream>
+#include <stdexcept>
+#include <system_error>
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+static_assert(false, "No <filesystem> or <experimental/filesystem> found.");
+#endif
+
 #include "test_asserts.cuh"
 
 //==============================================================================
@@ -48,6 +63,40 @@ NVBENCH_BENCH_TYPES(TestBench, NVBENCH_TYPE_AXES(Ts, Us))
 
 namespace
 {
+
+struct temp_tree
+{
+  explicit temp_tree(fs::path root)
+      : root_path{std::move(root)}
+  {
+    std::error_code ec;
+    fs::remove_all(root_path, ec);
+    if (ec)
+    {
+      throw std::runtime_error{fmt::format("Failed to remove temporary directory `{}`: {}",
+                                           root_path.string(),
+                                           ec.message())};
+    }
+  }
+
+  ~temp_tree()
+  {
+    std::error_code ec;
+    fs::remove_all(root_path, ec);
+    if (ec)
+    {
+      std::cerr << "Failed to remove temporary directory `" << root_path.string()
+                << "`: " << ec.message() << "\n";
+    }
+  }
+
+  temp_tree(const temp_tree &)            = delete;
+  temp_tree(temp_tree &&)                 = delete;
+  temp_tree &operator=(const temp_tree &) = delete;
+  temp_tree &operator=(temp_tree &&)      = delete;
+
+  fs::path root_path;
+};
 
 [[nodiscard]] std::string states_to_string(const std::vector<nvbench::state> &states)
 {
@@ -1175,6 +1224,22 @@ void test_timeout()
   ASSERT(std::abs(states[0].get_timeout() - 12345e2) < 1.);
 }
 
+void test_output_parent_directories_created()
+{
+  const auto unique_suffix = std::chrono::steady_clock::now().time_since_epoch().count();
+  const temp_tree temp{fs::temp_directory_path() /
+                       fmt::format("nvbench_option_parser_test_{}", unique_suffix)};
+  const auto output_path = temp.root_path / "nested" / "results.json";
+
+  {
+    nvbench::option_parser parser;
+    parser.parse({"--json", output_path.string()});
+  }
+
+  ASSERT(fs::is_directory(output_path.parent_path()));
+  ASSERT(fs::exists(output_path));
+}
+
 void test_stopping_criterion()
 {
   { // Per benchmark criterion
@@ -1468,6 +1533,7 @@ try
   test_min_samples();
   test_skip_time();
   test_timeout();
+  test_output_parent_directories_created();
 
   test_stopping_criterion();
 

--- a/testing/option_parser.cu
+++ b/testing/option_parser.cu
@@ -34,7 +34,7 @@ namespace fs = std::filesystem;
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
 #else
-static_assert(false, "No <filesystem> or <experimental/filesystem> found.");
+#error "No <filesystem> or <experimental/filesystem> found."
 #endif
 
 #include "test_asserts.cuh"


### PR DESCRIPTION
Closes #185 

Now, specifying `--json /tmp/nested/json/axes.json` where `/tmp/nested` does not exist, creates subdirectories and places output files there.

```
(py313) :~/repos/nvbench$ rm -rf /tmp/nested/

(py313) :~/repos/nvbench$ ./build2/bin/nvbench.example.cpp20.axes \
    -b copy_type_and_block_size_sweep -a Type=I32 -a BlockSize=64 \
    --jsonbin /tmp/nested/json/axes.json                          \
    --md /tmp/nested/md/res.md                                    \
    --csv /tmp/nested/csv/res.csv > /dev/null 2>&1

(py313) :~/repos/nvbench$ tree /tmp/nested/
/tmp/nested/
├── csv
│   └── res.csv
├── json
│   ├── axes.json
│   ├── axes.json-bin
│   │   └── 0.bin
│   └── axes.json-freqs-bin
│       └── 0.bin
└── md
    └── res.md

6 directories, 5 files
```