### PR TITLE
Reduce stdrel criterion complexity and ensure termination

### DIFF
--- a/docs/cli_help.md
+++ b/docs/cli_help.md
@@ -162,9 +162,10 @@
   * If both GPU and CPU times are gathered, GPU time is used for stopping
     analysis.
   * Stopping criteria provided by NVBench are:
-    * "stdrel": (default) Converges to a minimal relative standard deviation,
-       stdev / mean
-    * "entropy": Converges based on the cumulative entropy of all samples.
+    * "stdrel": (default) Stops when relative standard deviation falls below
+      max-noise, or when the noise estimate stabilizes without reaching that
+      threshold.
+    * "entropy": Stops when the entropy estimate of all collected samples converges.
     * "sample-count": Stops after a target number of samples.
   * Each stopping criterion may provide additional parameters to customize
     behavior, as detailed below:
@@ -172,15 +173,22 @@
 ### "stdrel" Stopping Criterion Parameters
 
 * `--min-time <seconds>`
-  * Accumulate at least `<seconds>` of execution time per measurement.
+  * Require at least `<seconds>` of accumulated execution time before `stdrel`
+    can stop based on the relative standard deviation estimate, either because
+    it falls below `--max-noise` or because it stabilizes above that threshold.
+    To avoid running indefinitely when relative standard deviation cannot be
+    computed reliably, NVBench may also stop earlier after repeated non-finite
+    noise estimates.
   * Only applies to `stdrel` stopping criterion.
   * Default is 0.5 seconds.
   * Applies to the most recent `--benchmark`, or all benchmarks if specified
     before any `--benchmark` arguments.
 
 * `--max-noise <value>`
-  * Gather samples until the error in the measurement drops below `<value>`.
-  * Noise is specified as the percent relative standard deviation (stdev/mean).
+  * Target relative standard deviation (stdev/mean). `stdrel` stops once the
+    estimate falls below this value, or once the estimate has stabilized above
+    it and additional samples are unlikely to improve convergence.
+  * Noise is specified as the percent relative standard deviation.
   * Default is 0.5% (`--max-noise 0.5`)
   * Applies to the most recent `--benchmark`, or all benchmarks if specified
     before any `--benchmark` arguments.

--- a/docs/cli_help.md
+++ b/docs/cli_help.md
@@ -163,7 +163,7 @@
     analysis.
   * Stopping criteria provided by NVBench are:
     * "stdrel": (default) Stops when relative standard deviation falls below
-      max-noise, or when the noise estimate stabilizes without reaching that
+      `--max-noise`, or when the noise estimate stabilizes without reaching that
       threshold.
     * "entropy": Stops when the entropy estimate of all collected samples converges.
     * "sample-count": Stops after a target number of samples.

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -36,6 +36,7 @@
 #include <iterator>
 #include <limits>
 #include <numeric>
+#include <optional>
 #include <type_traits>
 
 #ifndef M_PI
@@ -45,10 +46,12 @@
 namespace nvbench::detail::statistics
 {
 
+inline constexpr nvbench::int64_t min_samples_for_noise_estimate = 5;
+
 /**
  * Computes and returns the unbiased sample standard deviation.
  *
- * If the input has fewer than 5 sample, infinity is returned.
+ * If the input has fewer than min_samples_for_noise_estimate samples, infinity is returned.
  */
 template <typename Iter, typename ValueType = typename std::iterator_traits<Iter>::value_type>
 ValueType standard_deviation(Iter first, Iter last, ValueType mean)
@@ -57,7 +60,7 @@ ValueType standard_deviation(Iter first, Iter last, ValueType mean)
 
   const auto num = std::distance(first, last);
 
-  if (num < 5) // don't bother with low sample sizes.
+  if (num < min_samples_for_noise_estimate) // don't bother with low sample sizes.
   {
     return std::numeric_limits<ValueType>::infinity();
   }
@@ -93,6 +96,111 @@ nvbench::float64_t compute_mean(It first, It last)
   return std::accumulate(first, last, 0.0) / static_cast<nvbench::float64_t>(num);
 }
 
