### PR TITLE
Rename IR to IQR in */ir/absolute and */ir/relative tags

### DIFF
--- a/nvbench/detail/measure_cold.cu
+++ b/nvbench/detail/measure_cold.cu
@@ -295,12 +295,12 @@ void measure_cold_base::generate_summaries()
     summ.set_string("hide", "Hidden by default.");
   }
   {
-    auto &summ = m_state.add_summary("nv/cold/time/cpu/ir/absolute");
+    auto &summ = m_state.add_summary("nv/cold/time/cpu/iqr/absolute");
     summ.set_string("name", "IQR");
     summ.set_string("hint", "duration");
     summ.set_string("description", "Interquartile range of isolated kernel execution CPU times");
-    const auto cpu_time_ir = cpu_time_third_quartile - cpu_time_first_quartile;
-    summ.set_float64("value", cpu_time_ir);
+    const auto cpu_time_iqr = cpu_time_third_quartile - cpu_time_first_quartile;
+    summ.set_float64("value", cpu_time_iqr);
     summ.set_string("hide", "Hidden by default.");
   }
   const auto cpu_robust_noise = statistics::compute_robust_noise(m_total_samples,
@@ -309,7 +309,7 @@ void measure_cold_base::generate_summaries()
                                                                  cpu_time_third_quartile);
   if (cpu_robust_noise)
   {
-    auto &summ = m_state.add_summary("nv/cold/time/cpu/ir/relative");
+    auto &summ = m_state.add_summary("nv/cold/time/cpu/iqr/relative");
     summ.set_string("name", "Rel IQR");
     summ.set_string("hint", "percentage");
     summ.set_string("description",
@@ -401,12 +401,12 @@ void measure_cold_base::generate_summaries()
     summ.set_string("hide", "Hidden by default.");
   }
   {
-    auto &summ = m_state.add_summary("nv/cold/time/gpu/ir/absolute");
+    auto &summ = m_state.add_summary("nv/cold/time/gpu/iqr/absolute");
     summ.set_string("name", "IQR");
     summ.set_string("hint", "duration");
     summ.set_string("description", "Interquartile range of isolated kernel execution GPU times");
-    const auto cuda_time_ir = cuda_time_third_quartile - cuda_time_first_quartile;
-    summ.set_float64("value", cuda_time_ir);
+    const auto cuda_time_iqr = cuda_time_third_quartile - cuda_time_first_quartile;
+    summ.set_float64("value", cuda_time_iqr);
     summ.set_string("hide", "Hidden by default.");
   }
   const auto cuda_robust_noise = statistics::compute_robust_noise(m_total_samples,
@@ -415,7 +415,7 @@ void measure_cold_base::generate_summaries()
                                                                   cuda_time_third_quartile);
   if (cuda_robust_noise)
   {
-    auto &summ = m_state.add_summary("nv/cold/time/gpu/ir/relative");
+    auto &summ = m_state.add_summary("nv/cold/time/gpu/iqr/relative");
     summ.set_string("name", "Rel IQR");
     summ.set_string("hint", "percentage");
     summ.set_string("description",

--- a/nvbench/detail/measure_cpu_only.cxx
+++ b/nvbench/detail/measure_cpu_only.cxx
@@ -205,13 +205,13 @@ void measure_cpu_only_base::generate_summaries()
     summ.set_string("hide", "Hidden by default.");
   }
   {
-    auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/ir/absolute");
+    auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/iqr/absolute");
     summ.set_string("name", "IQR");
     summ.set_string("hint", "duration");
     summ.set_string("description",
                     "Interquartile range of CPU times of isolated kernel executions");
-    const auto cpu_ir = cpu_third_quartile - cpu_first_quartile;
-    summ.set_float64("value", cpu_ir);
+    const auto cpu_iqr = cpu_third_quartile - cpu_first_quartile;
+    summ.set_float64("value", cpu_iqr);
     summ.set_string("hide", "Hidden by default.");
   }
   const auto cpu_robust_noise = statistics::compute_robust_noise(m_total_samples,
@@ -220,7 +220,7 @@ void measure_cpu_only_base::generate_summaries()
                                                                  cpu_third_quartile);
   if (cpu_robust_noise)
   {
-    auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/ir/relative");
+    auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/iqr/relative");
     summ.set_string("name", "Rel IQR");
     summ.set_string("hint", "percentage");
     summ.set_string("description",


### PR DESCRIPTION
This is a follow up to #379. 

It follows up with @fbusato feedback to replace using IR abbreviation used to represent interquartile-range with more conventional IQR acronym. It was changed in the "name" and "description" values, but not in the tag name itself.

This PR replaced it in the tag names too, and renames variables that used the abbreviation in their names.

