### PR TITLE
Introduce robust metrics

### DIFF
--- a/nvbench/detail/measure_cold.cu
+++ b/nvbench/detail/measure_cold.cu
@@ -211,6 +211,7 @@ void measure_cold_base::generate_summaries()
     summ.set_int64("value", m_total_samples);
   }
 
+  // cpu time statistics
   {
     auto &summ = m_state.add_summary("nv/cold/time/cpu/min");
     summ.set_string("name", "Min CPU Time");
@@ -245,27 +246,79 @@ void measure_cold_base::generate_summaries()
     summ.set_float64("value", cpu_mean);
   }
 
-  const auto cpu_stdev = nvbench::detail::statistics::standard_deviation(m_cpu_times.cbegin(),
-                                                                         m_cpu_times.cend(),
-                                                                         cpu_mean);
+  const auto cpu_stdev =
+    statistics::standard_deviation(m_cpu_times.cbegin(), m_cpu_times.cend(), cpu_mean);
   {
     auto &summ = m_state.add_summary("nv/cold/time/cpu/stdev/absolute");
     summ.set_string("name", "Noise");
     summ.set_string("hint", "duration");
-    summ.set_string("description", "Standard deviation of isolated CPU times");
+    summ.set_string("description", "Standard deviation of isolated kernel execution CPU times");
     summ.set_float64("value", cpu_stdev);
     summ.set_string("hide", "Hidden by default.");
   }
 
-  const auto cpu_noise = cpu_stdev / cpu_mean;
+  const auto cpu_stdev_noise = statistics::compute_relative_dispersion(cpu_stdev, cpu_mean);
+  if (cpu_stdev_noise)
   {
     auto &summ = m_state.add_summary("nv/cold/time/cpu/stdev/relative");
     summ.set_string("name", "Noise");
     summ.set_string("hint", "percentage");
-    summ.set_string("description", "Relative standard deviation of isolated CPU times");
-    summ.set_float64("value", cpu_noise);
+    summ.set_string("description",
+                    "Relative standard deviation of isolated kernel execution CPU times");
+    summ.set_float64("value", *cpu_stdev_noise);
   }
 
+  const auto [cpu_time_first_quartile, cpu_time_median, cpu_time_third_quartile] =
+    statistics::compute_quartiles(m_cpu_times.cbegin(), m_cpu_times.cend());
+  {
+    auto &summ = m_state.add_summary("nv/cold/time/cpu/q1");
+    summ.set_string("name", "Q1");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "First quartile of isolated kernel execution CPU times");
+    summ.set_float64("value", cpu_time_first_quartile);
+    summ.set_string("hide", "Hidden by default.");
+  }
+  {
+    auto &summ = m_state.add_summary("nv/cold/time/cpu/median");
+    summ.set_string("name", "CPU Time");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "Median of isolated kernel execution CPU times");
+    summ.set_float64("value", cpu_time_median);
+    summ.set_string("hide", "Hidden by default.");
+  }
+  {
+    auto &summ = m_state.add_summary("nv/cold/time/cpu/q3");
+    summ.set_string("name", "Q3");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "Third quartile of isolated kernel execution CPU times");
+    summ.set_float64("value", cpu_time_third_quartile);
+    summ.set_string("hide", "Hidden by default.");
+  }
+  {
+    auto &summ = m_state.add_summary("nv/cold/time/cpu/ir/absolute");
+    summ.set_string("name", "IR");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "Interquartile range of isolated kernel execution CPU times");
+    const auto cpu_time_ir = cpu_time_third_quartile - cpu_time_first_quartile;
+    summ.set_float64("value", cpu_time_ir);
+    summ.set_string("hide", "Hidden by default.");
+  }
+  const auto cpu_robust_noise = statistics::compute_robust_noise(m_total_samples,
+                                                                 cpu_time_first_quartile,
+                                                                 cpu_time_median,
+                                                                 cpu_time_third_quartile);
+  if (cpu_robust_noise)
+  {
+    auto &summ = m_state.add_summary("nv/cold/time/cpu/ir/relative");
+    summ.set_string("name", "Noise");
+    summ.set_string("hint", "percentage");
+    summ.set_string("description",
+                    "Relative interquartile range of isolated kernel execution CPU times");
+    summ.set_float64("value", *cpu_robust_noise);
+    summ.set_string("hide", "Hidden by default.");
+  }
+
+  // gpu time statistics
   {
     auto &summ = m_state.add_summary("nv/cold/time/gpu/min");
     summ.set_string("name", "Min GPU Time");
@@ -299,25 +352,76 @@ void measure_cold_base::generate_summaries()
     summ.set_float64("value", cuda_mean);
   }
 
-  const auto cuda_stdev = nvbench::detail::statistics::standard_deviation(m_cuda_times.cbegin(),
-                                                                          m_cuda_times.cend(),
-                                                                          cuda_mean);
+  const auto cuda_stdev =
+    statistics::standard_deviation(m_cuda_times.cbegin(), m_cuda_times.cend(), cuda_mean);
   {
     auto &summ = m_state.add_summary("nv/cold/time/gpu/stdev/absolute");
     summ.set_string("name", "Noise");
     summ.set_string("hint", "duration");
-    summ.set_string("description", "Standard deviation of isolated GPU times");
+    summ.set_string("description", "Standard deviation of isolated kernel execution GPU times");
     summ.set_float64("value", cuda_stdev);
     summ.set_string("hide", "Hidden by default.");
   }
 
-  const auto cuda_noise = cuda_stdev / cuda_mean;
+  const auto cuda_stdev_noise = statistics::compute_relative_dispersion(cuda_stdev, cuda_mean);
+  if (cuda_stdev_noise)
   {
     auto &summ = m_state.add_summary("nv/cold/time/gpu/stdev/relative");
     summ.set_string("name", "Noise");
     summ.set_string("hint", "percentage");
-    summ.set_string("description", "Relative standard deviation of isolated GPU times");
-    summ.set_float64("value", cuda_noise);
+    summ.set_string("description",
+                    "Relative standard deviation of isolated kernel execution GPU times");
+    summ.set_float64("value", *cuda_stdev_noise);
+  }
+
+  const auto [cuda_time_first_quartile, cuda_time_median, cuda_time_third_quartile] =
+    statistics::compute_quartiles(m_cuda_times.cbegin(), m_cuda_times.cend());
+  {
+    auto &summ = m_state.add_summary("nv/cold/time/gpu/q1");
+    summ.set_string("name", "Q1");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "First quartile of isolated kernel execution GPU times");
+    summ.set_float64("value", cuda_time_first_quartile);
+    summ.set_string("hide", "Hidden by default.");
+  }
+  {
+    auto &summ = m_state.add_summary("nv/cold/time/gpu/median");
+    summ.set_string("name", "GPU Time");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "Median of isolated kernel execution GPU times");
+    summ.set_float64("value", cuda_time_median);
+    summ.set_string("hide", "Hidden by default.");
+  }
+  {
+    auto &summ = m_state.add_summary("nv/cold/time/gpu/q3");
+    summ.set_string("name", "Q3");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "Third quartile of isolated kernel execution GPU times");
+    summ.set_float64("value", cuda_time_third_quartile);
+    summ.set_string("hide", "Hidden by default.");
+  }
+  {
+    auto &summ = m_state.add_summary("nv/cold/time/gpu/ir/absolute");
+    summ.set_string("name", "IR");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "Interquartile range of isolated kernel execution GPU times");
+    const auto cuda_time_ir = cuda_time_third_quartile - cuda_time_first_quartile;
+    summ.set_float64("value", cuda_time_ir);
+    summ.set_string("hide", "Hidden by default.");
+  }
+  const auto cuda_robust_noise = statistics::compute_robust_noise(m_total_samples,
+                                                                  cuda_time_first_quartile,
+                                                                  cuda_time_median,
+                                                                  cuda_time_third_quartile);
+  if (cuda_robust_noise)
+  {
+    auto &summ = m_state.add_summary("nv/cold/time/gpu/ir/relative");
+    summ.set_string("name", "Noise");
+    summ.set_string("hint", "percentage");
+    summ.set_string("description",
+                    "Relative interquartile range of isolated kernel execution GPU times");
+    summ.set_float64("value", *cuda_robust_noise);
+    summ.set_string("hide", "Hidden by default.");
   }
 
   if (const auto items = m_state.get_element_count(); items != 0)