+class online_mean_variance
+{
+  nvbench::int64_t m_size{};       // number of samples
+  nvbench::float64_t m_mean{};     // sample mean
+  nvbench::float64_t m_variance{}; // unbiased (MLE) sample variance
+
+public:
+  void update(nvbench::float64_t measurement) noexcept
+  {
+    ++m_size;
+
+    if (m_size > 2)
+    {
+      const auto diff    = measurement - m_mean;
+      constexpr auto one = nvbench::float64_t{1};
+      const auto f       = one / static_cast<nvbench::float64_t>(m_size);
+
+      // mu_{n+1} = mu_{n} + (x_{n+1} - mu_{n}) / (n+1)
+      m_mean += diff * f;
+
+      // var_{n+1} = var_{n} + (n/(n+1) * diff * diff - var_{n}) / (n+1)
+      const auto diff2 = diff * diff;
+      m_variance += f * ((diff2 - m_variance) - f * diff2);
+    }
+    else if (m_size == 2)
+    {
+      const auto x1 = m_mean;
+      const auto x2 = measurement;
+
+      // mu = (x1 + x2) /2
+      m_mean = 0.5 * (x1 + x2);
+
+      // var = ((x1 - x2)/2)^2
+      const auto diff      = x1 - x2;
+      const auto half_diff = 0.5 * diff;
+      m_variance           = half_diff * half_diff;
+    }
+    else
+    {
+      // mu = x1, var = 0
+      m_mean = measurement;
+    }
+  }
+
+  void merge(const online_mean_variance &other) noexcept
+  {
+    if (other.m_size == 0)
+    {
+      return;
+    }
+    if (m_size == 0)
+    {
+      *this = other;
+      return;
+    }
+
+    const auto merged_size = m_size + other.m_size;
+    const auto diff        = other.m_mean - m_mean;
+    const auto f           = static_cast<nvbench::float64_t>(other.m_size) /
+                             static_cast<nvbench::float64_t>(merged_size);
+
+    // mu_{n+m} = mu_n + (m / (n + m)) * (mu_m - mu_n)
+    m_mean += f * diff;
+
+    // var_{n+m} = var_n + (m / (n + m)) * (var_m - var_n + (n / (n + m)) * (mu_n - mu_m)^2)
+    const auto diff2 = diff * diff;
+    m_variance += f * ((other.m_variance - m_variance + diff2) - f * diff2);
+    m_size = merged_size;
+  }
+
+  [[nodiscard]] nvbench::int64_t get_size() const noexcept { return m_size; }
+
+  [[nodiscard]] nvbench::float64_t get_mean() const noexcept { return m_mean; }
+
+  [[nodiscard]] nvbench::float64_t get_sample_variance() const noexcept { return m_variance; }
+
+  [[nodiscard]] nvbench::float64_t get_unbiased_variance() const noexcept
+  {
+    constexpr auto zero = nvbench::float64_t{0};
+    constexpr auto one  = nvbench::float64_t{1};
+
+    if (m_size <= 1 || m_variance < zero)
+    {
+      return std::numeric_limits<nvbench::float64_t>::quiet_NaN();
+    }
+
+    // \hat{var}_n = var_n / (1 - (1 / n))
+    const auto f = one / static_cast<nvbench::float64_t>(m_size);
+    return m_variance / (one - f);
+  }
+};
+
+// Returns nullopt for invalid inputs. A +inf result is allowed: it represents
+// unbounded relative dispersion rather than missing data.
+inline std::optional<nvbench::float64_t> compute_relative_dispersion(nvbench::float64_t dispersion,
+                                                                     nvbench::float64_t center)
+{
+  if (center <= nvbench::float64_t{} || !std::isfinite(center) ||
+      dispersion < nvbench::float64_t{} || std::isnan(dispersion))
+  {
+    return std::nullopt;
+  }
+
+  return dispersion / center;
+}
 /**
  * Computes linear regression and returns the slope and intercept
  *

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -100,7 +100,19 @@ class online_mean_variance
 {
   nvbench::int64_t m_size{};       // number of samples
   nvbench::float64_t m_mean{};     // sample mean
-  nvbench::float64_t m_variance{}; // unbiased (MLE) sample variance
+  nvbench::float64_t m_variance{}; // biased (MLE) sample variance
+
+  nvbench::float64_t update_mean_increment(nvbench::float64_t diff, nvbench::float64_t f) const
+  {
+    return f * diff;
+  }
+
+  nvbench::float64_t update_variance_increment(nvbench::float64_t var,
+                                               nvbench::float64_t diff2,
+                                               nvbench::float64_t f) const
+  {
+    return f * ((diff2 - var) - f * diff2);
+  }
 
 public:
   void update(nvbench::float64_t measurement) noexcept
@@ -109,16 +121,16 @@ public:
 
     if (m_size > 2)
     {
-      const auto diff    = measurement - m_mean;
       constexpr auto one = nvbench::float64_t{1};
       const auto f       = one / static_cast<nvbench::float64_t>(m_size);
 
       // mu_{n+1} = mu_{n} + (x_{n+1} - mu_{n}) / (n+1)
-      m_mean += diff * f;
+      const auto diff = measurement - m_mean;
+      m_mean += update_mean_increment(diff, f);
 
       // var_{n+1} = var_{n} + (n/(n+1) * diff * diff - var_{n}) / (n+1)
       const auto diff2 = diff * diff;
-      m_variance += f * ((diff2 - m_variance) - f * diff2);
+      m_variance += update_variance_increment(m_variance, diff2, f);
     }
     else if (m_size == 2)
     {
@@ -152,18 +164,17 @@ public:
       return;
     }
 
-    const auto merged_size = m_size + other.m_size;
-    const auto diff        = other.m_mean - m_mean;
-    const auto f           = static_cast<nvbench::float64_t>(other.m_size) /
-                             static_cast<nvbench::float64_t>(merged_size);
+    m_size += other.m_size;
+    const auto f = static_cast<nvbench::float64_t>(other.m_size) /
+                   static_cast<nvbench::float64_t>(m_size);
 
     // mu_{n+m} = mu_n + (m / (n + m)) * (mu_m - mu_n)
-    m_mean += f * diff;
+    const auto diff = other.m_mean - m_mean;
+    m_mean += update_mean_increment(diff, f);
 
     // var_{n+m} = var_n + (m / (n + m)) * (var_m - var_n + (n / (n + m)) * (mu_n - mu_m)^2)
     const auto diff2 = diff * diff;
-    m_variance += f * ((other.m_variance - m_variance + diff2) - f * diff2);
-    m_size = merged_size;
+    m_variance += update_variance_increment(m_variance - other.m_variance, diff2, f);
   }
 
   [[nodiscard]] nvbench::int64_t get_size() const noexcept { return m_size; }

--- a/nvbench/detail/stdrel_criterion.cuh
+++ b/nvbench/detail/stdrel_criterion.cuh
@@ -40,7 +40,7 @@ class stdrel_criterion final : public stopping_criterion_base
 {
   // state
   nvbench::int64_t m_consecutive_invalid_noise_estimates{};
-  nvbench::detail::statistics::online_mean_variance m_cuda_times_summary{};
+  nvbench::detail::statistics::online_mean_variance m_measurements_summary{};
   nvbench::detail::ring_buffer<nvbench::float64_t> m_noise_tracker{512};
 
 public:

--- a/nvbench/detail/stdrel_criterion.cuh
+++ b/nvbench/detail/stdrel_criterion.cuh
@@ -29,10 +29,9 @@
 #endif
 
 #include <nvbench/detail/ring_buffer.cuh>
+#include <nvbench/detail/statistics.cuh>
 #include <nvbench/stopping_criterion.cuh>
 #include <nvbench/types.cuh>
-
-#include <vector>
 
 namespace nvbench::detail
 {
@@ -40,9 +39,8 @@ namespace nvbench::detail
 class stdrel_criterion final : public stopping_criterion_base
 {
   // state
-  nvbench::int64_t m_total_samples{};
-  nvbench::float64_t m_total_cuda_time{};
-  std::vector<nvbench::float64_t> m_cuda_times{};
+  nvbench::int64_t m_consecutive_invalid_noise_estimates{};
+  nvbench::detail::statistics::online_mean_variance m_cuda_times_summary{};
   nvbench::detail::ring_buffer<nvbench::float64_t> m_noise_tracker{512};
 
 public:

--- a/nvbench/detail/stdrel_criterion.cxx
+++ b/nvbench/detail/stdrel_criterion.cxx
@@ -100,8 +100,8 @@ bool stdrel_criterion::do_is_finished()
     return true;
   }
 
-  constexpr std::size_t min_noise_stability_window     = 64;
-  constexpr std::size_t noise_stability_check_interval = 16;
+  constexpr std::size_t min_noise_stability_window          = 64;
+  constexpr nvbench::int64_t noise_stability_check_interval = 16;
 
   // Check if the noise has converged by inspecting a
   // trailing window of recorded noise measurements.

--- a/nvbench/detail/stdrel_criterion.cxx
+++ b/nvbench/detail/stdrel_criterion.cxx
@@ -24,16 +24,12 @@
 namespace nvbench::detail
 {
 
-namespace
-{
-
 // Allow transient invalid noise estimates while still terminating when
-// stdev relative noise cannot be computed persistently. The limit is high
-// enough to tolerate short startup/transient phases, but bounded so a stream
-// of invalid estimates cannot run until the wall-time timeout.
+// stdev relative noise does not have finite value for this many
+// consecutive iterations. The limit is high enough to tolerate short
+// startup/transient phases, but bounded so a stream of invalid estimates
+// cannot run until the wall-time timeout.
 constexpr nvbench::int64_t invalid_noise_estimate_limit = 64;
-
-} // namespace
 
 stdrel_criterion::stdrel_criterion()
     : stopping_criterion_base{"stdrel",
@@ -43,29 +39,29 @@ stdrel_criterion::stdrel_criterion()
 
 void stdrel_criterion::do_initialize()
 {
-  m_cuda_times_summary                  = {};
+  m_measurements_summary                = {};
   m_consecutive_invalid_noise_estimates = 0;
   m_noise_tracker.clear();
 }
 
 void stdrel_criterion::do_add_measurement(nvbench::float64_t measurement)
 {
-  m_cuda_times_summary.update(measurement);
+  m_measurements_summary.update(measurement);
 
-  if (m_cuda_times_summary.get_size() < statistics::min_samples_for_noise_estimate)
+  if (m_measurements_summary.get_size() < statistics::min_samples_for_noise_estimate)
   {
     return;
   }
 
-  // Compute convergence statistics using CUDA timings
+  // Compute convergence statistics using timing measurements
   // dispersion includes Bessel correction to preserve legacy behavior
-  const auto unbiased_dispersion = std::sqrt(m_cuda_times_summary.get_unbiased_variance());
-  const auto cuda_noise = statistics::compute_relative_dispersion(unbiased_dispersion,
-                                                                  m_cuda_times_summary.get_mean());
-  if (cuda_noise && std::isfinite(*cuda_noise))
+  const auto unbiased_dispersion = std::sqrt(m_measurements_summary.get_unbiased_variance());
+  const auto measurement_noise =
+    statistics::compute_relative_dispersion(unbiased_dispersion, m_measurements_summary.get_mean());
+  if (measurement_noise && std::isfinite(*measurement_noise))
   {
     m_consecutive_invalid_noise_estimates = 0;
-    m_noise_tracker.push_back(*cuda_noise);
+    m_noise_tracker.push_back(*measurement_noise);
   }
   else
   {
@@ -80,9 +76,10 @@ bool stdrel_criterion::do_is_finished()
     return true;
   }
 
-  const auto total_cuda_time = m_cuda_times_summary.get_mean() *
-                               static_cast<nvbench::float64_t>(m_cuda_times_summary.get_size());
-  if (total_cuda_time <= m_params.get_float64("min-time"))
+  const auto total_measured_time =
+    m_measurements_summary.get_mean() *
+    static_cast<nvbench::float64_t>(m_measurements_summary.get_size());
+  if (total_measured_time <= m_params.get_float64("min-time"))
   {
     return false;
   }
@@ -103,6 +100,9 @@ bool stdrel_criterion::do_is_finished()
     return true;
   }
 
+  constexpr std::size_t min_noise_stability_window     = 64;
+  constexpr std::size_t noise_stability_check_interval = 16;
+
   // Check if the noise has converged by inspecting a
   // trailing window of recorded noise measurements.
   // This helps identify benchmarks that are inherently noisy and would
@@ -110,7 +110,10 @@ bool stdrel_criterion::do_is_finished()
   // benchmark will end if the noise stabilizes above the target threshold.
   // Gather some iterations before checking noise, and limit how often we
   // check this.
-  if (m_noise_tracker.size() > 64 && (m_cuda_times_summary.get_size() % 16 == 0))
+  const bool do_check_noise_stability =
+    ((m_noise_tracker.size() > min_noise_stability_window) &&
+     (m_measurements_summary.get_size() % noise_stability_check_interval == 0));
+  if (do_check_noise_stability)
   {
     statistics::online_mean_variance noise_summary{};
     for (const auto noise_v : m_noise_tracker)
@@ -120,11 +123,11 @@ bool stdrel_criterion::do_is_finished()
     if (std::isfinite(noise_summary.get_mean()) &&
         std::isfinite(noise_summary.get_sample_variance()))
     {
-      // If the rel stdev of the last N cuda noise measurements is less than
+      // If the rel stdev of the last N noise measurements is less than
       // 5%, consider the result stable.
-      const auto noise_threshold    = 0.05;
-      const auto mean_scaled        = noise_summary.get_mean() * noise_threshold;
-      const auto variance_threshold = mean_scaled * mean_scaled;
+      constexpr auto noise_threshold = 0.05;
+      const auto mean_scaled         = noise_summary.get_mean() * noise_threshold;
+      const auto variance_threshold  = mean_scaled * mean_scaled;
       if (noise_summary.get_sample_variance() < variance_threshold)
       {
         return true;

--- a/nvbench/detail/stdrel_criterion.cxx
+++ b/nvbench/detail/stdrel_criterion.cxx
@@ -112,19 +112,20 @@ bool stdrel_criterion::do_is_finished()
   // check this.
   if (m_noise_tracker.size() > 64 && (m_cuda_times_summary.get_size() % 16 == 0))
   {
-    // Use the current noise as the stdev reference.
-    const auto current_noise = m_noise_tracker.back();
-    if (std::isfinite(current_noise) && current_noise > 0.0)
+    statistics::online_mean_variance noise_summary{};
+    for (const auto noise_v : m_noise_tracker)
     {
-      const auto noise_stdev     = statistics::standard_deviation(m_noise_tracker.cbegin(),
-                                                                  m_noise_tracker.cend(),
-                                                                  current_noise);
-      const auto noise_rel_stdev = noise_stdev / current_noise;
-
+      noise_summary.update(noise_v);
+    }
+    if (std::isfinite(noise_summary.get_mean()) &&
+        std::isfinite(noise_summary.get_sample_variance()))
+    {
       // If the rel stdev of the last N cuda noise measurements is less than
       // 5%, consider the result stable.
-      const auto noise_threshold = 0.05;
-      if (noise_rel_stdev < noise_threshold)
+      const auto noise_threshold    = 0.05;
+      const auto mean_scaled        = noise_summary.get_mean() * noise_threshold;
+      const auto variance_threshold = mean_scaled * mean_scaled;
+      if (noise_summary.get_sample_variance() < variance_threshold)
       {
         return true;
       }

--- a/nvbench/detail/stdrel_criterion.cxx
+++ b/nvbench/detail/stdrel_criterion.cxx
@@ -16,10 +16,24 @@
  *  limitations under the License.
  */
 
