### PR TITLE
Build and test cuda-bench wheels for Python 3.10-3.14

### DIFF
--- a/.github/workflows/build-and-test-python-wheels.yml
+++ b/.github/workflows/build-and-test-python-wheels.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout repository
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         cuda: ['12', '13']
-        python: ['3.10', '3.11', '3.12', '3.13']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout repository
@@ -72,24 +72,9 @@ jobs:
 
       - name: Test wheel
         run: |
-          # Use the same rapidsai/ci-wheel Docker image as build
-          if [[ "${{ matrix.cuda }}" == "12" ]]; then
-            cuda_full_version="12.9.1"
-            cuda_extra="cu12"
-          else
-            cuda_full_version="13.0.1"
-            cuda_extra="cu13"
-          fi
-
-          docker run --rm \
-            --workdir /workspace \
-            --gpus all \
-            --mount type=bind,source=$(pwd),target=/workspace/ \
-            --env py_version=${{ matrix.python }} \
-            --env cuda_version=${{ matrix.cuda }} \
-            --env cuda_extra="${cuda_extra}" \
-            rapidsai/ci-wheel:25.12-cuda${cuda_full_version}-rockylinux8-py${{ matrix.python }} \
-            /workspace/ci/test_cuda_bench_inner.sh
+          bash ci/test_cuda_bench.sh \
+            -py-version ${{ matrix.python }} \
+            -cuda-version ${{ matrix.cuda }}
 
   verify-workflow:
     name: Verify all builds and tests succeeded

--- a/ci/build_multi_cuda_wheel.sh
+++ b/ci/build_multi_cuda_wheel.sh
@@ -28,13 +28,14 @@ ci_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage="Usage: $0 -py-version <python_version> [additional options...]"
 
+# shellcheck source=ci/util/python/common_arg_parser.sh
 source "$ci_dir/util/python/common_arg_parser.sh"
 parse_python_args "$@"
 
 # Check if py_version was provided (this script requires it)
 require_py_version "$usage" || exit 1
 
-echo "Docker socket: " $(ls /var/run/docker.sock)
+echo "Docker socket: $(ls /var/run/docker.sock)"
 
 # Set HOST_WORKSPACE if not already set (for local runs)
 if [[ -z "${HOST_WORKSPACE:-}" ]]; then
@@ -48,9 +49,6 @@ fi
 # We build separate wheels using separate containers for each CUDA version,
 # then merge them into a single wheel.
 
-readonly cuda12_version=12.9.1
-readonly cuda13_version=13.0.1
-readonly devcontainer_version=25.12
 readonly devcontainer_distro=rockylinux8
 
 if [[ "$(uname -m)" == "aarch64" ]]; then
@@ -59,26 +57,53 @@ else
   readonly host_arch_suffix=""
 fi
 
-readonly cuda12_image=rapidsai/ci-wheel:${devcontainer_version}-cuda${cuda12_version}-${devcontainer_distro}-py${py_version}${host_arch_suffix}
-readonly cuda13_image=rapidsai/ci-wheel:${devcontainer_version}-cuda${cuda13_version}-${devcontainer_distro}-py${py_version}${host_arch_suffix}
+rapids_ci_wheel_version() {
+  if [[ "${py_version}" == "3.10" ]]; then
+    echo "25.12"
+  else
+    echo "26.08"
+  fi
+}
+
+ci_wheel_image() {
+  local ctk="$1"
+  local rapids_ci_wheel_version=""
+  local cuda_version=""
+
+  case "${ctk}" in
+    12)
+      cuda_version="12.9.1"
+      ;;
+    13)
+      cuda_version="13.0.2"
+      ;;
+    *)
+      echo "Error: Unsupported CUDA version: ${ctk}" >&2
+      return 1
+      ;;
+  esac
+
+  rapids_ci_wheel_version="$(rapids_ci_wheel_version)"
+  echo "rapidsai/ci-wheel:${rapids_ci_wheel_version}-cuda${cuda_version}-${devcontainer_distro}-py${py_version}${host_arch_suffix}"
+}
 
 mkdir -p wheelhouse
 
 for ctk in 12 13; do
