### PR TITLE
nvbench::cpu_timer changed to use steady_clock

### DIFF
--- a/nvbench/cpu_timer.cuh
+++ b/nvbench/cpu_timer.cuh
@@ -31,6 +31,7 @@
 #include <nvbench/types.cuh>
 
 #include <chrono>
+#include <type_traits>
 
 namespace nvbench
 {
@@ -45,9 +46,9 @@ struct cpu_timer
   cpu_timer &operator=(const cpu_timer &) = delete;
   cpu_timer &operator=(cpu_timer &&)      = default;
 
-  __forceinline__ void start() noexcept { m_start = std::chrono::high_resolution_clock::now(); }
+  __forceinline__ void start() noexcept { m_start = cpu_timer_clock::now(); }
 
-  __forceinline__ void stop() noexcept { m_stop = std::chrono::high_resolution_clock::now(); }
+  __forceinline__ void stop() noexcept { m_stop = cpu_timer_clock::now(); }
 
   // In seconds:
   [[nodiscard]] __forceinline__ nvbench::float64_t get_duration()
@@ -58,8 +59,17 @@ struct cpu_timer
   }
 
 private:
-  std::chrono::high_resolution_clock::time_point m_start;
-  std::chrono::high_resolution_clock::time_point m_stop;
+  // Use high_resolution_clock only when it is monotonic; otherwise fall back to
+  // steady_clock to avoid negative elapsed times after system clock adjustments.
+  using cpu_timer_clock = std::conditional_t<std::chrono::high_resolution_clock::is_steady,
+                                             std::chrono::high_resolution_clock,
+                                             std::chrono::steady_clock>;
+  static_assert(cpu_timer_clock::is_steady, "cpu_timer requires a steady clock.");
+
+  using time_point_t = cpu_timer_clock::time_point;
+
+  time_point_t m_start;
+  time_point_t m_stop;
 };
 
 } // namespace nvbench


### PR DESCRIPTION
Closes #370 

Using `std::chrono::steady_clock `is more appropriate for timing measurements. It guarantees that duration computed from two time-points will not contain correction deltas (positive or negative).