+#include <nvbench/detail/statistics.cuh>
 #include <nvbench/detail/stdrel_criterion.cuh>
+
+#include <cmath> // std::sqrt
 
 namespace nvbench::detail
 {
+
+namespace
+{
+
+// Allow transient invalid noise estimates while still terminating when
+// stdev relative noise cannot be computed persistently. The limit is high
+// enough to tolerate short startup/transient phases, but bounded so a stream
+// of invalid estimates cannot run until the wall-time timeout.
+constexpr nvbench::int64_t invalid_noise_estimate_limit = 64;
+
+} // namespace
 
 stdrel_criterion::stdrel_criterion()
     : stopping_criterion_base{"stdrel",
@@ -29,38 +43,56 @@ stdrel_criterion::stdrel_criterion()
 
 void stdrel_criterion::do_initialize()
 {
-  m_total_samples   = 0;
-  m_total_cuda_time = 0.0;
-  m_cuda_times.clear();
+  m_cuda_times_summary                  = {};
+  m_consecutive_invalid_noise_estimates = 0;
   m_noise_tracker.clear();
 }
 
 void stdrel_criterion::do_add_measurement(nvbench::float64_t measurement)
 {
-  m_total_samples++;
-  m_total_cuda_time += measurement;
-  m_cuda_times.push_back(measurement);
+  m_cuda_times_summary.update(measurement);
 
-  // Compute convergence statistics using CUDA timings:
-  const auto mean_cuda_time = m_total_cuda_time / static_cast<nvbench::float64_t>(m_total_samples);
-  const auto cuda_stdev     = nvbench::detail::statistics::standard_deviation(m_cuda_times.cbegin(),
-                                                                              m_cuda_times.cend(),
-                                                                              mean_cuda_time);
-  const auto cuda_rel_stdev = cuda_stdev / mean_cuda_time;
-  if (std::isfinite(cuda_rel_stdev))
+  if (m_cuda_times_summary.get_size() < statistics::min_samples_for_noise_estimate)
   {
-    m_noise_tracker.push_back(cuda_rel_stdev);
+    return;
+  }
+
+  // Compute convergence statistics using CUDA timings
+  // dispersion includes Bessel correction to preserve legacy behavior
+  const auto unbiased_dispersion = std::sqrt(m_cuda_times_summary.get_unbiased_variance());
+  const auto cuda_noise = statistics::compute_relative_dispersion(unbiased_dispersion,
+                                                                  m_cuda_times_summary.get_mean());
+  if (cuda_noise && std::isfinite(*cuda_noise))
+  {
+    m_consecutive_invalid_noise_estimates = 0;
+    m_noise_tracker.push_back(*cuda_noise);
+  }
+  else
+  {
+    ++m_consecutive_invalid_noise_estimates;
   }
 }
 
 bool stdrel_criterion::do_is_finished()
 {
-  if (m_total_cuda_time <= m_params.get_float64("min-time"))
+  if (m_consecutive_invalid_noise_estimates >= invalid_noise_estimate_limit)
+  {
+    return true;
+  }
+
+  const auto total_cuda_time = m_cuda_times_summary.get_mean() *
+                               static_cast<nvbench::float64_t>(m_cuda_times_summary.get_size());
+  if (total_cuda_time <= m_params.get_float64("min-time"))
   {
     return false;
   }
 
   if (m_noise_tracker.empty())
+  {
+    return false;
+  }
+
+  if (m_consecutive_invalid_noise_estimates != 0)
   {
     return false;
   }
@@ -71,29 +103,31 @@ bool stdrel_criterion::do_is_finished()
     return true;
   }
 
-  // Check if the noise (cuda rel stdev) has converged by inspecting a
+  // Check if the noise has converged by inspecting a
   // trailing window of recorded noise measurements.
   // This helps identify benchmarks that are inherently noisy and would
-  // never converge to the target stdev threshold. This check ensures that the
-  // benchmark will end if the stdev stabilizes above the target threshold.
+  // never converge to the target noise threshold. This check ensures that the
+  // benchmark will end if the noise stabilizes above the target threshold.
   // Gather some iterations before checking noise, and limit how often we
   // check this.
-  if (m_noise_tracker.size() > 64 && (m_total_samples % 16 == 0))
+  if (m_noise_tracker.size() > 64 && (m_cuda_times_summary.get_size() % 16 == 0))
   {
     // Use the current noise as the stdev reference.
     const auto current_noise = m_noise_tracker.back();
-    const auto noise_stdev =
-      nvbench::detail::statistics::standard_deviation(m_noise_tracker.cbegin(),
-                                                      m_noise_tracker.cend(),
-                                                      current_noise);
-    const auto noise_rel_stdev = noise_stdev / current_noise;
-
-    // If the rel stdev of the last N cuda noise measurements is less than
-    // 5%, consider the result stable.
-    const auto noise_threshold = 0.05;
-    if (noise_rel_stdev < noise_threshold)
+    if (std::isfinite(current_noise) && current_noise > 0.0)
     {
-      return true;
+      const auto noise_stdev     = statistics::standard_deviation(m_noise_tracker.cbegin(),
+                                                                  m_noise_tracker.cend(),
+                                                                  current_noise);
+      const auto noise_rel_stdev = noise_stdev / current_noise;
+
+      // If the rel stdev of the last N cuda noise measurements is less than
+      // 5%, consider the result stable.
+      const auto noise_threshold = 0.05;
+      if (noise_rel_stdev < noise_threshold)
+      {
+        return true;
+      }
     }
   }
 

--- a/testing/statistics.cu
+++ b/testing/statistics.cu
@@ -27,13 +27,29 @@
 
 namespace statistics = nvbench::detail::statistics;
 
+inline constexpr nvbench::float64_t default_atol = 1.0e-14;
+inline constexpr nvbench::float64_t default_rtol = 1.0e-14;
+
+inline bool is_close(nvbench::float64_t actual,
+                     nvbench::float64_t expected,
+                     nvbench::float64_t atol,
+                     nvbench::float64_t rtol)
+{
+  return std::abs(actual - expected) < std::max(atol, rtol * std::abs(expected));
+}
+
+inline bool is_close(nvbench::float64_t actual, nvbench::float64_t expected)
+{
+  return is_close(actual, expected, default_atol, default_rtol);
+}
+
 void test_mean()
 {
   {
     std::vector<nvbench::float64_t> data{1.0, 2.0, 3.0, 4.0, 5.0};
     const nvbench::float64_t actual   = statistics::compute_mean(std::begin(data), std::end(data));
     const nvbench::float64_t expected = 3.0;
-    ASSERT(std::abs(actual - expected) < 0.001);
+    ASSERT(is_close(actual, expected));
   }
 
   {
@@ -71,10 +87,9 @@ void test_online_mean_variance()
     }
 
     ASSERT(stats.get_size() == 5);
-    constexpr nvbench::float64_t eps = 1e-14;
-    ASSERT(std::abs(stats.get_mean() - 3.0) < eps);
-    ASSERT(std::abs(stats.get_sample_variance() - 2.0) < eps);
-    ASSERT(std::abs(stats.get_unbiased_variance() - 2.5) < eps);
+    ASSERT(is_close(stats.get_mean(), 3.0));
+    ASSERT(is_close(stats.get_sample_variance(), 2.0));
+    ASSERT(is_close(stats.get_unbiased_variance(), 2.5));
   }
 
   {
@@ -112,10 +127,9 @@ void test_online_mean_variance()
     }
 
     ASSERT(merged.get_size() == expected.get_size());
-    constexpr nvbench::float64_t eps = 1e-14;
-    ASSERT(std::abs(merged.get_mean() - expected.get_mean()) < eps);
-    ASSERT(std::abs(merged.get_sample_variance() - expected.get_sample_variance()) < eps);
-    ASSERT(std::abs(merged.get_unbiased_variance() - expected.get_unbiased_variance()) < eps);
+    ASSERT(is_close(merged.get_mean(), expected.get_mean()));
+    ASSERT(is_close(merged.get_sample_variance(), expected.get_sample_variance()));
+    ASSERT(is_close(merged.get_unbiased_variance(), expected.get_unbiased_variance()));
   }
 
   {
@@ -160,7 +174,7 @@ void test_std()
     const nvbench::float64_t actual =
       statistics::standard_deviation(std::begin(data), std::end(data), mean);
     const nvbench::float64_t expected = 1.581;
-    ASSERT(std::abs(actual - expected) < 0.001);
+    ASSERT(is_close(actual, expected, 0.001, 0.0));
   }
 
   {
@@ -202,7 +216,7 @@ void test_r2()
     const nvbench::float64_t actual =
       statistics::compute_r2(std::begin(ys), std::end(ys), slope, intercept);
     const nvbench::float64_t expected = 1.0;
-    ASSERT(std::abs(actual - expected) < 0.001);
+    ASSERT(is_close(actual, expected, 0.001, 0.0));
   }
   {
     std::vector<nvbench::float64_t> signal{1.0, 2.0, 3.0, 4.0, 5.0};
@@ -219,7 +233,7 @@ void test_r2()
     const nvbench::float64_t expected = 0.675;
     const nvbench::float64_t actual =
       statistics::compute_r2(std::begin(ys), std::end(ys), slope, intercept);
-    ASSERT(std::abs(actual - expected) < 0.001);
+    ASSERT(is_close(actual, expected, 0.001, 0.0));
   }
 }
 
