### PR TITLE
include cleanup across nvbench/

### DIFF
--- a/nvbench/axes_metadata.cuh
+++ b/nvbench/axes_metadata.cuh
@@ -32,12 +32,15 @@
 #include <nvbench/int64_axis.cuh>
 #include <nvbench/string_axis.cuh>
 #include <nvbench/type_axis.cuh>
+#include <nvbench/type_list.cuh>
 #include <nvbench/types.cuh>
 
+#include <cstddef>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/axes_metadata.cxx
+++ b/nvbench/axes_metadata.cxx
@@ -24,7 +24,14 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
+#include <exception>
+#include <memory>
 #include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 namespace nvbench
 {

--- a/nvbench/axis_base.cuh
+++ b/nvbench/axis_base.cuh
@@ -28,6 +28,7 @@
 #pragma system_header
 #endif
 
+#include <cstddef>
 #include <memory>
 #include <stdexcept>
 #include <string>

--- a/nvbench/axis_base.cxx
+++ b/nvbench/axis_base.cxx
@@ -18,6 +18,8 @@
 
 #include <nvbench/axis_base.cuh>
 
+#include <memory>
+
 namespace nvbench
 {
 

--- a/nvbench/benchmark.cuh
+++ b/nvbench/benchmark.cuh
@@ -33,7 +33,10 @@
 #include <nvbench/runner.cuh>
 #include <nvbench/type_list.cuh>
 
+#include <cstddef>
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/benchmark_base.cuh
+++ b/nvbench/benchmark_base.cuh
@@ -33,7 +33,10 @@
 #include <nvbench/state.cuh>
 #include <nvbench/stopping_criterion.cuh>
 
+#include <cstddef>
 #include <memory>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/benchmark_base.cxx
+++ b/nvbench/benchmark_base.cxx
@@ -21,7 +21,12 @@
 #include <nvbench/detail/transform_reduce.cuh>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace nvbench
 {

--- a/nvbench/benchmark_manager.cuh
+++ b/nvbench/benchmark_manager.cuh
@@ -30,7 +30,9 @@
 
 #include <nvbench/benchmark_base.cuh>
 
+#include <cstddef>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/benchmark_manager.cxx
+++ b/nvbench/benchmark_manager.cxx
@@ -23,7 +23,10 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <memory>
 #include <stdexcept>
+#include <string>
+#include <utility>
 
 namespace nvbench
 {

--- a/nvbench/blocking_kernel.cu
+++ b/nvbench/blocking_kernel.cu
@@ -28,6 +28,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <stdexcept>
 
 namespace
 {

--- a/nvbench/criterion_manager.cuh
+++ b/nvbench/criterion_manager.cuh
@@ -35,7 +35,10 @@
 #include <nvbench/types.cuh>
 
 #include <memory>
+#include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace nvbench
 {

--- a/nvbench/csv_printer.cu
+++ b/nvbench/csv_printer.cu
@@ -25,9 +25,14 @@
 
 #include <fmt/format.h>
 
+#include <cstddef>
 #include <cstdint>
+#include <iterator>
+#include <optional>
 #include <ostream>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 

--- a/nvbench/cuda_call.cu
+++ b/nvbench/cuda_call.cu
@@ -21,6 +21,7 @@
 
 #include <fmt/format.h>
 
+#include <cstddef>
 #include <cstdlib>
 #include <stdexcept>
 #include <string>

--- a/nvbench/cuda_call.cuh
+++ b/nvbench/cuda_call.cuh
@@ -31,6 +31,7 @@
 #include <cuda.h>
 #include <cuda_runtime_api.h>
 
+#include <cstddef>
 #include <string>
 
 /// Throws a std::runtime_error if `call` doesn't return `cudaSuccess`.

--- a/nvbench/cupti_profiler_host.cuh
+++ b/nvbench/cupti_profiler_host.cuh
@@ -30,6 +30,7 @@
 
 #include <nvbench/device_info.cuh>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/nvbench/cupti_profiler_host.cxx
+++ b/nvbench/cupti_profiler_host.cxx
@@ -26,10 +26,15 @@
 #include <cupti_range_profiler.h>
 #include <cupti_target.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 namespace nvbench::detail
 {

--- a/nvbench/cupti_profiler_nvpw.cuh
+++ b/nvbench/cupti_profiler_nvpw.cuh
@@ -30,6 +30,7 @@
 
 #include <nvbench/device_info.cuh>
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>

--- a/nvbench/cupti_profiler_nvpw.cxx
+++ b/nvbench/cupti_profiler_nvpw.cxx
@@ -29,8 +29,13 @@
 
 #include <fmt/format.h>
 
+#include <cstddef>
+#include <cstdint>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 namespace nvbench::detail
 {

--- a/nvbench/detail/entropy_criterion.cuh
+++ b/nvbench/detail/entropy_criterion.cuh
@@ -33,6 +33,7 @@
 #include <nvbench/stopping_criterion.cuh>
 #include <nvbench/types.cuh>
 
+#include <utility>
 #include <vector>
 
 namespace nvbench::detail

--- a/nvbench/detail/entropy_criterion.cxx
+++ b/nvbench/detail/entropy_criterion.cxx
@@ -19,7 +19,9 @@
 #include <nvbench/detail/entropy_criterion.cuh>
 #include <nvbench/types.cuh>
 
+#include <algorithm>
 #include <cmath>
+#include <utility>
 
 namespace nvbench::detail
 {

--- a/nvbench/detail/gpu_frequency.cuh
+++ b/nvbench/detail/gpu_frequency.cuh
@@ -31,10 +31,13 @@
 #include <nvbench/detail/timestamps_kernel.cuh>
 #include <nvbench/types.cuh>
 
+namespace nvbench
+{
+struct cuda_stream;
+}
+
 namespace nvbench::detail
 {
-
-struct cuda_stream;
 
 struct gpu_frequency
 {

--- a/nvbench/detail/l2flush.cuh
+++ b/nvbench/detail/l2flush.cuh
@@ -32,6 +32,8 @@
 
 #include <cuda_runtime_api.h>
 
+#include <cstddef>
+
 namespace nvbench::detail
 {
 

--- a/nvbench/detail/measure_cold.cu
+++ b/nvbench/detail/measure_cold.cu
@@ -29,9 +29,13 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <limits>
 #include <optional>
+#include <stdexcept>
+#include <string>
 #include <thread>
+#include <utility>
 
 namespace nvbench::detail
 {

--- a/nvbench/detail/measure_cpu_only.cxx
+++ b/nvbench/detail/measure_cpu_only.cxx
@@ -27,7 +27,12 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cstddef>
 #include <limits>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
 
 namespace nvbench::detail
 {

--- a/nvbench/detail/measure_cupti.cu
+++ b/nvbench/detail/measure_cupti.cu
@@ -25,7 +25,11 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <exception>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace nvbench::detail
 {

--- a/nvbench/detail/measure_hot.cu
+++ b/nvbench/detail/measure_hot.cu
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <stdexcept>
+#include <utility>
 #include <variant>
 
 namespace nvbench::detail

--- a/nvbench/detail/online_linear_regression.cuh
+++ b/nvbench/detail/online_linear_regression.cuh
@@ -30,6 +30,7 @@
 
 #include <nvbench/types.cuh>
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <utility>

--- a/nvbench/detail/state_exec.cuh
+++ b/nvbench/detail/state_exec.cuh
@@ -44,7 +44,9 @@
 #include <nvbench/detail/measure_cupti.cuh>
 #endif // NVBENCH_HAS_CUPTI
 
+#include <stdexcept>
 #include <type_traits>
+#include <utility>
 
 namespace nvbench
 {

--- a/nvbench/detail/state_generator.cuh
+++ b/nvbench/detail/state_generator.cuh
@@ -32,6 +32,7 @@
 #include <nvbench/axis_base.cuh>
 #include <nvbench/state.cuh>
 
+#include <cstddef>
 #include <optional>
 #include <string>
 #include <utility>

--- a/nvbench/detail/state_generator.cxx
+++ b/nvbench/detail/state_generator.cxx
@@ -25,8 +25,14 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <functional>
+#include <memory>
 #include <numeric>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace nvbench::detail
 {

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -32,6 +32,7 @@
 #include <nvbench/types.cuh>
 
 #include <cmath>
+#include <cstddef>
 #include <functional>
 #include <iterator>
 #include <limits>

--- a/nvbench/detail/type_list_impl.cuh
+++ b/nvbench/detail/type_list_impl.cuh
@@ -10,8 +10,11 @@
 #pragma system_header
 #endif
 
+#include <cstddef>
 #include <cstdint>
 #include <tuple>
+#include <type_traits>
+#include <utility>
 
 namespace nvbench
 {

--- a/nvbench/device_info.cu
+++ b/nvbench/device_info.cu
@@ -24,6 +24,9 @@
 
 #include <cuda_runtime_api.h>
 
+#include <cstddef>
+#include <stdexcept>
+
 #define UNUSED(x) (void)(x)
 
 namespace nvbench

--- a/nvbench/device_info.cuh
+++ b/nvbench/device_info.cuh
@@ -33,7 +33,9 @@
 
 #include <cuda_runtime_api.h>
 
-#include <cstdint> // CHAR_BIT
+#include <climits>
+#include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 #include <string_view>
 #include <utility>

--- a/nvbench/device_manager.cu
+++ b/nvbench/device_manager.cu
@@ -23,6 +23,9 @@
 
 #include <cuda_runtime_api.h>
 
+#include <cstddef>
+#include <stdexcept>
+
 namespace nvbench
 {
 

--- a/nvbench/device_manager.cuh
+++ b/nvbench/device_manager.cuh
@@ -30,6 +30,7 @@
 
 #include <nvbench/device_info.cuh>
 
+#include <utility>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/enum_type_list.cuh
+++ b/nvbench/enum_type_list.cuh
@@ -31,6 +31,7 @@
 #include <nvbench/type_list.cuh>
 #include <nvbench/type_strings.cuh>
 
+#include <string>
 #include <type_traits>
 
 namespace nvbench

--- a/nvbench/float64_axis.cuh
+++ b/nvbench/float64_axis.cuh
@@ -31,6 +31,10 @@
 #include <nvbench/axis_base.cuh>
 #include <nvbench/types.cuh>
 
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/float64_axis.cxx
+++ b/nvbench/float64_axis.cxx
@@ -20,6 +20,9 @@
 
 #include <fmt/format.h>
 
+#include <cstddef>
+#include <string>
+
 namespace nvbench
 {
 

--- a/nvbench/int64_axis.cuh
+++ b/nvbench/int64_axis.cuh
@@ -32,7 +32,11 @@
 #include <nvbench/flags.cuh>
 #include <nvbench/types.cuh>
 
+#include <cstddef>
+#include <memory>
 #include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/int64_axis.cxx
+++ b/nvbench/int64_axis.cxx
@@ -22,7 +22,11 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cstddef>
 #include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/internal/markdown_table.cuh
+++ b/nvbench/internal/markdown_table.cuh
@@ -35,9 +35,11 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace nvbench::internal

--- a/nvbench/internal/nvml.cuh
+++ b/nvbench/internal/nvml.cuh
@@ -36,7 +36,9 @@
 
 #include <fmt/format.h>
 
+#include <cstddef>
 #include <stdexcept>
+#include <string>
 
 namespace nvbench::nvml
 {

--- a/nvbench/internal/nvml.cxx
+++ b/nvbench/internal/nvml.cxx
@@ -18,6 +18,8 @@
 
 #include <nvbench/internal/nvml.cuh>
 
+#include <exception>
+
 namespace nvbench::nvml
 {
 NVMLLifetimeManager::NVMLLifetimeManager()

--- a/nvbench/internal/table_builder.cuh
+++ b/nvbench/internal/table_builder.cuh
@@ -28,9 +28,13 @@
 #pragma system_header
 #endif
 
+#include <nvbench/detail/transform_reduce.cuh>
+
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace nvbench::internal

--- a/nvbench/json_printer.cu
+++ b/nvbench/json_printer.cu
@@ -32,8 +32,12 @@
 
 #include <fmt/format.h>
 
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <exception>
 #include <fstream>
+#include <ios>
 #include <iterator>
 #include <ostream>
 #include <stdexcept>

--- a/nvbench/json_printer.cuh
+++ b/nvbench/json_printer.cuh
@@ -31,7 +31,10 @@
 #include <nvbench/printer_base.cuh>
 #include <nvbench/types.cuh>
 
+#include <cstddef>
+#include <iosfwd>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/main.cuh
+++ b/nvbench/main.cuh
@@ -34,8 +34,12 @@
 #include <nvbench/option_parser.cuh>
 #include <nvbench/printer_base.cuh>
 
+#include <cstddef>
 #include <cstdlib>
+#include <exception>
 #include <iostream>
+#include <string>
+#include <vector>
 
 // Advanced users can rebuild NVBench's `main` function using the macros in this file, or replace
 // them with customized implementations.

--- a/nvbench/markdown_printer.cu
+++ b/nvbench/markdown_printer.cu
@@ -26,11 +26,16 @@
 #include <fmt/color.h>
 #include <fmt/format.h>
 
+#include <cstddef>
 #include <functional>
+#include <iterator>
 #include <numeric>
+#include <optional>
 #include <ostream>
 #include <string>
 #include <type_traits>
+#include <utility>
+#include <variant>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/named_values.cuh
+++ b/nvbench/named_values.cuh
@@ -30,6 +30,7 @@
 
 #include <nvbench/types.cuh>
 
+#include <cstddef>
 #include <string>
 #include <variant>
 #include <vector>

--- a/nvbench/named_values.cxx
+++ b/nvbench/named_values.cxx
@@ -23,9 +23,15 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <exception>
 #include <iterator>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
 
 namespace nvbench
 {

--- a/nvbench/option_parser.cu
+++ b/nvbench/option_parser.cu
@@ -38,6 +38,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <cstdlib>
 #include <exception>
 #include <fstream>
@@ -50,6 +51,7 @@
 #include <string_view>
 #include <system_error>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #if __has_include(<filesystem>)

--- a/nvbench/option_parser.cuh
+++ b/nvbench/option_parser.cuh
@@ -35,6 +35,7 @@
 #include <iosfwd>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/printer_base.cuh
+++ b/nvbench/printer_base.cuh
@@ -30,6 +30,7 @@
 
 #include <nvbench/types.cuh>
 
+#include <cstddef>
 #include <iosfwd>
 #include <memory>
 #include <stdexcept>

--- a/nvbench/printer_base.cxx
+++ b/nvbench/printer_base.cxx
@@ -18,7 +18,10 @@
 
 #include <nvbench/printer_base.cuh>
 
+#include <cstddef>
 #include <ostream>
+#include <string>
+#include <utility>
 
 namespace nvbench
 {

--- a/nvbench/printer_multiplex.cuh
+++ b/nvbench/printer_multiplex.cuh
@@ -30,7 +30,10 @@
 
 #include <nvbench/printer_base.cuh>
 
+#include <cstddef>
 #include <memory>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/printer_multiplex.cxx
+++ b/nvbench/printer_multiplex.cxx
@@ -18,7 +18,10 @@
 
 #include <nvbench/printer_multiplex.cuh>
 
+#include <cstddef>
 #include <iostream>
+#include <string>
+#include <vector>
 
 namespace nvbench
 {

--- a/nvbench/runner.cuh
+++ b/nvbench/runner.cuh
@@ -31,6 +31,9 @@
 #include <nvbench/benchmark_base.cuh>
 #include <nvbench/detail/state_generator.cuh>
 
+#include <cstddef>
+#include <exception>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 

--- a/nvbench/runner.cxx
+++ b/nvbench/runner.cxx
@@ -24,6 +24,7 @@
 #include <fmt/format.h>
 
 #include <cstdio>
+#include <exception>
 #include <stdexcept>
 
 namespace nvbench

--- a/nvbench/state.cuh
+++ b/nvbench/state.cuh
@@ -36,8 +36,11 @@
 #include <nvbench/summary.cuh>
 #include <nvbench/types.cuh>
 
+#include <cstddef>
 #include <optional>
 #include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/state.cxx
+++ b/nvbench/state.cxx
@@ -25,8 +25,15 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
 
 namespace nvbench
 {

--- a/nvbench/stopping_criterion.cuh
+++ b/nvbench/stopping_criterion.cuh
@@ -34,6 +34,8 @@
 #include <initializer_list>
 #include <string>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace nvbench
 {

--- a/nvbench/stopping_criterion.cxx
+++ b/nvbench/stopping_criterion.cxx
@@ -19,6 +19,11 @@
 #include <nvbench/detail/throw.cuh>
 #include <nvbench/stopping_criterion.cuh>
 
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace nvbench
 {
 

--- a/nvbench/string_axis.cuh
+++ b/nvbench/string_axis.cuh
@@ -31,6 +31,10 @@
 #include <nvbench/axis_base.cuh>
 #include <nvbench/types.cuh>
 
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/test_kernels.cuh
+++ b/nvbench/test_kernels.cuh
@@ -34,6 +34,8 @@
 
 #include <cuda_runtime.h>
 
+#include <cstddef>
+
 /*!
  * @file test_kernels.cuh
  * A collection of simple kernels for testing purposes.

--- a/nvbench/type_axis.cuh
+++ b/nvbench/type_axis.cuh
@@ -32,7 +32,10 @@
 #include <nvbench/type_list.cuh>
 #include <nvbench/type_strings.cuh>
 
+#include <cstddef>
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace nvbench

--- a/nvbench/type_axis.cxx
+++ b/nvbench/type_axis.cxx
@@ -23,7 +23,10 @@
 #include <fmt/ranges.h>
 
 #include <algorithm>
+#include <cstddef>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace nvbench
 {

--- a/nvbench/type_list.cuh
+++ b/nvbench/type_list.cuh
@@ -30,8 +30,10 @@
 
 #include <nvbench/detail/type_list_impl.cuh>
 
+#include <cstddef>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 namespace nvbench
 {


### PR DESCRIPTION
Closes #376 

Added missing direct standard includes for entities such as std::size_t, std::move, std::vector, std::optional, std::exception, std::memcpy, etc.

Added missing project include in nvbench/internal/table_builder.cuh for nvbench::detail::transform_reduce.

Fixed nvbench/detail/gpu_frequency.cuh to forward-declare nvbench::cuda_stream in nvbench namespace instead of in nvbench::detail namespace.