### PR TITLE
docs: separate measurement options from stopping criteria

### DIFF
--- a/docs/cli_help.md
+++ b/docs/cli_help.md
@@ -136,7 +136,7 @@
   * Applied to the most recent `--benchmark`, or all benchmarks if specified
     before any `--benchmark` arguments.
 
-## Stopping Criteria
+## Measurement Collection
 
 * `--timeout <seconds>`
   * Measurements will timeout after `<seconds>` have elapsed.
@@ -154,6 +154,8 @@
   * Default is 10 samples.
   * Applies to the most recent `--benchmark`, or all benchmarks if specified
     before any `--benchmark` arguments.
+
+## Stopping Criteria
 
 * `--stopping-criterion <criterion>`
   * After `--min-samples` is satisfied, use `<criterion>` to detect if enough


### PR DESCRIPTION
Summary:
- Move `--timeout` and `--min-samples` under a new `Measurement Collection` section.
- Leave `Stopping Criteria` focused on `--stopping-criterion` and criterion-specific parameters.

Verification:
- `rg -n "## Measurement Collection|## Stopping Criteria|--timeout|--min-samples|--stopping-criterion" docs/cli_help.md`
- `git diff --check`

Fixes #366.

This was implemented with Codex assistance, with the final diff manually reviewed and kept to the docs scope.