@@ -228,17 +242,17 @@ void test_slope_conversion()
   {
     const nvbench::float64_t actual   = statistics::slope2deg(0.0);
     const nvbench::float64_t expected = 0.0;
-    ASSERT(std::abs(actual - expected) < 0.001);
+    ASSERT(is_close(actual, expected, 0.001, 0.0));
   }
   {
     const nvbench::float64_t actual   = statistics::slope2deg(1.0);
     const nvbench::float64_t expected = 45.0;
-    ASSERT(std::abs(actual - expected) < 0.001);
+    ASSERT(is_close(actual, expected, 0.001, 0.0));
   }
   {
     const nvbench::float64_t actual   = statistics::slope2deg(5.0);
     const nvbench::float64_t expected = 78.69;
-    ASSERT(std::abs(actual - expected) < 0.001);
+    ASSERT(is_close(actual, expected, 0.001, 0.0));
   }
 }
 

--- a/testing/statistics.cu
+++ b/testing/statistics.cu
@@ -20,6 +20,7 @@
 #include <nvbench/types.cuh>
 
 #include <algorithm>
+#include <cmath>
 #include <vector>
 
 #include "test_asserts.cuh"
@@ -42,14 +43,133 @@ void test_mean()
   }
 }
 
+void test_online_mean_variance()
+{
+  {
+    statistics::online_mean_variance stats;
+    ASSERT(stats.get_size() == 0);
+    ASSERT(stats.get_mean() == 0.0);
+    ASSERT(stats.get_sample_variance() == 0.0);
+    ASSERT(std::isnan(stats.get_unbiased_variance()));
+  }
+
+  {
+    statistics::online_mean_variance stats;
+    stats.update(42.0);
+
+    ASSERT(stats.get_size() == 1);
+    ASSERT(stats.get_mean() == 42.0);
+    ASSERT(stats.get_sample_variance() == 0.0);
+    ASSERT(std::isnan(stats.get_unbiased_variance()));
+  }
+
+  {
+    statistics::online_mean_variance stats;
+    for (const auto value : std::vector<nvbench::float64_t>{1.0, 2.0, 3.0, 4.0, 5.0})
+    {
+      stats.update(value);
+    }
+
+    ASSERT(stats.get_size() == 5);
+    constexpr nvbench::float64_t eps = 1e-14;
+    ASSERT(std::abs(stats.get_mean() - 3.0) < eps);
+    ASSERT(std::abs(stats.get_sample_variance() - 2.0) < eps);
+    ASSERT(std::abs(stats.get_unbiased_variance() - 2.5) < eps);
+  }
+
+  {
+    statistics::online_mean_variance left;
+    left.update(1.0);
+
+    statistics::online_mean_variance right;
+    right.update(3.0);
+
+    left.merge(right);
+
+    ASSERT(left.get_size() == 2);
+    ASSERT(left.get_mean() == 2.0);
+    ASSERT(left.get_sample_variance() == 1.0);
+    ASSERT(left.get_unbiased_variance() == 2.0);
+  }
+
+  {
+    statistics::online_mean_variance left;
+    left.update(1.0);
+    left.update(2.0);
+
+    statistics::online_mean_variance right;
+    right.update(3.0);
+    right.update(4.0);
+    right.update(5.0);
+
+    statistics::online_mean_variance merged = left;
+    merged.merge(right);
+
+    statistics::online_mean_variance expected;
+    for (const auto value : std::vector<nvbench::float64_t>{1.0, 2.0, 3.0, 4.0, 5.0})
+    {
+      expected.update(value);
+    }
+
+    ASSERT(merged.get_size() == expected.get_size());
+    constexpr nvbench::float64_t eps = 1e-14;
+    ASSERT(std::abs(merged.get_mean() - expected.get_mean()) < eps);
+    ASSERT(std::abs(merged.get_sample_variance() - expected.get_sample_variance()) < eps);
+    ASSERT(std::abs(merged.get_unbiased_variance() - expected.get_unbiased_variance()) < eps);
+  }
+
+  {
+    statistics::online_mean_variance empty;
+    statistics::online_mean_variance stats;
+    stats.update(1.0);
+    stats.update(3.0);
+
+    const auto size              = stats.get_size();
+    const auto mean              = stats.get_mean();
+    const auto sample_variance   = stats.get_sample_variance();
+    const auto unbiased_variance = stats.get_unbiased_variance();
+
+    stats.merge(empty);
+
+    ASSERT(stats.get_size() == size);
+    ASSERT(stats.get_mean() == mean);
+    ASSERT(stats.get_sample_variance() == sample_variance);
+    ASSERT(stats.get_unbiased_variance() == unbiased_variance);
+  }
+
+  {
+    statistics::online_mean_variance stats;
+    stats.update(1.4e154);
+    stats.update(1.4e154);
+
+    statistics::online_mean_variance merged;
+    merged.merge(stats);
+
+    ASSERT(merged.get_size() == stats.get_size());
+    ASSERT(merged.get_mean() == stats.get_mean());
+    ASSERT(merged.get_sample_variance() == stats.get_sample_variance());
+    ASSERT(merged.get_unbiased_variance() == stats.get_unbiased_variance());
+  }
+}
+
 void test_std()
 {
-  std::vector<nvbench::float64_t> data{1.0, 2.0, 3.0, 4.0, 5.0};
-  const nvbench::float64_t mean = 3.0;
-  const nvbench::float64_t actual =
-    statistics::standard_deviation(std::begin(data), std::end(data), mean);
-  const nvbench::float64_t expected = 1.581;
-  ASSERT(std::abs(actual - expected) < 0.001);
+  {
+    std::vector<nvbench::float64_t> data{1.0, 2.0, 3.0, 4.0, 5.0};
+    const nvbench::float64_t mean = 3.0;
+    const nvbench::float64_t actual =
+      statistics::standard_deviation(std::begin(data), std::end(data), mean);
+    const nvbench::float64_t expected = 1.581;
+    ASSERT(std::abs(actual - expected) < 0.001);
+  }
+
+  {
+    std::vector<nvbench::float64_t> data;
+    data.resize(static_cast<std::size_t>(statistics::min_samples_for_noise_estimate - 1), 1.0);
+    const nvbench::float64_t actual =
+      statistics::standard_deviation(std::begin(data), std::end(data), 1.0);
+    ASSERT(!std::isfinite(actual));
+  }
 }
 
 void test_lin_regression()
