### PR TITLE
Fix docutil error when building docs

### DIFF
--- a/python/cuda/bench/__init__.py
+++ b/python/cuda/bench/__init__.py
@@ -134,11 +134,6 @@ def __dir__():
     )
 
 
-__doc__ = """
-CUDA Kernel Benchmarking Library Python API
-"""
-
-
 def _get_register():
     if _register is not None:
         return _register

--- a/python/cuda/bench/_decorators.py
+++ b/python/cuda/bench/_decorators.py
@@ -98,6 +98,9 @@ def make_register(get_register: _RegisterGetter) -> Callable[..., Any]:
 
         Example
         -------
+
+        .. code-block:: python
+
             @bench.register()
             @bench.axis.int64("Elements", [1024, 2048])
             @bench.option.min_samples(10)


### PR DESCRIPTION
When building documentation using #323 locally, encountered

```
/home/opavlyk/miniforge/envs/nvbench-docs/lib/python3.14/site-packages/cuda/bench/__init__.py:docstring of cuda.bench.register:18: ERROR: Unexpected indentation. [docutils]
```

This was being tripped by use of code in docstring of `cuda.bench.register` indented under `Example` header, but not carrying any RST annotation as a code-block. 