### PR TITLE
Implement Timer, and support State.exec(fn, timer=True)

### DIFF
--- a/python/cuda/bench/__init__.py
+++ b/python/cuda/bench/__init__.py
@@ -42,6 +42,7 @@ _NVBENCH_EXPORTS = (
     "Launch",
     "NVBenchRuntimeError",
     "State",
+    "Timer",
     "run_all_benchmarks",
 )
 

--- a/python/cuda/bench/__init__.pyi
+++ b/python/cuda/bench/__init__.pyi
@@ -129,6 +129,7 @@ class State:
         /,
         *,
         timer: Literal[True],
+        batched: Literal[False],
         sync: Optional[bool] = False,
     ) -> None: ...
     def get_short_description(self) -> str: ...

--- a/python/cuda/bench/__init__.pyi
+++ b/python/cuda/bench/__init__.pyi
@@ -119,7 +119,7 @@ class State:
         /,
         *,
         batched: Optional[bool] = None,
-        sync: Optional[bool] = False,
+        sync: bool = False,
         timer: Literal[False] = False,
     ) -> None: ...
     @overload
@@ -130,7 +130,7 @@ class State:
         *,
         timer: Literal[True],
         batched: Literal[False] | None = None,
-        sync: Optional[bool] = False,
+        sync: bool = False,
     ) -> None: ...
     def get_short_description(self) -> str: ...
     def add_summary(

--- a/python/cuda/bench/__init__.pyi
+++ b/python/cuda/bench/__init__.pyi
@@ -118,7 +118,7 @@ class State:
         fn: Callable[[Launch], None],
         /,
         *,
-        batched: Optional[bool] = True,
+        batched: Optional[bool] = None,
         sync: Optional[bool] = False,
         timer: Literal[False] = False,
     ) -> None: ...
@@ -129,7 +129,7 @@ class State:
         /,
         *,
         timer: Literal[True],
-        batched: Literal[False],
+        batched: Literal[False] | None = None,
         sync: Optional[bool] = False,
     ) -> None: ...
     def get_short_description(self) -> str: ...