@@ -413,14 +517,14 @@ void measure_cold_base::generate_summaries()
       std::optional<nvbench::float64_t> min_time;
       get_param(min_time, "min-time");
 
-      if (max_noise && cuda_noise > *max_noise)
+      if (max_noise && cuda_stdev_noise && *cuda_stdev_noise > *max_noise)
       {
         printer.log(nvbench::log_level::warn,
                     fmt::format("Current measurement timed out ({:0.2f}s) "
                                 "while over noise threshold ({:0.2f}% > "
                                 "{:0.2f}%)",
                                 timeout,
-                                cuda_noise * 100,
+                                *cuda_stdev_noise * 100,
                                 *max_noise * 100));
       }
       if (m_total_samples < m_min_samples)

--- a/nvbench/detail/measure_cold.cu
+++ b/nvbench/detail/measure_cold.cu
@@ -272,7 +272,7 @@ void measure_cold_base::generate_summaries()
     statistics::compute_quartiles(m_cpu_times.cbegin(), m_cpu_times.cend());
   {
     auto &summ = m_state.add_summary("nv/cold/time/cpu/q1");
-    summ.set_string("name", "Q1");
+    summ.set_string("name", "Q1 CPU Time");
     summ.set_string("hint", "duration");
     summ.set_string("description", "First quartile of isolated kernel execution CPU times");
     summ.set_float64("value", cpu_time_first_quartile);
@@ -280,7 +280,7 @@ void measure_cold_base::generate_summaries()
   }
   {
     auto &summ = m_state.add_summary("nv/cold/time/cpu/median");
-    summ.set_string("name", "CPU Time");
+    summ.set_string("name", "Median CPU Time");
     summ.set_string("hint", "duration");
     summ.set_string("description", "Median of isolated kernel execution CPU times");
     summ.set_float64("value", cpu_time_median);
@@ -288,7 +288,7 @@ void measure_cold_base::generate_summaries()
   }
   {
     auto &summ = m_state.add_summary("nv/cold/time/cpu/q3");
-    summ.set_string("name", "Q3");
+    summ.set_string("name", "Q3 CPU Time");
     summ.set_string("hint", "duration");
     summ.set_string("description", "Third quartile of isolated kernel execution CPU times");
     summ.set_float64("value", cpu_time_third_quartile);
@@ -296,7 +296,7 @@ void measure_cold_base::generate_summaries()
   }
   {
     auto &summ = m_state.add_summary("nv/cold/time/cpu/ir/absolute");
-    summ.set_string("name", "IR");
+    summ.set_string("name", "IQR");
     summ.set_string("hint", "duration");
     summ.set_string("description", "Interquartile range of isolated kernel execution CPU times");
     const auto cpu_time_ir = cpu_time_third_quartile - cpu_time_first_quartile;
@@ -310,7 +310,7 @@ void measure_cold_base::generate_summaries()
   if (cpu_robust_noise)
   {
     auto &summ = m_state.add_summary("nv/cold/time/cpu/ir/relative");
-    summ.set_string("name", "Noise");
+    summ.set_string("name", "Rel IQR");
     summ.set_string("hint", "percentage");
     summ.set_string("description",
                     "Relative interquartile range of isolated kernel execution CPU times");
@@ -378,7 +378,7 @@ void measure_cold_base::generate_summaries()
     statistics::compute_quartiles(m_cuda_times.cbegin(), m_cuda_times.cend());
   {
     auto &summ = m_state.add_summary("nv/cold/time/gpu/q1");
-    summ.set_string("name", "Q1");
+    summ.set_string("name", "Q1 GPU Time");
     summ.set_string("hint", "duration");
     summ.set_string("description", "First quartile of isolated kernel execution GPU times");
     summ.set_float64("value", cuda_time_first_quartile);
@@ -386,7 +386,7 @@ void measure_cold_base::generate_summaries()
   }
   {
     auto &summ = m_state.add_summary("nv/cold/time/gpu/median");
-    summ.set_string("name", "GPU Time");
+    summ.set_string("name", "Median GPU Time");
     summ.set_string("hint", "duration");
     summ.set_string("description", "Median of isolated kernel execution GPU times");
     summ.set_float64("value", cuda_time_median);
@@ -394,7 +394,7 @@ void measure_cold_base::generate_summaries()
   }
   {
     auto &summ = m_state.add_summary("nv/cold/time/gpu/q3");
-    summ.set_string("name", "Q3");
+    summ.set_string("name", "Q3 GPU Time");
     summ.set_string("hint", "duration");
     summ.set_string("description", "Third quartile of isolated kernel execution GPU times");
     summ.set_float64("value", cuda_time_third_quartile);
@@ -402,7 +402,7 @@ void measure_cold_base::generate_summaries()
   }
   {
     auto &summ = m_state.add_summary("nv/cold/time/gpu/ir/absolute");
-    summ.set_string("name", "IR");
+    summ.set_string("name", "IQR");
     summ.set_string("hint", "duration");
     summ.set_string("description", "Interquartile range of isolated kernel execution GPU times");
     const auto cuda_time_ir = cuda_time_third_quartile - cuda_time_first_quartile;
@@ -416,7 +416,7 @@ void measure_cold_base::generate_summaries()
   if (cuda_robust_noise)
   {
     auto &summ = m_state.add_summary("nv/cold/time/gpu/ir/relative");
-    summ.set_string("name", "Noise");
+    summ.set_string("name", "Rel IQR");
     summ.set_string("hint", "percentage");
     summ.set_string("description",
                     "Relative interquartile range of isolated kernel execution GPU times");

--- a/nvbench/detail/measure_cold.cu
+++ b/nvbench/detail/measure_cold.cu
@@ -244,6 +244,7 @@ void measure_cold_base::generate_summaries()
                     "Mean isolated kernel execution time "
                     "(measured on host CPU)");
     summ.set_float64("value", cpu_mean);
+    summ.set_string("hide", "Hidden by default.");
   }
 
   const auto cpu_stdev =
@@ -266,6 +267,7 @@ void measure_cold_base::generate_summaries()
     summ.set_string("description",
                     "Relative standard deviation of isolated kernel execution CPU times");
     summ.set_float64("value", *cpu_stdev_noise);
+    summ.set_string("hide", "Hidden by default.");
   }
 
   const auto [cpu_time_first_quartile, cpu_time_median, cpu_time_third_quartile] =
@@ -284,7 +286,6 @@ void measure_cold_base::generate_summaries()
     summ.set_string("hint", "duration");
     summ.set_string("description", "Median of isolated kernel execution CPU times");
     summ.set_float64("value", cpu_time_median);
-    summ.set_string("hide", "Hidden by default.");
   }
   {
     auto &summ = m_state.add_summary("nv/cold/time/cpu/q3");
@@ -315,7 +316,6 @@ void measure_cold_base::generate_summaries()
     summ.set_string("description",
                     "Relative interquartile range of isolated kernel execution CPU times");
     summ.set_float64("value", *cpu_robust_noise);
-    summ.set_string("hide", "Hidden by default.");
   }
 
   // gpu time statistics