@@ -125,6 +245,7 @@ void test_slope_conversion()
 int main()
 {
   test_mean();
+  test_online_mean_variance();
   test_std();
   test_lin_regression();
   test_r2();

--- a/testing/stdrel_criterion.cu
+++ b/testing/stdrel_criterion.cu
@@ -16,53 +16,71 @@
  *  limitations under the License.
  */
 
+#include <nvbench/detail/statistics.cuh>
 #include <nvbench/detail/stdrel_criterion.cuh>
 #include <nvbench/stopping_criterion.cuh>
 #include <nvbench/types.cuh>
 
 #include <algorithm>
-#include <numeric>
-#include <random>
+#include <cmath>
+#include <limits>
 #include <vector>
 
 #include "test_asserts.cuh"
+
+constexpr nvbench::int64_t max_invalid_measurements_cap = 1024;
+
+nvbench::int64_t count_invalid_measurements_until_finished(nvbench::float64_t min_time)
+{
+  nvbench::criterion_params params;
+  params.set_float64("min-time", min_time);
+
+  nvbench::detail::stdrel_criterion criterion;
+  criterion.initialize(params);
+  // freshly initialized criterion starts as not is_finished
+  ASSERT(!criterion.is_finished());
+
+  const auto invalid_measurement              = nvbench::float64_t{0};
+  nvbench::int64_t total_invalid_measurements = 0;
+  while (!criterion.is_finished() && total_invalid_measurements < max_invalid_measurements_cap)
+  {
+    criterion.add_measurement(invalid_measurement);
+    ++total_invalid_measurements;
+  }
+  ASSERT(criterion.is_finished());
+  return total_invalid_measurements;
+}
 
 void test_const()
 {
   nvbench::criterion_params params;
   nvbench::detail::stdrel_criterion criterion;
+  using nvbench::detail::statistics::min_samples_for_noise_estimate;
 
   criterion.initialize(params);
-  for (int i = 0; i < 5; i++)
-  { // nvbench wants at least 5 to compute the standard deviation
+  for (nvbench::int64_t i = 0; i < min_samples_for_noise_estimate; ++i)
+  {
     criterion.add_measurement(42.0);
   }
   ASSERT(criterion.is_finished());
 }
 
-std::vector<double> generate(double mean, double rel_std_dev, int size)
-{
-  static std::mt19937::result_type seed = 0;
-  std::mt19937 gen(seed++);
-  std::vector<nvbench::float64_t> v(static_cast<std::size_t>(size));
-  std::normal_distribution<nvbench::float64_t> dist(mean, mean * rel_std_dev);
-  std::generate(v.begin(), v.end(), [&] { return dist(gen); });
-  return v;
-}
-
 void test_stdrel()
 {
-  const nvbench::int64_t size        = 10;
-  const nvbench::float64_t mean      = 42.0;
   const nvbench::float64_t max_noise = 0.1;
 
   nvbench::criterion_params params;
   params.set_float64("max-noise", max_noise);
+  params.set_float64("min-time", 0.0);
 
   nvbench::detail::stdrel_criterion criterion;
   criterion.initialize(params);
 
-  for (nvbench::float64_t measurement : generate(mean, max_noise / 2, size))
+  using nvbench::detail::statistics::min_samples_for_noise_estimate;
+
+  std::vector<nvbench::float64_t> low_noise(min_samples_for_noise_estimate, 100.0);
+  low_noise.back() = 101.0;
+  for (nvbench::float64_t measurement : low_noise)
   {
     criterion.add_measurement(measurement);
   }
@@ -71,7 +89,13 @@ void test_stdrel()
   params.set_float64("max-noise", max_noise);
   criterion.initialize(params);
 
-  for (nvbench::float64_t measurement : generate(mean, max_noise * 2, size))
+  std::vector<nvbench::float64_t> high_noise;
+  high_noise.reserve(min_samples_for_noise_estimate);
+  for (nvbench::int64_t i = 0; i < min_samples_for_noise_estimate; ++i)
+  {
+    high_noise.push_back(static_cast<nvbench::float64_t>(i + 1) * 10.0);
+  }
+  for (nvbench::float64_t measurement : high_noise)
   {
     criterion.add_measurement(measurement);
   }
@@ -86,11 +110,58 @@ void test_stdrel_needs_enough_samples()
   nvbench::detail::stdrel_criterion criterion;
   criterion.initialize(params);
 
-  for (int i = 0; i < 4; ++i)
+  using nvbench::detail::statistics::min_samples_for_noise_estimate;
+  for (nvbench::int64_t i = 1; i < min_samples_for_noise_estimate; ++i)
   {
     criterion.add_measurement(42.0);
   }
   ASSERT(!criterion.is_finished());
+}
+
+void test_stdrel_uses_sample_standard_deviation()
+{
+  using nvbench::detail::statistics::min_samples_for_noise_estimate;
+  const nvbench::int64_t n   = std::max(nvbench::int64_t{26}, min_samples_for_noise_estimate);
+  const nvbench::float64_t a = 6;
+  const nvbench::float64_t b = 0;
+  // for sequence t = a * i + b, 1 <= i <= n
+  // mean = a*(n+1)/2 + b
+  // variance = a^2/12 * (n^2 - 1)
+  // for a, b, n = 6, 0, 26, mean = 81,
+  // biased standard deviation = 45        (noise 0.5556)
+  // unbiased standard deviation = 45.8912 (noise 0.5666)
+
+  const nvbench::float64_t biased_noise = std::sqrt(static_cast<nvbench::float64_t>(n - 1) /
+                                                    static_cast<nvbench::float64_t>(3 * (n + 1)));
+  const nvbench::float64_t unbiased_noise =
+    std::sqrt(static_cast<nvbench::float64_t>(n) / static_cast<nvbench::float64_t>(3 * (n + 1)));
+
+  nvbench::criterion_params params;
+  params.set_float64("max-noise", 0.5 * (biased_noise + unbiased_noise));
+  params.set_float64("min-time", 0.0);
+
+  nvbench::detail::stdrel_criterion criterion;
+  criterion.initialize(params);
+
+  for (int i = 1; i <= n; ++i)
+  {
+    const nvbench::float64_t measurement = a * static_cast<nvbench::float64_t>(i) + b;
+    criterion.add_measurement(measurement);
+  }
+
+  ASSERT(!criterion.is_finished());
+}
+
+void test_stdrel_finishes_with_persistently_invalid_noise()
+{
+  const auto count = count_invalid_measurements_until_finished(0.0);
+  ASSERT(count > 1);
+}
+
+void test_stdrel_invalid_noise_bypasses_min_time()
+{
+  const auto count = count_invalid_measurements_until_finished(1.0);
+  ASSERT(count > 0);
 }
 
 int main()
@@ -98,4 +169,7 @@ int main()
   test_const();
   test_stdrel();
   test_stdrel_needs_enough_samples();
+  test_stdrel_uses_sample_standard_deviation();
+  test_stdrel_finishes_with_persistently_invalid_noise();
+  test_stdrel_invalid_noise_bypasses_min_time();
 }


### PR DESCRIPTION
Closes #375 

`stdrel_criterion` used to keep history of measurements and computed `statistics::standard_deviation` at each iteration. This has `O(n^2)` complexity.

This PR replaces the `"stdrel"` criterion's growing of sample history and its complete traversal for computation of standard deviation at every iteration with use of an online mean/variance accumulator (constant time complexity). This change reduces overall complexity from quadratic to linear. 

This keeps the stopping criterion based on relative standard deviation, preserves the unbiased standard-deviation estimate used for convergence, and reduces per-sample update work from recomputing over the full history to constant time.

Also, this PR adds a bounded invalid-noise path so measurements that persistently produce non-finite relative noise, such as all-zero timings, can terminate without waiting for the wall-time timeout. Keep the normal min-time gate for ordinary "stdrel" convergence.

Add focused tests for the online accumulator, stdrel sample-count threshold, sample-standard-deviation behavior, deterministic convergence inputs, and persistent invalid-noise termination. 

Update the CLI help for the stdrel termination behavior.