--- a/python/cuda/bench/__init__.pyi
+++ b/python/cuda/bench/__init__.pyi
@@ -28,6 +28,7 @@
 from collections.abc import Callable, Sequence
 from typing import (
     Any,
+    Literal,
     Optional,
     Self,
     SupportsFloat,
@@ -66,6 +67,10 @@ class Benchmark:
 
 class Launch:
     def get_stream(self) -> CudaStream: ...
+
+class Timer:
+    def start(self) -> None: ...
+    def stop(self) -> None: ...
 
 class State:
     def has_device(self) -> bool: ...
@@ -107,6 +112,7 @@ class State:
     def set_timeout(self, duration: SupportsFloat) -> None: ...
     def get_blocking_kernel_timeout(self) -> float: ...
     def set_blocking_kernel_timeout(self, duration: SupportsFloat) -> None: ...
+    @overload
     def exec(
         self,
         fn: Callable[[Launch], None],
@@ -114,7 +120,17 @@ class State:
         *,
         batched: Optional[bool] = True,
         sync: Optional[bool] = False,
-    ): ...
+        timer: Literal[False] = False,
+    ) -> None: ...
+    @overload
+    def exec(
+        self,
+        fn: Callable[[Launch, Timer], None],
+        /,
+        *,
+        timer: Literal[True],
+        sync: Optional[bool] = False,
+    ) -> None: ...
     def get_short_description(self) -> str: ...
     def add_summary(
         self, column_name: str, value: Union[SupportsInt, SupportsFloat, str]

--- a/python/examples/axes.py
+++ b/python/examples/axes.py
@@ -35,7 +35,7 @@ def make_sleep_kernel():
 
 // Each launched thread just sleeps for `seconds`.
 __global__ void sleep_kernel(double seconds) {
-  namespace chrono = ::cuda::std::chrono;
+  namespace chrono = cuda::std::chrono;
   using hr_clock = chrono::high_resolution_clock;
 
   auto duration = static_cast<cuda::std::int64_t>(seconds * 1e9);
@@ -101,7 +101,7 @@ def make_copy_kernel(in_type: Optional[str] = None, out_type: Optional[str] = No
  * Naive copy of `n` values from `in` -> `out`.
  */
 template <typename T, typename U>
-__global__ void copy_kernel(const T *in, U *out, ::cuda::std::size_t n)
+__global__ void copy_kernel(const T *in, U *out, cuda::std::size_t n)
 {
   const auto init = blockIdx.x * blockDim.x + threadIdx.x;
   const auto step = blockDim.x * gridDim.x;
@@ -116,9 +116,9 @@ __global__ void copy_kernel(const T *in, U *out, ::cuda::std::size_t n)
     opts = core.ProgramOptions(include_path=str(incl.libcudacxx))
     prog = core.Program(src, code_type="c++", options=opts)
     if in_type is None:
-        in_type = "::cuda::std::int32_t"
+        in_type = "cuda::std::int32_t"
     if out_type is None:
-        out_type = "::cuda::std::int32_t"
+        out_type = "cuda::std::int32_t"
     instance_name = f"copy_kernel<{in_type}, {out_type}>"
     mod = prog.compile("cubin", name_expressions=(instance_name,))
     return mod.get_kernel(instance_name)

--- a/python/examples/cpu_activity.py
+++ b/python/examples/cpu_activity.py
@@ -45,7 +45,7 @@ def make_sleep_kernel():
 
 // Each launched thread just sleeps for `seconds`.
 __global__ void sleep_kernel(double seconds) {
-  namespace chrono = ::cuda::std::chrono;
+  namespace chrono = cuda::std::chrono;
   using hr_clock = chrono::high_resolution_clock;
 
   auto duration = static_cast<cuda::std::int64_t>(seconds * 1e9);

--- a/python/examples/exec_tag_sync.py
+++ b/python/examples/exec_tag_sync.py
@@ -36,7 +36,7 @@ def make_fill_kernel(data_type: Optional[str] = None):
  * Naive setting of values in buffer
  */
 template <typename T>
-__global__ void fill_kernel(T *buf, T v, ::cuda::std::size_t n)
+__global__ void fill_kernel(T *buf, T v, cuda::std::size_t n)
 {
   const auto init = blockIdx.x * blockDim.x + threadIdx.x;
   const auto step = blockDim.x * gridDim.x;
@@ -51,7 +51,7 @@ __global__ void fill_kernel(T *buf, T v, ::cuda::std::size_t n)
     opts = core.ProgramOptions(include_path=str(incl.libcudacxx))
     prog = core.Program(src, code_type="c++", options=opts)
     if data_type is None:
-        data_type = "::cuda::std::int32_t"
+        data_type = "cuda::std::int32_t"
     instance_name = f"fill_kernel<{data_type}>"
     mod = prog.compile("cubin", name_expressions=(instance_name,))
     return mod.get_kernel(instance_name)

--- a/python/examples/exec_tag_timer.py
+++ b/python/examples/exec_tag_timer.py
@@ -26,38 +26,13 @@ def as_core_Stream(cs: bench.CudaStream) -> core.Stream:
     return core.Stream.from_handle(cs.addressof())
 
 
-def make_fill_kernel():
-    src = r"""
-#include <cuda/std/cstddef>
-#include <cuda/std/cstdint>
-
-template <typename T>
-__global__ void fill_kernel(T *buf, T value, ::cuda::std::size_t n)
-{
-  const auto init = blockIdx.x * blockDim.x + threadIdx.x;
-  const auto step = blockDim.x * gridDim.x;
-
-  for (auto i = init; i < n; i += step)
-  {
-    buf[i] = value;
-  }
-}
-"""
-    incl = headers.get_include_paths()
-    opts = core.ProgramOptions(include_path=str(incl.libcudacxx))
-    prog = core.Program(src, code_type="c++", options=opts)
-    instance_name = "fill_kernel<::cuda::std::int32_t>"
-    mod = prog.compile("cubin", name_expressions=(instance_name,))
-    return mod.get_kernel(instance_name)
-
-
 def make_copy_kernel():
     src = r"""
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 
 template <typename T>
-__global__ void copy_kernel(const T *in, T *out, ::cuda::std::size_t n)
+__global__ void copy_kernel(const T *in, T *out, cuda::std::size_t n)
 {
   const auto init = blockIdx.x * blockDim.x + threadIdx.x;
   const auto step = blockDim.x * gridDim.x;
@@ -71,154 +46,97 @@ __global__ void copy_kernel(const T *in, T *out, ::cuda::std::size_t n)
     incl = headers.get_include_paths()
     opts = core.ProgramOptions(include_path=str(incl.libcudacxx))
     prog = core.Program(src, code_type="c++", options=opts)
-    instance_name = "copy_kernel<::cuda::std::int32_t>"
+    instance_name = "copy_kernel<cuda::std::int32_t>"
     mod = prog.compile("cubin", name_expressions=(instance_name,))
     return mod.get_kernel(instance_name)
 
 
-def make_checksum_kernel():
+def make_sequence_kernel():
     src = r"""
 #include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 
-__global__ void checksum_kernel(const ::cuda::std::int32_t *in,
-                                ::cuda::std::int32_t *out,
-                                ::cuda::std::size_t n)
+template <typename T>
+__global__ void sequence_kernel(T *buf, cuda::std::size_t n)
 {
-  __shared__ ::cuda::std::int32_t block_sum[256];
-
   const auto init = blockIdx.x * blockDim.x + threadIdx.x;
   const auto step = blockDim.x * gridDim.x;
 
-  ::cuda::std::int32_t thread_sum = 0;
   for (auto i = init; i < n; i += step)
   {
-    thread_sum += in[i];
-  }
-
-  block_sum[threadIdx.x] = thread_sum;
-  __syncthreads();
-
-  for (::cuda::std::int32_t stride = blockDim.x / 2; stride > 0; stride /= 2)
-  {
-    if (threadIdx.x < stride)
-    {
-      block_sum[threadIdx.x] += block_sum[threadIdx.x + stride];
-    }
-    __syncthreads();
-  }
-
-  if (threadIdx.x == 0)
-  {
-    atomicAdd(out, block_sum[0]);
+    buf[i] = static_cast<T>(i);
   }
 }
 """
     incl = headers.get_include_paths()
     opts = core.ProgramOptions(include_path=str(incl.libcudacxx))
     prog = core.Program(src, code_type="c++", options=opts)
-    mod = prog.compile("cubin", name_expressions=("checksum_kernel",))
-    return mod.get_kernel("checksum_kernel")
+    instance_name = "sequence_kernel<cuda::std::int32_t>"
+    mod = prog.compile("cubin", name_expressions=(instance_name,))
+    return mod.get_kernel(instance_name)
+
+
+def make_mod2_inplace_kernel():
+    src = r"""
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+
+__global__ void mod2_inplace_kernel(cuda::std::int32_t *data,
+                                    cuda::std::size_t n)
+{
+  const auto init = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto step = blockDim.x * gridDim.x;
+
+  for (auto i = init; i < n; i += step)
+  {
+    data[i] = data[i] % 2;
+  }
+}
+"""
+    incl = headers.get_include_paths()
+    opts = core.ProgramOptions(include_path=str(incl.libcudacxx))
+    prog = core.Program(src, code_type="c++", options=opts)
+    mod = prog.compile("cubin", name_expressions=("mod2_inplace_kernel",))
+    return mod.get_kernel("mod2_inplace_kernel")
 
 
 @bench.register()
-@bench.axis.int64_power_of_two("Elements", range(20, 24))
-def copy_with_manual_timer(state: bench.State) -> None:
-    num_values = state.get_int64("Elements")
+def mod2_inplace(state: bench.State) -> None:
+    num_values = 64 * 1024 * 1024 // ctypes.sizeof(ctypes.c_int32(0))
     nbytes = num_values * ctypes.sizeof(ctypes.c_int32(0))
 
     alloc_stream = as_core_Stream(state.get_stream())
     mem = core.DeviceMemoryResource(state.get_device())
     input_buf = mem.allocate(nbytes, alloc_stream)
-    output_buf = mem.allocate(nbytes, alloc_stream)
+    data_buf = mem.allocate(nbytes, alloc_stream)
 
     state.add_element_count(num_values)
     state.add_global_memory_reads(nbytes)
     state.add_global_memory_writes(nbytes)
 
-    fill_kernel = make_fill_kernel()
+    sequence_kernel = make_sequence_kernel()
     copy_kernel = make_copy_kernel()
+    mod2_kernel = make_mod2_inplace_kernel()
 
     threads_per_block = 256
     blocks_in_grid = (num_values + threads_per_block - 1) // threads_per_block
     launch_config = core.LaunchConfig(
         grid=blocks_in_grid, block=threads_per_block, shmem_size=0
     )
+
+    core.launch(alloc_stream, launch_config, sequence_kernel, input_buf, num_values)
 
     def launcher(launch: bench.Launch, timer: bench.Timer):
         stream = as_core_Stream(launch.get_stream())
 
-        # Setup work before timer.start() is excluded from the measurement.
-        core.launch(stream, launch_config, fill_kernel, input_buf, 1, num_values)
-        core.launch(stream, launch_config, fill_kernel, output_buf, 0, num_values)
+        # Reset working data before timing the in-place operation.
+        core.launch(stream, launch_config, copy_kernel, input_buf, data_buf, num_values)
 
-        # Only the copy kernel is timed.
         timer.start()
-        core.launch(
-            stream, launch_config, copy_kernel, input_buf, output_buf, num_values
-        )
+        core.launch(stream, launch_config, mod2_kernel, data_buf, num_values)
         timer.stop()
 
     state.exec(launcher, timer=True)
-
-
-@bench.register()
-@bench.axis.int64_power_of_two("Elements", range(20, 24))
-def checksum_with_manual_timer_and_host_check(state: bench.State) -> None:
-    num_values = state.get_int64("Elements")
-    nbytes = num_values * ctypes.sizeof(ctypes.c_int32(0))
-    result_nbytes = ctypes.sizeof(ctypes.c_int32(0))
-
-    alloc_stream = as_core_Stream(state.get_stream())
-    mem = core.DeviceMemoryResource(state.get_device())
-    input_buf = mem.allocate(nbytes, alloc_stream)
-    output_buf = mem.allocate(result_nbytes, alloc_stream)
-    host_buf = core.PinnedMemoryResource().allocate(result_nbytes, alloc_stream)
-
-    state.add_element_count(num_values)
-    state.add_global_memory_reads(nbytes)
-    state.add_global_memory_writes(result_nbytes)
-
-    fill_kernel = make_fill_kernel()
-    checksum_kernel = make_checksum_kernel()
-    threads_per_block = 256
-    blocks_in_grid = (num_values + threads_per_block - 1) // threads_per_block
-    launch_config = core.LaunchConfig(
-        grid=blocks_in_grid, block=threads_per_block, shmem_size=0
-    )
-
-    def launcher(launch: bench.Launch, timer: bench.Timer):
-        nvbench_stream = launch.get_stream()
-        core_stream = as_core_Stream(nvbench_stream)
-
-        core.launch(core_stream, launch_config, fill_kernel, input_buf, 1, num_values)
-        core.launch(core_stream, launch_config, fill_kernel, output_buf, 0, 1)
-
-        # Only the async checksum kernel is timed. The host readback below is
-        # deliberately outside this timed region.
-        timer.start()
-        core.launch(
-            core_stream,
-            launch_config,
-            checksum_kernel,
-            input_buf,
-            output_buf,
-            num_values,
-        )
-        timer.stop()
-
-        output_buf.copy_to(host_buf, stream=core_stream)
-        core_stream.sync()
-
-        result = ctypes.c_int32.from_address(int(host_buf.handle)).value
-        if result != num_values:
-            raise RuntimeError(
-                f"Checksum mismatch: got {result}, expected {num_values}"
-            )
-
-    # because synchronization within launcher is not bracketed by timer start/stop
-    # there is no need to disable use of blocking kernel by passing sync=True
-    state.exec(launcher, timer=True, sync=False)
 
 
 if __name__ == "__main__":

--- a/python/examples/exec_tag_timer.py
+++ b/python/examples/exec_tag_timer.py
@@ -76,6 +76,51 @@ __global__ void copy_kernel(const T *in, T *out, ::cuda::std::size_t n)
     return mod.get_kernel(instance_name)
 
 
+def make_checksum_kernel():
+    src = r"""
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+
+__global__ void checksum_kernel(const ::cuda::std::int32_t *in,
+                                ::cuda::std::int32_t *out,
+                                ::cuda::std::size_t n)
+{
+  __shared__ ::cuda::std::int32_t block_sum[256];
+
+  const auto init = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto step = blockDim.x * gridDim.x;
+
+  ::cuda::std::int32_t thread_sum = 0;
+  for (auto i = init; i < n; i += step)
+  {
+    thread_sum += in[i];
+  }
+
+  block_sum[threadIdx.x] = thread_sum;
+  __syncthreads();
+
+  for (::cuda::std::int32_t stride = blockDim.x / 2; stride > 0; stride /= 2)
+  {
+    if (threadIdx.x < stride)
+    {
+      block_sum[threadIdx.x] += block_sum[threadIdx.x + stride];
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0)
+  {
+    atomicAdd(out, block_sum[0]);
+  }
+}
+"""
+    incl = headers.get_include_paths()
+    opts = core.ProgramOptions(include_path=str(incl.libcudacxx))
+    prog = core.Program(src, code_type="c++", options=opts)
+    mod = prog.compile("cubin", name_expressions=("checksum_kernel",))
+    return mod.get_kernel("checksum_kernel")
+
+
 @bench.register()
 @bench.axis.int64_power_of_two("Elements", range(20, 24))
 def copy_with_manual_timer(state: bench.State) -> None:
@@ -115,6 +160,65 @@ def copy_with_manual_timer(state: bench.State) -> None:
         timer.stop()
 
     state.exec(launcher, timer=True)
+
+
+@bench.register()
+@bench.axis.int64_power_of_two("Elements", range(20, 24))
+def checksum_with_manual_timer_and_host_check(state: bench.State) -> None:
+    num_values = state.get_int64("Elements")
+    nbytes = num_values * ctypes.sizeof(ctypes.c_int32(0))
+    result_nbytes = ctypes.sizeof(ctypes.c_int32(0))
+
+    alloc_stream = as_core_Stream(state.get_stream())
+    mem = core.DeviceMemoryResource(state.get_device())
+    input_buf = mem.allocate(nbytes, alloc_stream)
+    output_buf = mem.allocate(result_nbytes, alloc_stream)
+    host_buf = core.PinnedMemoryResource().allocate(result_nbytes, alloc_stream)
+
+    state.add_element_count(num_values)
+    state.add_global_memory_reads(nbytes)
+    state.add_global_memory_writes(result_nbytes)
+
+    fill_kernel = make_fill_kernel()
+    checksum_kernel = make_checksum_kernel()
+    threads_per_block = 256
+    blocks_in_grid = (num_values + threads_per_block - 1) // threads_per_block
+    launch_config = core.LaunchConfig(
+        grid=blocks_in_grid, block=threads_per_block, shmem_size=0
+    )
+
+    def launcher(launch: bench.Launch, timer: bench.Timer):
+        nvbench_stream = launch.get_stream()
+        core_stream = as_core_Stream(nvbench_stream)
+
+        core.launch(core_stream, launch_config, fill_kernel, input_buf, 1, num_values)
+        core.launch(core_stream, launch_config, fill_kernel, output_buf, 0, 1)
+
+        # Only the async checksum kernel is timed. The host readback below is
+        # deliberately outside this timed region.
+        timer.start()
+        core.launch(
+            core_stream,
+            launch_config,
+            checksum_kernel,
+            input_buf,
+            output_buf,
+            num_values,
+        )
+        timer.stop()
+
+        output_buf.copy_to(host_buf, stream=core_stream)
+        core_stream.sync()
+
+        result = ctypes.c_int32.from_address(int(host_buf.handle)).value
+        if result != num_values:
+            raise RuntimeError(
+                f"Checksum mismatch: got {result}, expected {num_values}"
+            )
+
+    # because synchronization within launcher is not bracketed by timer start/stop
+    # there is no need to disable use of blocking kernel by passing sync=True
+    state.exec(launcher, timer=True, sync=False)
 
 
 if __name__ == "__main__":

--- a/python/examples/exec_tag_timer.py
+++ b/python/examples/exec_tag_timer.py
@@ -1,0 +1,121 @@
+# Copyright 2026 NVIDIA Corporation
+#
+#  Licensed under the Apache License, Version 2.0 with the LLVM exception
+#  (the "License"); you may not use this file except in compliance with
+#  the License.
+#
+#  You may obtain a copy of the License at
+#
+#      http://llvm.org/foundation/relicensing/LICENSE.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import ctypes
+import sys
+
+import cuda.bench as bench
+import cuda.cccl.headers as headers
+import cuda.core as core
+
+
+def as_core_Stream(cs: bench.CudaStream) -> core.Stream:
+    return core.Stream.from_handle(cs.addressof())
+
+
+def make_fill_kernel():
+    src = r"""
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+
+template <typename T>
+__global__ void fill_kernel(T *buf, T value, ::cuda::std::size_t n)
+{
+  const auto init = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto step = blockDim.x * gridDim.x;
+
+  for (auto i = init; i < n; i += step)
+  {
+    buf[i] = value;
+  }
+}
+"""
+    incl = headers.get_include_paths()
+    opts = core.ProgramOptions(include_path=str(incl.libcudacxx))
+    prog = core.Program(src, code_type="c++", options=opts)
+    instance_name = "fill_kernel<::cuda::std::int32_t>"
+    mod = prog.compile("cubin", name_expressions=(instance_name,))
+    return mod.get_kernel(instance_name)
+
+
+def make_copy_kernel():
+    src = r"""
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+
+template <typename T>
+__global__ void copy_kernel(const T *in, T *out, ::cuda::std::size_t n)
+{
+  const auto init = blockIdx.x * blockDim.x + threadIdx.x;
+  const auto step = blockDim.x * gridDim.x;
+
+  for (auto i = init; i < n; i += step)
+  {
+    out[i] = in[i];
+  }
+}
+"""
+    incl = headers.get_include_paths()
+    opts = core.ProgramOptions(include_path=str(incl.libcudacxx))
+    prog = core.Program(src, code_type="c++", options=opts)
+    instance_name = "copy_kernel<::cuda::std::int32_t>"
+    mod = prog.compile("cubin", name_expressions=(instance_name,))
+    return mod.get_kernel(instance_name)
+
+
+@bench.register()
+@bench.axis.int64_power_of_two("Elements", range(20, 24))
+def copy_with_manual_timer(state: bench.State) -> None:
+    num_values = state.get_int64("Elements")
+    nbytes = num_values * ctypes.sizeof(ctypes.c_int32(0))
+
+    alloc_stream = as_core_Stream(state.get_stream())
+    mem = core.DeviceMemoryResource(state.get_device())
+    input_buf = mem.allocate(nbytes, alloc_stream)
+    output_buf = mem.allocate(nbytes, alloc_stream)
+
+    state.add_element_count(num_values)
+    state.add_global_memory_reads(nbytes)
+    state.add_global_memory_writes(nbytes)
+
+    fill_kernel = make_fill_kernel()
+    copy_kernel = make_copy_kernel()
+
+    threads_per_block = 256
+    blocks_in_grid = (num_values + threads_per_block - 1) // threads_per_block
+    launch_config = core.LaunchConfig(
+        grid=blocks_in_grid, block=threads_per_block, shmem_size=0
+    )
+
+    def launcher(launch: bench.Launch, timer: bench.Timer):
+        stream = as_core_Stream(launch.get_stream())
+
+        # Setup work before timer.start() is excluded from the measurement.
+        core.launch(stream, launch_config, fill_kernel, input_buf, 1, num_values)
+        core.launch(stream, launch_config, fill_kernel, output_buf, 0, num_values)
+
+        # Only the copy kernel is timed.
+        timer.start()
+        core.launch(
+            stream, launch_config, copy_kernel, input_buf, output_buf, num_values
+        )
+        timer.stop()
+
+    state.exec(launcher, timer=True)
+
+
+if __name__ == "__main__":
+    bench.run_all_benchmarks(sys.argv)

--- a/python/examples/skip.py
+++ b/python/examples/skip.py
@@ -34,7 +34,7 @@ def make_sleep_kernel():
 
 // Each launched thread just sleeps for `seconds`.
 __global__ void sleep_kernel(double seconds) {
-  namespace chrono = ::cuda::std::chrono;
+  namespace chrono = cuda::std::chrono;
   using hr_clock = chrono::high_resolution_clock;
 
   auto duration = static_cast<cuda::std::int64_t>(seconds * 1e9);

--- a/python/src/py_nvbench.cpp
+++ b/python/src/py_nvbench.cpp
@@ -117,6 +117,50 @@ private:
   std::shared_ptr<py::object> m_fn;
 };
 
+struct py_timer
+{
+  using callback_t = void (*)(void *);
+
+  py_timer(void *timer, callback_t start, callback_t stop)
+      : m_timer{timer}
+      , m_start{start}
+      , m_stop{stop}
+      , m_valid{true}
+  {}
+
+  void start()
+  {
+    this->check_valid();
+    m_start(m_timer);
+  }
+
+  void stop()
+  {
+    this->check_valid();
+    m_stop(m_timer);
+  }
+
+  void invalidate() noexcept
+  {
+    m_valid = false;
+    m_timer = nullptr;
+  }
+
+private:
+  void check_valid() const
+  {
+    if (!m_valid || !m_timer)
+    {
+      throw std::runtime_error("Timer is no longer valid.");
+    }
+  }
+
+  void *m_timer{};
+  callback_t m_start{};
+  callback_t m_stop{};
+  bool m_valid{false};
+};
+
 // Use struct to ensure public inheritance
 struct nvbench_run_error : std::runtime_error
 {
@@ -338,6 +382,25 @@ void def_class_Launch(py::module_ m)
                     method_get_stream_impl,
                     method_get_stream_doc,
                     py::return_value_policy::reference);
+}
+
+void def_class_Timer(py::module_ m)
+{
+  static constexpr const char *class_Timer_doc = R"XXXX(
+    Controls the manually timed region of a benchmark launch.
+
+    Note
+    ----
+        The class is not user-constructible. NVBench provides Timer instances
+        to launch callables that request manual timing.
+)XXXX";
+  auto py_timer_cls                            = py::class_<py_timer>(m, "Timer", class_Timer_doc);
+
+  static constexpr const char *method_start_doc = R"XXXX(Start the timed region.)XXXX";
+  py_timer_cls.def("start", &py_timer::start, method_start_doc);
+
+  static constexpr const char *method_stop_doc = R"XXXX(Stop the timed region.)XXXX";
+  py_timer_cls.def("stop", &py_timer::stop, method_stop_doc);
 }
 
 static void def_class_Benchmark(py::module_ m)
@@ -1139,6 +1202,8 @@ PYBIND11_MODULE(PYBIND11_MODULE_NAME, m)
   def_class_CudaStream(m);
 
   def_class_Launch(m);
+
+  def_class_Timer(m);
 
   def_class_Benchmark(m);
 

--- a/python/src/py_nvbench.cpp
+++ b/python/src/py_nvbench.cpp
@@ -1193,6 +1193,7 @@ Use argument True to disable use of blocking kernel by NVBench"
                   method_exec_doc,
                   py::arg("launcher_fn"),
                   py::pos_only{},
+                  py::kw_only{},
                   py::arg("batched") = py::none(),
                   py::arg("sync")    = false,
                   py::arg("timer")   = false);

--- a/python/src/py_nvbench.cpp
+++ b/python/src/py_nvbench.cpp
@@ -1061,13 +1061,15 @@ Use argument True to disable use of blocking kernel by NVBench"
   // method State.exec
   auto method_exec_impl = [](nvbench::state &state,
                              py::object py_launcher_fn,
-                             bool batched,
+                             py::object py_batched,
                              bool sync,
                              bool timer) -> void {
     if (!PyCallable_Check(py_launcher_fn.ptr()))
     {
       throw py::type_error("Argument of exec method must be a callable object");
     }
+
+    const bool batched = py_batched.is_none() ? !timer : py_batched.cast<bool>();
 
     // wrapper to invoke Python callable
     auto cpp_launcher_fn = [py_launcher_fn](nvbench::launch &launch_descr) -> void {
@@ -1145,9 +1147,11 @@ Use argument True to disable use of blocking kernel by NVBench"
     ----------
         fn: Callable
             Python callable with signature fn(Launch) -> None that executes the benchmark.
-        batched: bool, optional
+        batched: bool or None, optional
             If `True`, no cache flushing is performed between callable invocations.
-            Default: `True`.
+            If `None`, defaults to `True` unless timer=True is set. When
+            timer=True is set, batched defaults to `False`.
+            Default: `None`.
         sync: bool, optional
             True value indicates that callable performs device synchronization.
             NVBench disables use of blocking kernel in this case.
@@ -1155,8 +1159,8 @@ Use argument True to disable use of blocking kernel by NVBench"
         timer: bool, optional
             True value requests manual timing. The callable must have signature
             fn(Launch, Timer) -> None and call Timer.start() / Timer.stop() to
-            delimit the timed region. Manual timing requires batched=False,
-            matching nvbench::exec_tag::timer in the C++ API, which disables
+            delimit the timed region. Passing timer=True and batched=True is
+            invalid because nvbench::exec_tag::timer in the C++ API disables
             batched measurement.
             Default: `False`.
 
@@ -1166,7 +1170,7 @@ Use argument True to disable use of blocking kernel by NVBench"
                   method_exec_doc,
                   py::arg("launcher_fn"),
                   py::pos_only{},
-                  py::arg("batched") = true,
+                  py::arg("batched") = py::none(),
                   py::arg("sync")    = false,
                   py::arg("timer")   = false);
 

--- a/python/src/py_nvbench.cpp
+++ b/python/src/py_nvbench.cpp
@@ -414,6 +414,15 @@ void def_class_Timer(py::module_ m)
   static constexpr const char *class_Timer_doc = R"XXXX(
     Controls the manually timed region of a benchmark launch.
 
+    Each call to start() must be paired with a corresponding call to stop()
+    before the launch callable returns. NVBench does not validate all possible
+    unpaired or misordered start()/stop() sequences; benchmark results from
+    such use should not be trusted.
+
+    A launch callable may call start() and stop() more than once, matching the
+    C++ API behavior. Repeated pairs overwrite the timer state for the launch;
+    they do not accumulate elapsed time and do not create additional samples.
+
     Note
     ----
         The class is not user-constructible. NVBench provides Timer instances
@@ -421,10 +430,24 @@ void def_class_Timer(py::module_ m)
 )XXXX";
   auto py_timer_cls                            = py::class_<py_timer>(m, "Timer", class_Timer_doc);
 
-  static constexpr const char *method_start_doc = R"XXXX(Start the timed region.)XXXX";
+  static constexpr const char *method_start_doc = R"XXXX(
+    Start the timed region.
+
+    This call must be paired with a corresponding stop() call before the launch
+    callable returns. Calling start()/stop() repeatedly in the same launch
+    overwrites the recorded interval rather than accumulating time or creating
+    additional samples.
+)XXXX";
   py_timer_cls.def("start", &py_timer::start, method_start_doc);
 
-  static constexpr const char *method_stop_doc = R"XXXX(Stop the timed region.)XXXX";
+  static constexpr const char *method_stop_doc = R"XXXX(
+    Stop the timed region.
+
+    This records the interval since the most recent start() call. It must be
+    paired with a preceding start() call. Calling start()/stop() repeatedly in
+    the same launch overwrites the recorded interval rather than accumulating
+    time or creating additional samples.
+)XXXX";
   py_timer_cls.def("stop", &py_timer::stop, method_stop_doc);
 }
 

--- a/python/src/py_nvbench.cpp
+++ b/python/src/py_nvbench.cpp
@@ -161,6 +161,31 @@ private:
   bool m_valid{false};
 };
 
+template <typename TimerT>
+py_timer make_py_timer(TimerT &timer)
+{
+  return py_timer{std::addressof(timer),
+                  [](void *timer_ptr) { static_cast<TimerT *>(timer_ptr)->start(); },
+                  [](void *timer_ptr) { static_cast<TimerT *>(timer_ptr)->stop(); }};
+}
+
+struct py_timer_invalidation_guard
+{
+  explicit py_timer_invalidation_guard(py_timer &timer)
+      : m_timer{timer}
+  {}
+
+  py_timer_invalidation_guard(const py_timer_invalidation_guard &)            = delete;
+  py_timer_invalidation_guard(py_timer_invalidation_guard &&)                 = delete;
+  py_timer_invalidation_guard &operator=(const py_timer_invalidation_guard &) = delete;
+  py_timer_invalidation_guard &operator=(py_timer_invalidation_guard &&)      = delete;
+
+  ~py_timer_invalidation_guard() noexcept { m_timer.invalidate(); }
+
+private:
+  py_timer &m_timer;
+};
+
 // Use struct to ensure public inheritance
 struct nvbench_run_error : std::runtime_error
 {
@@ -1034,8 +1059,11 @@ Use argument True to disable use of blocking kernel by NVBench"
                   py::arg("duration_seconds"));
 
   // method State.exec
-  auto method_exec_impl =
-    [](nvbench::state &state, py::object py_launcher_fn, bool batched, bool sync) -> void {
+  auto method_exec_impl = [](nvbench::state &state,
+                             py::object py_launcher_fn,
+                             bool batched,
+                             bool sync,
+                             bool timer) -> void {
     if (!PyCallable_Check(py_launcher_fn.ptr()))
     {
       throw py::type_error("Argument of exec method must be a callable object");
@@ -1048,6 +1076,36 @@ Use argument True to disable use of blocking kernel by NVBench"
       // call Python callable
       py_launcher_fn(launch_pyarg);
     };
+
+    auto cpp_timer_launcher_fn = [py_launcher_fn](nvbench::launch &launch_descr,
+                                                  auto &timer_descr) -> void {
+      auto launch_pyarg = py::cast(std::ref(launch_descr), py::return_value_policy::reference);
+      auto timer_pyarg  = py::cast(make_py_timer(timer_descr));
+      auto &timer_ref   = timer_pyarg.template cast<py_timer &>();
+      py_timer_invalidation_guard guard{timer_ref};
+
+      py_launcher_fn(launch_pyarg, timer_pyarg);
+    };
+
+    if (timer)
+    {
+      if (batched)
+      {
+        throw py::value_error("State.exec(..., timer=True) requires batched=False.");
+      }
+
+      if (sync)
+      {
+        constexpr auto tag = nvbench::exec_tag::timer | nvbench::exec_tag::sync;
+        state.exec(tag, cpp_timer_launcher_fn);
+      }
+      else
+      {
+        constexpr auto tag = nvbench::exec_tag::timer;
+        state.exec(tag, cpp_timer_launcher_fn);
+      }
+      return;
+    }
 
     if (sync)
     {
@@ -1080,7 +1138,8 @@ Use argument True to disable use of blocking kernel by NVBench"
     Execute callable running the benchmark.
 
     The callable may be executed multiple times. The callable
-    will be passed `Launch` object argument.
+    will be passed a `Launch` object argument by default. When `timer=True`,
+    the callable will be passed `Launch` and `Timer` arguments.
 
     Parameters
     ----------
@@ -1093,6 +1152,13 @@ Use argument True to disable use of blocking kernel by NVBench"
             True value indicates that callable performs device synchronization.
             NVBench disables use of blocking kernel in this case.
             Default: `False`.
+        timer: bool, optional
+            True value requests manual timing. The callable must have signature
+            fn(Launch, Timer) -> None and call Timer.start() / Timer.stop() to
+            delimit the timed region. Manual timing requires batched=False,
+            matching nvbench::exec_tag::timer in the C++ API, which disables
+            batched measurement.
+            Default: `False`.
 
 )XXXX";
   pystate_cls.def("exec",
@@ -1101,7 +1167,8 @@ Use argument True to disable use of blocking kernel by NVBench"
                   py::arg("launcher_fn"),
                   py::pos_only{},
                   py::arg("batched") = true,
-                  py::arg("sync")    = false);
+                  py::arg("sync")    = false,
+                  py::arg("timer")   = false);
 
   // method State.get_short_description
   static constexpr const char *method_get_short_description_doc = R"XXXX(

--- a/python/test/test_cuda_bench.py
+++ b/python/test/test_cuda_bench.py
@@ -32,7 +32,7 @@ def test_py_exception():
 
 
 @pytest.mark.parametrize(
-    "cls", [bench.CudaStream, bench.State, bench.Launch, bench.Benchmark]
+    "cls", [bench.CudaStream, bench.State, bench.Launch, bench.Timer, bench.Benchmark]
 )
 def test_api_ctor(cls):
     with pytest.raises(TypeError, match="No constructor defined!"):
@@ -224,6 +224,13 @@ def test_Launch_doc():
     cl = bench.Launch
     obj_has_docstring_check(cl)
     obj_has_docstring_check(cl.get_stream)
+
+
+def test_Timer_doc():
+    cl = bench.Timer
+    obj_has_docstring_check(cl)
+    obj_has_docstring_check(cl.start)
+    obj_has_docstring_check(cl.stop)
 
 
 def test_CudaStream_doc():

--- a/python/test/test_cuda_bench.py
+++ b/python/test/test_cuda_bench.py
@@ -62,7 +62,7 @@ def test_cpu_only():
                 _ = json.dumps(s)
             timer.stop()
 
-        with pytest.raises(ValueError, match="timer=True.*batched=False"):
+        with pytest.raises(ValueError, match=r"timer=True.*batched=False"):
             state.exec(launcher, timer=True, batched=True)
 
         state.exec(launcher, timer=True)

--- a/python/test/test_cuda_bench.py
+++ b/python/test/test_cuda_bench.py
@@ -50,10 +50,31 @@ def t_bench(state: bench.State):
 
 
 def test_cpu_only():
+    saved_timers = []
+
+    def t_bench_timer(state: bench.State):
+        s = {"a": 1, "b": 0.5, "c": "test", "d": {"a": 1}}
+
+        def launcher(launch: bench.Launch, timer: bench.Timer):
+            saved_timers.append(timer)
+            timer.start()
+            for _ in range(10000):
+                _ = json.dumps(s)
+            timer.stop()
+
+        state.exec(launcher, timer=True, batched=False)
+
     b = bench.register(t_bench)
     b.set_is_cpu_only(True)
 
+    b_timer = bench.register(t_bench_timer)
+    b_timer.set_is_cpu_only(True)
+
     bench.run_all_benchmarks(["-q", "--profile"])
+
+    assert saved_timers
+    with pytest.raises(RuntimeError, match="Timer is no longer valid"):
+        saved_timers[0].start()
 
 
 def docstring_check(doc_str: Union[str, None]) -> None:

--- a/python/test/test_cuda_bench.py
+++ b/python/test/test_cuda_bench.py
@@ -62,7 +62,10 @@ def test_cpu_only():
                 _ = json.dumps(s)
             timer.stop()
 
-        state.exec(launcher, timer=True, batched=False)
+        with pytest.raises(ValueError, match="timer=True.*batched=False"):
+            state.exec(launcher, timer=True, batched=True)
+
+        state.exec(launcher, timer=True)
 
     b = bench.register(t_bench)
     b.set_is_cpu_only(True)


### PR DESCRIPTION
This PR implements `cuda.bench.Timer` and extends Python API to support `State.exec( Callable[[State, Timer], None], timer=True)`.

This permits writing Python benchmarks to time a kernel that might require input data reinitialization within the launchable (such as in-place operations).

This PR adds `python/example/exec_tag_timer.py`, which closely follows the corresponding C++ example.