@@ -350,6 +350,7 @@ void measure_cold_base::generate_summaries()
                     "Mean isolated kernel execution time "
                     "(measured with CUDA events)");
     summ.set_float64("value", cuda_mean);
+    summ.set_string("hide", "Hidden by default.");
   }
 
   const auto cuda_stdev =
@@ -372,6 +373,7 @@ void measure_cold_base::generate_summaries()
     summ.set_string("description",
                     "Relative standard deviation of isolated kernel execution GPU times");
     summ.set_float64("value", *cuda_stdev_noise);
+    summ.set_string("hide", "Hidden by default.");
   }
 
   const auto [cuda_time_first_quartile, cuda_time_median, cuda_time_third_quartile] =
@@ -390,7 +392,6 @@ void measure_cold_base::generate_summaries()
     summ.set_string("hint", "duration");
     summ.set_string("description", "Median of isolated kernel execution GPU times");
     summ.set_float64("value", cuda_time_median);
-    summ.set_string("hide", "Hidden by default.");
   }
   {
     auto &summ = m_state.add_summary("nv/cold/time/gpu/q3");
@@ -421,7 +422,6 @@ void measure_cold_base::generate_summaries()
     summ.set_string("description",
                     "Relative interquartile range of isolated kernel execution GPU times");
     summ.set_float64("value", *cuda_robust_noise);
-    summ.set_string("hide", "Hidden by default.");
   }
 
   if (const auto items = m_state.get_element_count(); items != 0)

--- a/nvbench/detail/measure_cold.cu
+++ b/nvbench/detail/measure_cold.cu
@@ -244,7 +244,6 @@ void measure_cold_base::generate_summaries()
                     "Mean isolated kernel execution time "
                     "(measured on host CPU)");
     summ.set_float64("value", cpu_mean);
-    summ.set_string("hide", "Hidden by default.");
   }
 
   const auto cpu_stdev =
@@ -267,7 +266,6 @@ void measure_cold_base::generate_summaries()
     summ.set_string("description",
                     "Relative standard deviation of isolated kernel execution CPU times");
     summ.set_float64("value", *cpu_stdev_noise);
-    summ.set_string("hide", "Hidden by default.");
   }
 
   const auto [cpu_time_first_quartile, cpu_time_median, cpu_time_third_quartile] =
@@ -286,6 +284,7 @@ void measure_cold_base::generate_summaries()
     summ.set_string("hint", "duration");
     summ.set_string("description", "Median of isolated kernel execution CPU times");
     summ.set_float64("value", cpu_time_median);
+    summ.set_string("hide", "Hidden by default.");
   }
   {
     auto &summ = m_state.add_summary("nv/cold/time/cpu/q3");
@@ -316,6 +315,7 @@ void measure_cold_base::generate_summaries()
     summ.set_string("description",
                     "Relative interquartile range of isolated kernel execution CPU times");
     summ.set_float64("value", *cpu_robust_noise);
+    summ.set_string("hide", "Hidden by default.");
   }
 
   // gpu time statistics
@@ -350,7 +350,6 @@ void measure_cold_base::generate_summaries()
                     "Mean isolated kernel execution time "
                     "(measured with CUDA events)");
     summ.set_float64("value", cuda_mean);
-    summ.set_string("hide", "Hidden by default.");
   }
 
   const auto cuda_stdev =
@@ -373,7 +372,6 @@ void measure_cold_base::generate_summaries()
     summ.set_string("description",
                     "Relative standard deviation of isolated kernel execution GPU times");
     summ.set_float64("value", *cuda_stdev_noise);
-    summ.set_string("hide", "Hidden by default.");
   }
 
   const auto [cuda_time_first_quartile, cuda_time_median, cuda_time_third_quartile] =
@@ -392,6 +390,7 @@ void measure_cold_base::generate_summaries()
     summ.set_string("hint", "duration");
     summ.set_string("description", "Median of isolated kernel execution GPU times");
     summ.set_float64("value", cuda_time_median);
+    summ.set_string("hide", "Hidden by default.");
   }
   {
     auto &summ = m_state.add_summary("nv/cold/time/gpu/q3");
@@ -422,6 +421,7 @@ void measure_cold_base::generate_summaries()
     summ.set_string("description",
                     "Relative interquartile range of isolated kernel execution GPU times");
     summ.set_float64("value", *cuda_robust_noise);
+    summ.set_string("hide", "Hidden by default.");
   }
 
   if (const auto items = m_state.get_element_count(); items != 0)

--- a/nvbench/detail/measure_cpu_only.cxx
+++ b/nvbench/detail/measure_cpu_only.cxx
@@ -155,6 +155,7 @@ void measure_cpu_only_base::generate_summaries()
     summ.set_string("hint", "duration");
     summ.set_string("description", "Mean CPU time of isolated kernel executions");
     summ.set_float64("value", cpu_mean);
+    summ.set_string("hide", "Hidden by default.");
   }
 
   const auto cpu_stdev =
@@ -176,6 +177,7 @@ void measure_cpu_only_base::generate_summaries()
     summ.set_string("hint", "percentage");
     summ.set_string("description", "Relative standard deviation of isolated CPU times");
     summ.set_float64("value", *cpu_stdev_noise);
+    summ.set_string("hide", "Hidden by default.");
   }
 
   const auto [cpu_first_quartile, cpu_median, cpu_third_quartile] =
@@ -194,7 +196,6 @@ void measure_cpu_only_base::generate_summaries()
     summ.set_string("hint", "duration");
     summ.set_string("description", "Median of CPU times of isolated kernel executions");
     summ.set_float64("value", cpu_median);
-    summ.set_string("hide", "Hidden by default.");
   }
   {
     auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/q3");
@@ -226,7 +227,6 @@ void measure_cpu_only_base::generate_summaries()
     summ.set_string("description",
                     "Relative interquartile range of CPU times of isolated kernel executions");
     summ.set_float64("value", *cpu_robust_noise);
-    summ.set_string("hide", "Hidden by default.");
   }
 
   if (const auto items = m_state.get_element_count(); items != 0)

--- a/nvbench/detail/measure_cpu_only.cxx
+++ b/nvbench/detail/measure_cpu_only.cxx
@@ -155,7 +155,6 @@ void measure_cpu_only_base::generate_summaries()
     summ.set_string("hint", "duration");
     summ.set_string("description", "Mean CPU time of isolated kernel executions");
     summ.set_float64("value", cpu_mean);
-    summ.set_string("hide", "Hidden by default.");
   }
 
   const auto cpu_stdev =