-  image=$(eval echo \$cuda${ctk}_image)
+  image="$(ci_wheel_image "${ctk}")"
   echo "::group::⚒️ Building CUDA ${ctk} wheel on ${image}"
   (
     set -x
-    docker pull $image
+    docker pull "${image}"
     docker run --rm -i \
         --workdir /workspace/python \
-        --mount type=bind,source=${HOST_WORKSPACE},target=/workspace/ \
-        --env py_version=${py_version} \
-        $image \
+        --mount "type=bind,source=${HOST_WORKSPACE},target=/workspace/" \
+        --env "py_version=${py_version}" \
+        "${image}" \
         /workspace/ci/build_cuda_bench_wheel_for_cuda.sh
     # Prevent GHA runners from exhausting available storage with leftover images:
     if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
-      docker rmi -f $image
+      docker rmi -f "${image}"
     fi
   )
   echo "::endgroup::"

--- a/ci/pyenv_helper.sh
+++ b/ci/pyenv_helper.sh
@@ -2,6 +2,27 @@
 
 setup_python_env() {
     local py_version=$1
+    local python_bin=""
+    local python_bin_quoted=""
+    local python_shim_dir=""
+
+    if command -v "python${py_version}" &> /dev/null; then
+        python_bin="$(command -v "python${py_version}")"
+    elif command -v python &> /dev/null &&
+         [[ "$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" == "${py_version}" ]]; then
+        python_bin="$(command -v python)"
+    fi
+
+    if [[ -n "${python_bin}" ]]; then
+        python_shim_dir="${TMPDIR:-/tmp}/nvbench-python-${py_version}/bin"
+        mkdir -p "${python_shim_dir}"
+        python_bin_quoted="$(printf '%q' "${python_bin}")"
+        printf '#!/bin/bash\nexec %s "$@"\n' "${python_bin_quoted}" > "${python_shim_dir}/python"
+        chmod +x "${python_shim_dir}/python"
+        export PATH="${python_shim_dir}:$PATH"
+        python -m pip install --upgrade pip
+        return 0
+    fi
 
     # check if pyenv is installed
     if ! command -v pyenv &> /dev/null; then

--- a/ci/test_cuda_bench.sh
+++ b/ci/test_cuda_bench.sh
@@ -5,6 +5,7 @@ ci_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage="Usage: $0 -py-version <python_version> -cuda-version <cuda_version>"
 
+# shellcheck source=ci/util/python/common_arg_parser.sh
 source "$ci_dir/util/python/common_arg_parser.sh"
 
 # Parse arguments including CUDA version
@@ -40,44 +41,48 @@ if [[ -z "$cuda_version" ]]; then
     exit 1
 fi
 
-# Map cuda_version to full version and set CUDA extra
+# Use the same rapidsai/ci-wheel images as the build
+readonly devcontainer_distro=rockylinux8
+
+if [[ "${py_version}" == "3.10" ]]; then
+    rapids_ci_wheel_version="25.12"
+else
+    rapids_ci_wheel_version="26.08"
+fi
+
 if [[ "$cuda_version" == "12" ]]; then
     cuda_full_version="12.9.1"
     cuda_extra="cu12"
 elif [[ "$cuda_version" == "13" ]]; then
-    cuda_full_version="13.0.1"
+    cuda_full_version="13.0.2"
     cuda_extra="cu13"
 else
     echo "Error: Unsupported CUDA version: $cuda_version"
     exit 1
 fi
 
-# Use the same rapidsai/ci-wheel images as the build
-readonly devcontainer_version=25.12
-readonly devcontainer_distro=rockylinux8
-
 if [[ "$(uname -m)" == "aarch64" ]]; then
-  readonly cuda_image=rapidsai/ci-wheel:${devcontainer_version}-cuda${cuda_full_version}-${devcontainer_distro}-py${py_version}-arm64
+  readonly cuda_image=rapidsai/ci-wheel:${rapids_ci_wheel_version}-cuda${cuda_full_version}-${devcontainer_distro}-py${py_version}-arm64
 else
-  readonly cuda_image=rapidsai/ci-wheel:${devcontainer_version}-cuda${cuda_full_version}-${devcontainer_distro}-py${py_version}
+  readonly cuda_image=rapidsai/ci-wheel:${rapids_ci_wheel_version}-cuda${cuda_full_version}-${devcontainer_distro}-py${py_version}
 fi
 
 echo "::group::🧪 Testing CUDA ${cuda_version} wheel on ${cuda_image}"
 (
   set -x
-  docker pull $cuda_image
+  docker pull "${cuda_image}"
   docker run --rm -i \
       --workdir /workspace \
       --gpus all \
-      --mount type=bind,source=$(pwd),target=/workspace/ \
-      --env py_version=${py_version} \
-      --env cuda_version=${cuda_version} \
-      --env cuda_extra="${cuda_extra}" \
-      $cuda_image \
+      --mount "type=bind,source=$(pwd),target=/workspace/" \
+      --env "py_version=${py_version}" \
+      --env "cuda_version=${cuda_version}" \
+      --env "cuda_extra=${cuda_extra}" \
+      "${cuda_image}" \
       /workspace/ci/test_cuda_bench_inner.sh
   # Prevent GHA runners from exhausting available storage with leftover images:
   if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
-    docker rmi -f $cuda_image
+    docker rmi -f "${cuda_image}" || true
   fi
 )
 echo "::endgroup::"

--- a/ci/test_cuda_bench_inner.sh
+++ b/ci/test_cuda_bench_inner.sh
@@ -7,13 +7,16 @@ set -euo pipefail
 # Install GCC 13 toolset (needed for builds that might happen during testing)
 /workspace/ci/util/retry.sh 5 30 dnf -y install gcc-toolset-13-gcc gcc-toolset-13-gcc-c++
 echo -e "#!/bin/bash\nsource /opt/rh/gcc-toolset-13/enable" >/etc/profile.d/enable_devtools.sh
+# shellcheck source=/dev/null
 source /etc/profile.d/enable_devtools.sh
 
-# Set up Python environment (only if not already available)
+: "${py_version:?py_version must be set}"
+: "${cuda_version:?cuda_version must be set}"
+
+# Set up Python environment.
+# shellcheck source=ci/pyenv_helper.sh
 source /workspace/ci/pyenv_helper.sh
-if ! command -v python${py_version} &> /dev/null; then
-    setup_python_env "${py_version}"
-fi
+setup_python_env "${py_version}"
 
 # Upgrade pip
 python -m pip install --upgrade pip
@@ -26,9 +29,9 @@ WHEELHOUSE_DIR="/workspace/wheelhouse"
 
 # Find the cuda-bench wheel (multi-CUDA wheel)
 # Prefer manylinux wheels, fall back to any wheel
-CUDA_BENCH_WHEEL_PATH="$(ls ${WHEELHOUSE_DIR}/cuda_bench-*manylinux*.whl 2>/dev/null | head -1)"
+CUDA_BENCH_WHEEL_PATH="$(find "${WHEELHOUSE_DIR}" -maxdepth 1 -name 'cuda_bench-*manylinux*.whl' -print -quit)"
 if [[ -z "$CUDA_BENCH_WHEEL_PATH" ]]; then
-    CUDA_BENCH_WHEEL_PATH="$(ls ${WHEELHOUSE_DIR}/cuda_bench-*.whl 2>/dev/null | head -1)"
+    CUDA_BENCH_WHEEL_PATH="$(find "${WHEELHOUSE_DIR}" -maxdepth 1 -name 'cuda_bench-*.whl' -print -quit)"
 fi
 
 if [[ -z "$CUDA_BENCH_WHEEL_PATH" ]]; then
@@ -38,8 +41,7 @@ if [[ -z "$CUDA_BENCH_WHEEL_PATH" ]]; then
     exit 1
 fi
 
-# Determine which CUDA extra to install (defaults to cu12 if not specified)
-CUDA_EXTRA="${cuda_extra:-cu${cuda_version}}"
+# Determine which CUDA extra to install.
 TEST_EXTRA="test-cu${cuda_version}"
 
 echo "Installing wheel: $CUDA_BENCH_WHEEL_PATH with extras: ${TEST_EXTRA}"


### PR DESCRIPTION
Add building of `cuda.bench` wheel for Python 3.14.
 
  - Use RAPIDS AI ci-wheel image 26.08 with CTK12.9.1/13.0.2 for Python versions 3.11-3.14
  - Use ci-wheel image 25.12 with CTK 12.9.1/13.0.2 for Python version 3.10

The reason Python 3.10 is singled out is that 26.08 image no longer supports 3.10. It is likely because 3.10 EOL is Oct. 31, 2026

Closes #378 