@@ -177,7 +176,6 @@ void measure_cpu_only_base::generate_summaries()
     summ.set_string("hint", "percentage");
     summ.set_string("description", "Relative standard deviation of isolated CPU times");
     summ.set_float64("value", *cpu_stdev_noise);
-    summ.set_string("hide", "Hidden by default.");
   }
 
   const auto [cpu_first_quartile, cpu_median, cpu_third_quartile] =
@@ -196,6 +194,7 @@ void measure_cpu_only_base::generate_summaries()
     summ.set_string("hint", "duration");
     summ.set_string("description", "Median of CPU times of isolated kernel executions");
     summ.set_float64("value", cpu_median);
+    summ.set_string("hide", "Hidden by default.");
   }
   {
     auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/q3");
@@ -227,6 +226,7 @@ void measure_cpu_only_base::generate_summaries()
     summ.set_string("description",
                     "Relative interquartile range of CPU times of isolated kernel executions");
     summ.set_float64("value", *cpu_robust_noise);
+    summ.set_string("hide", "Hidden by default.");
   }
 
   if (const auto items = m_state.get_element_count(); items != 0)

--- a/nvbench/detail/measure_cpu_only.cxx
+++ b/nvbench/detail/measure_cpu_only.cxx
@@ -182,7 +182,7 @@ void measure_cpu_only_base::generate_summaries()
     statistics::compute_quartiles(m_cpu_times.cbegin(), m_cpu_times.cend());
   {
     auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/q1");
-    summ.set_string("name", "Q1");
+    summ.set_string("name", "Q1 CPU Time");
     summ.set_string("hint", "duration");
     summ.set_string("description", "First quartile of CPU times of isolated kernel executions");
     summ.set_float64("value", cpu_first_quartile);
@@ -190,7 +190,7 @@ void measure_cpu_only_base::generate_summaries()
   }
   {
     auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/median");
-    summ.set_string("name", "CPU Time");
+    summ.set_string("name", "Median CPU Time");
     summ.set_string("hint", "duration");
     summ.set_string("description", "Median of CPU times of isolated kernel executions");
     summ.set_float64("value", cpu_median);
@@ -198,7 +198,7 @@ void measure_cpu_only_base::generate_summaries()
   }
   {
     auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/q3");
-    summ.set_string("name", "Q3");
+    summ.set_string("name", "Q3 CPU Time");
     summ.set_string("hint", "duration");
     summ.set_string("description", "Third quartile of CPU times of isolated kernel executions");
     summ.set_float64("value", cpu_third_quartile);
@@ -206,7 +206,7 @@ void measure_cpu_only_base::generate_summaries()
   }
   {
     auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/ir/absolute");
-    summ.set_string("name", "IR");
+    summ.set_string("name", "IQR");
     summ.set_string("hint", "duration");
     summ.set_string("description",
                     "Interquartile range of CPU times of isolated kernel executions");
@@ -221,7 +221,7 @@ void measure_cpu_only_base::generate_summaries()
   if (cpu_robust_noise)
   {
     auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/ir/relative");
-    summ.set_string("name", "Noise");
+    summ.set_string("name", "Rel IQR");
     summ.set_string("hint", "percentage");
     summ.set_string("description",
                     "Relative interquartile range of CPU times of isolated kernel executions");

--- a/nvbench/detail/measure_cpu_only.cxx
+++ b/nvbench/detail/measure_cpu_only.cxx
@@ -157,9 +157,8 @@ void measure_cpu_only_base::generate_summaries()
     summ.set_float64("value", cpu_mean);
   }
 
-  const auto cpu_stdev = nvbench::detail::statistics::standard_deviation(m_cpu_times.cbegin(),
-                                                                         m_cpu_times.cend(),
-                                                                         cpu_mean);
+  const auto cpu_stdev =
+    statistics::standard_deviation(m_cpu_times.cbegin(), m_cpu_times.cend(), cpu_mean);
   {
     auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/stdev/absolute");
     summ.set_string("name", "Noise");
@@ -169,13 +168,65 @@ void measure_cpu_only_base::generate_summaries()
     summ.set_string("hide", "Hidden by default.");
   }
 
-  const auto cpu_noise = cpu_stdev / cpu_mean;
+  const auto cpu_stdev_noise = statistics::compute_relative_dispersion(cpu_stdev, cpu_mean);
+  if (cpu_stdev_noise)
   {
     auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/stdev/relative");
     summ.set_string("name", "Noise");
     summ.set_string("hint", "percentage");
     summ.set_string("description", "Relative standard deviation of isolated CPU times");
-    summ.set_float64("value", cpu_noise);
+    summ.set_float64("value", *cpu_stdev_noise);
+  }
+
+  const auto [cpu_first_quartile, cpu_median, cpu_third_quartile] =
+    statistics::compute_quartiles(m_cpu_times.cbegin(), m_cpu_times.cend());
+  {
+    auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/q1");
+    summ.set_string("name", "Q1");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "First quartile of CPU times of isolated kernel executions");
+    summ.set_float64("value", cpu_first_quartile);
+    summ.set_string("hide", "Hidden by default.");
+  }
+  {
+    auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/median");
+    summ.set_string("name", "CPU Time");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "Median of CPU times of isolated kernel executions");
+    summ.set_float64("value", cpu_median);
+    summ.set_string("hide", "Hidden by default.");
+  }
+  {
+    auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/q3");
+    summ.set_string("name", "Q3");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "Third quartile of CPU times of isolated kernel executions");
+    summ.set_float64("value", cpu_third_quartile);
+    summ.set_string("hide", "Hidden by default.");
+  }
+  {
+    auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/ir/absolute");
+    summ.set_string("name", "IR");
+    summ.set_string("hint", "duration");
+    summ.set_string("description",
+                    "Interquartile range of CPU times of isolated kernel executions");
+    const auto cpu_ir = cpu_third_quartile - cpu_first_quartile;
+    summ.set_float64("value", cpu_ir);
+    summ.set_string("hide", "Hidden by default.");
+  }
+  const auto cpu_robust_noise = statistics::compute_robust_noise(m_total_samples,
+                                                                 cpu_first_quartile,
+                                                                 cpu_median,
+                                                                 cpu_third_quartile);
+  if (cpu_robust_noise)
+  {
+    auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/ir/relative");
+    summ.set_string("name", "Noise");
+    summ.set_string("hint", "percentage");
+    summ.set_string("description",
+                    "Relative interquartile range of CPU times of isolated kernel executions");
+    summ.set_float64("value", *cpu_robust_noise);
+    summ.set_string("hide", "Hidden by default.");
   }
 
   if (const auto items = m_state.get_element_count(); items != 0)
@@ -230,14 +281,14 @@ void measure_cpu_only_base::generate_summaries()
       std::optional<nvbench::float64_t> min_time;
       get_param(min_time, "min-time");
 
-      if (max_noise && cpu_noise > *max_noise)
+      if (max_noise && cpu_stdev_noise && *cpu_stdev_noise > *max_noise)
       {
         printer.log(nvbench::log_level::warn,
                     fmt::format("Current measurement timed out ({:0.2f}s) "
                                 "while over noise threshold ({:0.2f}% > "
                                 "{:0.2f}%)",
                                 timeout,
-                                cpu_noise * 100,
+                                *cpu_stdev_noise * 100,
                                 *max_noise * 100));
       }
       if (m_total_samples < m_min_samples)

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -209,15 +209,16 @@ public:
 inline std::size_t percentile_rank(int percentile, std::size_t size)
 {
   assert(size > 0 && "percentile_rank requires non-empty sample set");
-  const auto p        = std::clamp(percentile, 0, 100);
+  const auto p = std::clamp(percentile, 0, 100);
+  const auto q = static_cast<nvbench::float64_t>(p) / 100.0;
+
   const auto max_rank = static_cast<nvbench::float64_t>(size - 1);
-  const auto q        = static_cast<nvbench::float64_t>(p) / 100.0;
   return static_cast<std::size_t>(std::round(q * max_rank));
 }
 
 template <typename ValueType, std::size_t N>
-std::array<ValueType, N> compute_percentiles_by_sorting(std::vector<ValueType> samples,
-                                                        std::array<int, N> percentiles)
+std::array<ValueType, N> compute_percentiles_by_sorting(std::vector<ValueType> &&samples,
+                                                        const std::array<int, N> &percentiles)
 {
   std::array<ValueType, N> result{};
   if (samples.empty())
@@ -230,7 +231,9 @@ std::array<ValueType, N> compute_percentiles_by_sorting(std::vector<ValueType> s
 
   for (std::size_t i = 0; i < N; ++i)
   {
-    result[i] = samples[percentile_rank(percentiles[i], samples.size())];
+    const auto rank = ::nvbench::detail::statistics::percentile_rank(percentiles[i],
+                                                                     samples.size());
+    result[i]       = samples[rank];
   }
   return result;
 }
@@ -244,33 +247,41 @@ std::array<ValueType, N> compute_percentiles_by_sorting(std::vector<ValueType> s
 template <typename Iter,
           std::size_t N,
           typename ValueType = typename std::iterator_traits<Iter>::value_type>
-std::array<ValueType, N> compute_percentiles(Iter first, Iter last, std::array<int, N> percentiles)
+std::array<ValueType, N> compute_percentiles(Iter first,
+                                             Iter last,
+                                             const std::array<int, N> &percentiles)
 {
   static_assert(std::is_floating_point_v<ValueType>,
                 "compute_percentiles requires a floating-point value type.");
 
   std::vector<ValueType> samples(first, last);
-  return compute_percentiles_by_sorting(std::move(samples), percentiles);
+  return ::nvbench::detail::statistics::compute_percentiles_by_sorting(std::move(samples),
+                                                                       percentiles);
 }
 
 template <typename T>
 struct quartiles_t
 {
+  static_assert(std::is_arithmetic_v<T>,
+                "Template parameter used for quartiles_t must be arithmetic type");
+
   T first_quartile;
   T median;
   T third_quartile;
 };
 
 template <typename ValueType>
-quartiles_t<ValueType> compute_quartiles_by_sorting(std::vector<ValueType> samples)
+quartiles_t<ValueType> compute_quartiles_by_sorting(std::vector<ValueType> &&samples)
 {
   constexpr std::array<int, 3> qs{25, 50, 75};
-  const auto r = compute_percentiles_by_sorting(std::move(samples), qs);
+  const auto r = ::nvbench::detail::statistics::compute_percentiles_by_sorting(
+    std::forward<std::vector<ValueType>>(samples),
+    qs);
   return {r[0], r[1], r[2]};
 }
 
 template <typename ValueType>
-quartiles_t<ValueType> compute_quartiles_by_selection(std::vector<ValueType> samples)
+quartiles_t<ValueType> compute_quartiles_by_selection(std::vector<ValueType> &&samples)
 {
   if (samples.empty())
   {
@@ -279,7 +290,7 @@ quartiles_t<ValueType> compute_quartiles_by_selection(std::vector<ValueType> sam
   }
 
   const auto select = [](auto first, std::size_t rank, auto last) {
-    auto nth = first + static_cast<std::ptrdiff_t>(rank);
+    const auto nth = first + static_cast<std::ptrdiff_t>(rank);
     std::nth_element(first, nth, last);
     return nth;
   };
@@ -312,10 +323,10 @@ quartiles_t<ValueType> compute_quartiles(Iter first, Iter last)
 
   if (samples.size() >= selection_threshold)
   {
-    return compute_quartiles_by_selection(std::move(samples));
+    return ::nvbench::detail::statistics::compute_quartiles_by_selection(std::move(samples));
   }
 
-  return compute_quartiles_by_sorting(std::move(samples));
+  return ::nvbench::detail::statistics::compute_quartiles_by_sorting(std::move(samples));
 }
 
 // Returns nullopt for invalid inputs. A +inf result is allowed: it represents
@@ -343,7 +354,7 @@ compute_relative_interquartile_range(nvbench::float64_t first_quartile,
     return std::nullopt;
   }
 
-  return compute_relative_dispersion(interquartile_range, median);
+  return ::nvbench::detail::statistics::compute_relative_dispersion(interquartile_range, median);
 }
 
 // Returns nullopt until there are enough samples for a meaningful robust noise estimate.
@@ -357,7 +368,9 @@ inline std::optional<nvbench::float64_t> compute_robust_noise(nvbench::int64_t n
     return std::nullopt;
   }
 
-  return compute_relative_interquartile_range(first_quartile, median, third_quartile);
+  return ::nvbench::detail::statistics::compute_relative_interquartile_range(first_quartile,
+                                                                             median,
+                                                                             third_quartile);
 }
 
 /**

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -31,6 +31,9 @@
 #include <nvbench/detail/transform_reduce.cuh>
 #include <nvbench/types.cuh>
 
+#include <algorithm>
+#include <array>
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <functional>
@@ -39,6 +42,8 @@
 #include <numeric>
 #include <optional>
 #include <type_traits>
+#include <utility>
+#include <vector>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -200,6 +205,119 @@ public:
   }
 };
 
+// Compute percentile rank using nearest rank method
+inline std::size_t percentile_rank(int percentile, std::size_t size)
+{
+  assert(size > 0 && "percentile_rank requires non-empty sample set");
+  const auto p        = std::clamp(percentile, 0, 100);
+  const auto max_rank = static_cast<nvbench::float64_t>(size - 1);
+  const auto q        = static_cast<nvbench::float64_t>(p) / 100.0;
+  return static_cast<std::size_t>(std::round(q * max_rank));
+}
+
+template <typename ValueType, std::size_t N>
+std::array<ValueType, N> compute_percentiles_by_sorting(std::vector<ValueType> samples,
+                                                        std::array<int, N> percentiles)
+{
+  std::array<ValueType, N> result{};
+  if (samples.empty())
+  {
+    result.fill(std::numeric_limits<ValueType>::quiet_NaN());
+    return result;
+  }
+
+  std::sort(samples.begin(), samples.end());
+
+  for (std::size_t i = 0; i < N; ++i)
+  {
+    result[i] = samples[percentile_rank(percentiles[i], samples.size())];
+  }
+  return result;
+}
+
+/**
+ * Computes exact percentile values using rank round(p / 100 * (S - 1)).
+ *
+ * The input range is copied before sorting, so const iterators are supported.
+ * If the input has fewer than 1 sample, all percentiles are returned as quiet NaNs.
+ */
+template <typename Iter,
+          std::size_t N,
+          typename ValueType = typename std::iterator_traits<Iter>::value_type>
+std::array<ValueType, N> compute_percentiles(Iter first, Iter last, std::array<int, N> percentiles)
+{
+  static_assert(std::is_floating_point_v<ValueType>,
+                "compute_percentiles requires a floating-point value type.");
+
+  std::vector<ValueType> samples(first, last);
+  return compute_percentiles_by_sorting(std::move(samples), percentiles);
+}
+
+template <typename T>
+struct quartiles_t
+{
+  T first_quartile;
+  T median;
+  T third_quartile;
+};
+
+template <typename ValueType>
+quartiles_t<ValueType> compute_quartiles_by_sorting(std::vector<ValueType> samples)
+{
+  constexpr std::array<int, 3> qs{25, 50, 75};
+  const auto r = compute_percentiles_by_sorting(std::move(samples), qs);
+  return {r[0], r[1], r[2]};
+}
+
+template <typename ValueType>
+quartiles_t<ValueType> compute_quartiles_by_selection(std::vector<ValueType> samples)
+{
+  if (samples.empty())
+  {
+    constexpr auto nan = std::numeric_limits<ValueType>::quiet_NaN();
+    return {nan, nan, nan};
+  }
+
+  const auto select = [](auto first, std::size_t rank, auto last) {
+    auto nth = first + static_cast<std::ptrdiff_t>(rank);
+    std::nth_element(first, nth, last);
+    return nth;
+  };
+
+  const auto n       = samples.size();
+  const auto rank_25 = percentile_rank(25, n);
+  const auto rank_50 = percentile_rank(50, n);
+  const auto rank_75 = percentile_rank(75, n);
+
+  assert(rank_25 <= rank_50 && rank_50 <= rank_75 &&
+         "invariant: quartile ranks must be ordered: q1 <= median <= q3");
+
+  const auto q2_iter = select(samples.begin(), rank_50, samples.end());
+  const auto q2      = *q2_iter;
+
+  const auto q1 = rank_25 == rank_50 ? q2 : *select(samples.begin(), rank_25, q2_iter);
+  const auto q3 = rank_75 == rank_50 ? q2
+                                     : *select(q2_iter + 1, rank_75 - rank_50 - 1, samples.end());
+
+  return {q1, q2, q3};
+}
+
+template <typename Iter, typename ValueType = typename std::iterator_traits<Iter>::value_type>
+quartiles_t<ValueType> compute_quartiles(Iter first, Iter last)
+{
+  static_assert(std::is_floating_point_v<ValueType>);
+
+  std::vector<ValueType> samples(first, last);
+  constexpr std::size_t selection_threshold = 4096;
+
+  if (samples.size() >= selection_threshold)
+  {
+    return compute_quartiles_by_selection(std::move(samples));
+  }
+
+  return compute_quartiles_by_sorting(std::move(samples));
+}
+
 // Returns nullopt for invalid inputs. A +inf result is allowed: it represents
 // unbounded relative dispersion rather than missing data.
 inline std::optional<nvbench::float64_t> compute_relative_dispersion(nvbench::float64_t dispersion,
@@ -213,6 +331,35 @@ inline std::optional<nvbench::float64_t> compute_relative_dispersion(nvbench::fl
 
   return dispersion / center;
 }
+
+inline std::optional<nvbench::float64_t>
+compute_relative_interquartile_range(nvbench::float64_t first_quartile,
+                                     nvbench::float64_t median,
+                                     nvbench::float64_t third_quartile)
+{
+  const auto interquartile_range = third_quartile - first_quartile;
+  if (!std::isfinite(interquartile_range))
+  {
+    return std::nullopt;
+  }
+
+  return compute_relative_dispersion(interquartile_range, median);
+}
+
+// Returns nullopt until there are enough samples for a meaningful robust noise estimate.
+inline std::optional<nvbench::float64_t> compute_robust_noise(nvbench::int64_t num_samples,
+                                                              nvbench::float64_t first_quartile,
+                                                              nvbench::float64_t median,
+                                                              nvbench::float64_t third_quartile)
+{
+  if (num_samples < min_samples_for_noise_estimate)
+  {
+    return std::nullopt;
+  }
+
+  return compute_relative_interquartile_range(first_quartile, median, third_quartile);
+}
+
 /**
  * Computes linear regression and returns the slope and intercept
  *

--- a/testing/statistics.cu
+++ b/testing/statistics.cu
@@ -319,7 +319,7 @@ void test_relative_interquartile_range()
   {
     const auto actual = statistics::compute_relative_dispersion(6.0, 3.0);
     ASSERT(actual);
-    ASSERT(std::abs(*actual - 2.0) < 0.001);
+    ASSERT(is_close(*actual, 2.0));
   }
 
   {
@@ -355,7 +355,7 @@ void test_relative_interquartile_range()
   {
     const auto actual = statistics::compute_relative_interquartile_range(2.0, 4.0, 6.0);
     ASSERT(actual);
-    ASSERT(std::abs(*actual - 1.0) < 0.001);
+    ASSERT(is_close(*actual, 1.0));
   }
 
   {
@@ -371,7 +371,7 @@ void test_relative_interquartile_range()
     const auto actual =
       statistics::compute_robust_noise(statistics::min_samples_for_noise_estimate, 2.0, 4.0, 6.0);
     ASSERT(actual);
-    ASSERT(std::abs(*actual - 1.0) < 0.001);
+    ASSERT(is_close(*actual, 1.0));
   }
 
   {

--- a/testing/statistics.cu
+++ b/testing/statistics.cu
@@ -20,7 +20,11 @@
 #include <nvbench/types.cuh>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <iterator>
+#include <limits>
+#include <sstream>
 #include <vector>
 
 #include "test_asserts.cuh"
@@ -41,6 +45,22 @@ inline bool is_close(nvbench::float64_t actual,
 inline bool is_close(nvbench::float64_t actual, nvbench::float64_t expected)
 {
   return is_close(actual, expected, default_atol, default_rtol);
+}
+
+template <typename T>
+void assert_quartiles_equal(statistics::quartiles_t<T> actual, statistics::quartiles_t<T> expected)
+{
+  ASSERT(actual.first_quartile == expected.first_quartile);
+  ASSERT(actual.median == expected.median);
+  ASSERT(actual.third_quartile == expected.third_quartile);
+}
+
+template <typename T>
+void assert_quartiles_nan(statistics::quartiles_t<T> actual)
+{
+  ASSERT(std::isnan(actual.first_quartile));
+  ASSERT(std::isnan(actual.median));
+  ASSERT(std::isnan(actual.third_quartile));
 }
 
 void test_mean()
@@ -186,6 +206,197 @@ void test_std()
   }
 }
 
+void test_percentiles()
+{
+  {
+    const std::vector<nvbench::float64_t> data{40.0, 10.0, 30.0, 20.0};
+    const auto actual = statistics::compute_percentiles(data.cbegin(),
+                                                        data.cend(),
+                                                        std::array<int, 5>{0, 25, 50, 75, 100});
+    const std::array<nvbench::float64_t, 5> expected{10.0, 20.0, 30.0, 30.0, 40.0};
+    ASSERT(actual == expected);
+  }
+
+  {
+    const std::vector<nvbench::float64_t> data{42.0};
+    const auto actual =
+      statistics::compute_percentiles(data.cbegin(), data.cend(), std::array<int, 3>{25, 50, 75});
+    const std::array<nvbench::float64_t, 3> expected{42.0, 42.0, 42.0};
+    ASSERT(actual == expected);
+  }
+
+  {
+    const std::vector<nvbench::float64_t> data{40.0, 10.0, 30.0, 20.0};
+    const auto actual =
+      statistics::compute_percentiles(data.cbegin(), data.cend(), std::array<int, 3>{25, 50, 75});
+    const std::array<nvbench::float64_t, 3> expected{20.0, 30.0, 30.0};
+    ASSERT(actual == expected);
+  }
+
+  {
+    std::istringstream data{"40 10 30 20"};
+    const auto actual =
+      statistics::compute_percentiles(std::istream_iterator<nvbench::float64_t>{data},
+                                      std::istream_iterator<nvbench::float64_t>{},
+                                      std::array<int, 3>{25, 50, 75});
+    const std::array<nvbench::float64_t, 3> expected{20.0, 30.0, 30.0};
+    ASSERT(actual == expected);
+  }
+
+  {
+    const std::vector<nvbench::float64_t> data{10.0, 20.0, 30.0, 40.0};
+    const auto actual =
+      statistics::compute_percentiles(data.cbegin(), data.cend(), std::array<int, 2>{-25, 125});
+    const std::array<nvbench::float64_t, 2> expected{10.0, 40.0};
+    ASSERT(actual == expected);
+  }
+
+  {
+    const std::vector<nvbench::float64_t> data;
+    const auto actual =
+      statistics::compute_percentiles(data.cbegin(), data.cend(), std::array<int, 3>{25, 50, 75});
+    ASSERT(std::isnan(actual[0]));
+    ASSERT(std::isnan(actual[1]));
+    ASSERT(std::isnan(actual[2]));
+  }
+}
+
+void test_quartiles()
+{
+  {
+    const std::vector<nvbench::float64_t> data{40.0, 10.0, 30.0, 20.0};
+    const auto sorting   = statistics::compute_quartiles_by_sorting(data);
+    const auto selection = statistics::compute_quartiles_by_selection(data);
+    assert_quartiles_equal(selection, sorting);
+    assert_quartiles_equal(sorting, statistics::quartiles_t<nvbench::float64_t>{20.0, 30.0, 30.0});
+  }
+
+  {
+    const std::vector<nvbench::float64_t> data{5.0, -1.0, 5.0, 2.0, 9.0, 2.0, 5.0};
+    const auto sorting   = statistics::compute_quartiles_by_sorting(data);
+    const auto selection = statistics::compute_quartiles_by_selection(data);
+    assert_quartiles_equal(selection, sorting);
+  }
+
+  {
+    const std::vector<nvbench::float64_t> data{42.0};
+    assert_quartiles_equal(statistics::compute_quartiles(data.cbegin(), data.cend()),
+                           statistics::quartiles_t<nvbench::float64_t>{42.0, 42.0, 42.0});
+  }
+
+  {
+    const std::vector<nvbench::float64_t> data;
+    assert_quartiles_nan(statistics::compute_quartiles(data.cbegin(), data.cend()));
+  }
+
+  {
+    std::istringstream data{"40 10 30 20"};
+    const auto actual =
+      statistics::compute_quartiles(std::istream_iterator<nvbench::float64_t>{data},
+                                    std::istream_iterator<nvbench::float64_t>{});
+    assert_quartiles_equal(actual, statistics::quartiles_t<nvbench::float64_t>{20.0, 30.0, 30.0});
+  }
+
+  // test around threshold when public API switches between implementations
+  for (const auto n : std::array<std::size_t, 3>{4095, 4096, 4097})
+  {
+    std::vector<nvbench::float64_t> data(n);
+    for (std::size_t i = 0; i < data.size(); ++i)
+    {
+      data[i] = static_cast<nvbench::float64_t>((i * 37) % data.size());
+    }
+
+    const auto public_api = statistics::compute_quartiles(data.cbegin(), data.cend());
+    const auto sorting    = statistics::compute_quartiles_by_sorting(data);
+    const auto selection  = statistics::compute_quartiles_by_selection(data);
+    assert_quartiles_equal(selection, sorting);
+    assert_quartiles_equal(public_api, sorting);
+  }
+}
+
+void test_relative_interquartile_range()
+{
+  {
+    const auto actual = statistics::compute_relative_dispersion(6.0, 3.0);
+    ASSERT(actual);
+    ASSERT(std::abs(*actual - 2.0) < 0.001);
+  }
+
+  {
+    const auto actual = statistics::compute_relative_dispersion(1.0, 0.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual = statistics::compute_relative_dispersion(1.0, -1.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual =
+      statistics::compute_relative_dispersion(std::numeric_limits<nvbench::float64_t>::quiet_NaN(),
+                                              1.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual = statistics::compute_relative_dispersion(-1.0, 1.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual =
+      statistics::compute_relative_dispersion(std::numeric_limits<nvbench::float64_t>::infinity(),
+                                              1.0);
+    ASSERT(actual);
+    ASSERT(!std::isfinite(*actual));
+  }
+
+  {
+    const auto actual = statistics::compute_relative_interquartile_range(2.0, 4.0, 6.0);
+    ASSERT(actual);
+    ASSERT(std::abs(*actual - 1.0) < 0.001);
+  }
+
+  {
+    const auto actual =
+      statistics::compute_robust_noise(statistics::min_samples_for_noise_estimate - 1,
+                                       2.0,
+                                       4.0,
+                                       6.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual =
+      statistics::compute_robust_noise(statistics::min_samples_for_noise_estimate, 2.0, 4.0, 6.0);
+    ASSERT(actual);
+    ASSERT(std::abs(*actual - 1.0) < 0.001);
+  }
+
+  {
+    const auto actual = statistics::compute_relative_interquartile_range(0.0, 0.0, 1.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual = statistics::compute_relative_interquartile_range(
+      0.0,
+      1.0,
+      std::numeric_limits<nvbench::float64_t>::infinity());
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual = statistics::compute_relative_interquartile_range(
+      0.0,
+      std::numeric_limits<nvbench::float64_t>::min(),
+      std::numeric_limits<nvbench::float64_t>::max());
+    ASSERT(actual);
+    ASSERT(!std::isfinite(*actual));
+  }
+}
+
 void test_lin_regression()
 {
   {
@@ -261,6 +472,9 @@ int main()
   test_mean();
   test_online_mean_variance();
   test_std();
+  test_percentiles();
+  test_quartiles();
+  test_relative_interquartile_range();
   test_lin_regression();
   test_r2();
   test_slope_conversion();

--- a/testing/statistics.cu
+++ b/testing/statistics.cu
@@ -261,40 +261,25 @@ void test_percentiles()
   }
 }
 
-void test_quartiles()
+void test_quartiles_methods_agree()
 {
   {
     const std::vector<nvbench::float64_t> data{40.0, 10.0, 30.0, 20.0};
-    const auto sorting   = statistics::compute_quartiles_by_sorting(data);
-    const auto selection = statistics::compute_quartiles_by_selection(data);
+    const auto sorting =
+      statistics::compute_quartiles_by_sorting(std::vector<nvbench::float64_t>(data));
+    const auto selection =
+      statistics::compute_quartiles_by_selection(std::vector<nvbench::float64_t>(data));
     assert_quartiles_equal(selection, sorting);
     assert_quartiles_equal(sorting, statistics::quartiles_t<nvbench::float64_t>{20.0, 30.0, 30.0});
   }
 
   {
     const std::vector<nvbench::float64_t> data{5.0, -1.0, 5.0, 2.0, 9.0, 2.0, 5.0};
-    const auto sorting   = statistics::compute_quartiles_by_sorting(data);
-    const auto selection = statistics::compute_quartiles_by_selection(data);
+    const auto sorting =
+      statistics::compute_quartiles_by_sorting(std::vector<nvbench::float64_t>(data));
+    const auto selection =
+      statistics::compute_quartiles_by_selection(std::vector<nvbench::float64_t>(data));
     assert_quartiles_equal(selection, sorting);
-  }
-
-  {
-    const std::vector<nvbench::float64_t> data{42.0};
-    assert_quartiles_equal(statistics::compute_quartiles(data.cbegin(), data.cend()),
-                           statistics::quartiles_t<nvbench::float64_t>{42.0, 42.0, 42.0});
-  }
-
-  {
-    const std::vector<nvbench::float64_t> data;
-    assert_quartiles_nan(statistics::compute_quartiles(data.cbegin(), data.cend()));
-  }
-
-  {
-    std::istringstream data{"40 10 30 20"};
-    const auto actual =
-      statistics::compute_quartiles(std::istream_iterator<nvbench::float64_t>{data},
-                                    std::istream_iterator<nvbench::float64_t>{});
-    assert_quartiles_equal(actual, statistics::quartiles_t<nvbench::float64_t>{20.0, 30.0, 30.0});
   }
 
   // test around threshold when public API switches between implementations
@@ -307,14 +292,40 @@ void test_quartiles()
     }
 
     const auto public_api = statistics::compute_quartiles(data.cbegin(), data.cend());
-    const auto sorting    = statistics::compute_quartiles_by_sorting(data);
-    const auto selection  = statistics::compute_quartiles_by_selection(data);
+    const auto sorting =
+      statistics::compute_quartiles_by_sorting(std::vector<nvbench::float64_t>(data));
+    const auto selection =
+      statistics::compute_quartiles_by_selection(std::vector<nvbench::float64_t>(data));
     assert_quartiles_equal(selection, sorting);
     assert_quartiles_equal(public_api, sorting);
   }
 }
 
-void test_relative_interquartile_range()
+void test_quartiles()
+{
+  // special case inputs produce expected results
+  {
+    const std::vector<nvbench::float64_t> data{42.0};
+    assert_quartiles_equal(statistics::compute_quartiles(data.cbegin(), data.cend()),
+                           statistics::quartiles_t<nvbench::float64_t>{42.0, 42.0, 42.0});
+  }
+
+  {
+    const std::vector<nvbench::float64_t> data;
+    assert_quartiles_nan(statistics::compute_quartiles(data.cbegin(), data.cend()));
+  }
+
+  // works with input iterators
+  {
+    std::istringstream data{"40 10 30 20"};
+    const auto actual =
+      statistics::compute_quartiles(std::istream_iterator<nvbench::float64_t>{data},
+                                    std::istream_iterator<nvbench::float64_t>{});
+    assert_quartiles_equal(actual, statistics::quartiles_t<nvbench::float64_t>{20.0, 30.0, 30.0});
+  }
+}
+
+void test_compute_relative_dispersion_nominal_input()
 {
   {
     const auto actual = statistics::compute_relative_dispersion(6.0, 3.0);
@@ -322,6 +333,18 @@ void test_relative_interquartile_range()
     ASSERT(is_close(*actual, 2.0));
   }
 
+  // infinite dispersion is tolerated
+  {
+    const auto actual =
+      statistics::compute_relative_dispersion(std::numeric_limits<nvbench::float64_t>::infinity(),
+                                              1.0);
+    ASSERT(actual);
+    ASSERT(!std::isfinite(*actual));
+  }
+}
+
+void test_compute_relative_dispersion_invalid_inputs()
+{
   {
     const auto actual = statistics::compute_relative_dispersion(1.0, 0.0);
     ASSERT(!actual);
@@ -343,21 +366,10 @@ void test_relative_interquartile_range()
     const auto actual = statistics::compute_relative_dispersion(-1.0, 1.0);
     ASSERT(!actual);
   }
+}
 
-  {
-    const auto actual =
-      statistics::compute_relative_dispersion(std::numeric_limits<nvbench::float64_t>::infinity(),
-                                              1.0);
-    ASSERT(actual);
-    ASSERT(!std::isfinite(*actual));
-  }
-
-  {
-    const auto actual = statistics::compute_relative_interquartile_range(2.0, 4.0, 6.0);
-    ASSERT(actual);
-    ASSERT(is_close(*actual, 1.0));
-  }
-
+void test_compute_robust_noise()
+{
   {
     const auto actual =
       statistics::compute_robust_noise(statistics::min_samples_for_noise_estimate - 1,
@@ -370,6 +382,15 @@ void test_relative_interquartile_range()
   {
     const auto actual =
       statistics::compute_robust_noise(statistics::min_samples_for_noise_estimate, 2.0, 4.0, 6.0);
+    ASSERT(actual);
+    ASSERT(is_close(*actual, 1.0));
+  }
+}
+
+void test_relative_interquartile_range()
+{
+  {
+    const auto actual = statistics::compute_relative_interquartile_range(2.0, 4.0, 6.0);
     ASSERT(actual);
     ASSERT(is_close(*actual, 1.0));
   }
@@ -474,7 +495,11 @@ int main()
   test_std();
   test_percentiles();
   test_quartiles();
+  test_quartiles_methods_agree();
+  test_compute_relative_dispersion_nominal_input();
+  test_compute_relative_dispersion_invalid_inputs();
   test_relative_interquartile_range();
+  test_compute_robust_noise();
   test_lin_regression();
   test_r2();
   test_slope_conversion();


### PR DESCRIPTION
1. Add statistics utilities to compute quartiles using nearest rank method and tests.
   - sort-based computation for shorter datasets ( < 4096 `float64_t` elements)
   - selection-based computation for larger arrays (to keep overall complexity O(n))

2. Add quartile information for `"nv/cold/cpu/time"`, `"nv/cold/gpu/time"`, and `"nv/cpy_only/time"` summaries.
   Tags added are:
      - `"*/median"` : median
      - `"*/q1"`:  first quartile
      - `"*/q3"`: third quartile
      - `"*/ir/absolute"`: absolute interquartile range = $Q_3 - Q_1$
      - `"*/ir/relative"`: relative interquartile range, $(Q_3 - Q_1) / Q_2$.

3. <strike>Make `"*/mean"` and `"*/stdev/relative"` hidden, replaced by `"*/median"` and `"*/ir/relative"`.</strike>

Closes #342 .

<strike>
Technically, due to change described in item 3, `"CPU Time"`/`"Noise"` as well as `"GPU Time"`/`"Noise"` entries in the summary tables output by NVBench instrumented benchmarks change from being based on (`mean`, `standard_dev`) to being based on (`median`, `interquartile_range`).

This change only affects printed summaries, i.e., `--markdown` and `--csv` outputs.  Behavior of `nvbench_compare` won't change as JSON data still contains mean and standard deviation entries, albeit hidden by default. 
</strike>

---

#### Update

The change implementing item 3 has been reverted. See comments below.