### PR TITLE
Harden quartile statistics and measurement timeout handling

### DIFF
--- a/nvbench/detail/measure_cold.cu
+++ b/nvbench/detail/measure_cold.cu
@@ -302,14 +302,13 @@ void measure_cold_base::generate_summaries()
 
   const auto cpu_stdev_noise =
     statistics::compute_standard_deviation_noise(m_total_samples, cpu_stdev, cpu_mean);
-  if (cpu_stdev_noise)
   {
     auto &summ = m_state.add_summary("nv/cold/time/cpu/stdev/relative");
     summ.set_string("name", "Noise");
     summ.set_string("hint", "percentage");
     summ.set_string("description",
                     "Relative standard deviation of isolated kernel execution CPU times");
-    summ.set_float64("value", *cpu_stdev_noise);
+    summ.set_float64("value", statistics::stdev_noise_or_sentinel(cpu_stdev_noise));
   }
 
   const auto [cpu_time_first_quartile, cpu_time_median, cpu_time_third_quartile] =
@@ -409,14 +408,13 @@ void measure_cold_base::generate_summaries()
 
   const auto cuda_stdev_noise =
     statistics::compute_standard_deviation_noise(m_total_samples, cuda_stdev, cuda_mean);
-  if (cuda_stdev_noise)
   {
     auto &summ = m_state.add_summary("nv/cold/time/gpu/stdev/relative");
     summ.set_string("name", "Noise");
     summ.set_string("hint", "percentage");
     summ.set_string("description",
                     "Relative standard deviation of isolated kernel execution GPU times");
-    summ.set_float64("value", *cuda_stdev_noise);
+    summ.set_float64("value", statistics::stdev_noise_or_sentinel(cuda_stdev_noise));
   }
 
   const auto [cuda_time_first_quartile, cuda_time_median, cuda_time_third_quartile] =

--- a/nvbench/detail/measure_cold.cu
+++ b/nvbench/detail/measure_cold.cu
@@ -201,6 +201,71 @@ bool measure_cold_base::is_finished()
 
 void measure_cold_base::run_trials_epilogue() { m_walltime_timer.stop(); }
 
+void measure_cold_base::log_timeout_warnings(nvbench::printer_base &printer,
+                                             std::optional<nvbench::float64_t> cuda_stdev_noise)
+{
+  if (!m_max_time_exceeded)
+  {
+    return;
+  }
+
+  const auto timeout = m_walltime_timer.get_duration();
+
+  auto get_param = [this](std::optional<nvbench::float64_t> &param, const std::string &name) {
+    if (m_criterion_params.has_value(name))
+    {
+      param = m_criterion_params.get_float64(name);
+    }
+  };
+
+  std::optional<nvbench::float64_t> max_noise;
+  get_param(max_noise, "max-noise");
+
+  std::optional<nvbench::float64_t> min_time;
+  get_param(min_time, "min-time");
+
+  const auto enough_samples_for_noise =
+    statistics::has_enough_samples_for_noise_estimate(m_total_samples);
+  if (max_noise && !enough_samples_for_noise)
+  {
+    printer.log(nvbench::log_level::warn,
+                fmt::format("Current measurement timed out ({:0.2f}s) "
+                            "before accumulating enough samples to estimate noise ({} < {})",
+                            timeout,
+                            m_total_samples,
+                            statistics::min_samples_for_noise_estimate));
+  }
+  else if (max_noise && cuda_stdev_noise && *cuda_stdev_noise > *max_noise)
+  {
+    printer.log(nvbench::log_level::warn,
+                fmt::format("Current measurement timed out ({:0.2f}s) "
+                            "while over noise threshold ({:0.2f}% > "
+                            "{:0.2f}%)",
+                            timeout,
+                            *cuda_stdev_noise * 100,
+                            *max_noise * 100));
+  }
+  if (m_total_samples < m_min_samples)
+  {
+    printer.log(nvbench::log_level::warn,
+                fmt::format("Current measurement timed out ({:0.2f}s) "
+                            "before accumulating min_samples ({} < {})",
+                            timeout,
+                            m_total_samples,
+                            m_min_samples));
+  }
+  if (min_time && m_total_cuda_time < *min_time)
+  {
+    printer.log(nvbench::log_level::warn,
+                fmt::format("Current measurement timed out ({:0.2f}s) "
+                            "before accumulating min_time ({:0.2f}s < "
+                            "{:0.2f}s)",
+                            timeout,
+                            m_total_cuda_time,
+                            *min_time));
+  }
+}
+
 void measure_cold_base::generate_summaries()
 {
   {
@@ -209,6 +274,30 @@ void measure_cold_base::generate_summaries()
     summ.set_string("hint", "sample_size");
     summ.set_string("description", "Number of isolated kernel executions");
     summ.set_int64("value", m_total_samples);
+  }
+
+  {
+    auto &summ = m_state.add_summary("nv/cold/walltime");
+    summ.set_string("name", "Walltime");
+    summ.set_string("hint", "duration");
+    summ.set_string("description", "Walltime used for isolated measurements");
+    summ.set_float64("value", m_walltime_timer.get_duration());
+    summ.set_string("hide", "Hidden by default.");
+  }
+
+  if (m_total_samples == 0)
+  {
+    // Throttling can discard every trial before a timeout stops collection.
+    // Keep timeout diagnostics, but skip sample-derived summaries.
+    if (auto printer_ptr = m_state.get_benchmark().get_printer())
+    {
+      auto &printer = *printer_ptr;
+      this->log_timeout_warnings(printer);
+      printer.log(nvbench::log_level::warn,
+                  fmt::format("Cold: no accepted samples recorded in {:0.2f}s walltime.",
+                              m_walltime_timer.get_duration()));
+    }
+    return;
   }
 
   // cpu time statistics
@@ -257,7 +346,8 @@ void measure_cold_base::generate_summaries()
     summ.set_string("hide", "Hidden by default.");
   }
 
-  const auto cpu_stdev_noise = statistics::compute_relative_dispersion(cpu_stdev, cpu_mean);
+  const auto cpu_stdev_noise =
+    statistics::compute_standard_deviation_noise(m_total_samples, cpu_stdev, cpu_mean);
   if (cpu_stdev_noise)
   {
     auto &summ = m_state.add_summary("nv/cold/time/cpu/stdev/relative");
@@ -363,7 +453,8 @@ void measure_cold_base::generate_summaries()
     summ.set_string("hide", "Hidden by default.");
   }
 
-  const auto cuda_stdev_noise = statistics::compute_relative_dispersion(cuda_stdev, cuda_mean);
+  const auto cuda_stdev_noise =
+    statistics::compute_standard_deviation_noise(m_total_samples, cuda_stdev, cuda_mean);
   if (cuda_stdev_noise)
   {
     auto &summ = m_state.add_summary("nv/cold/time/gpu/stdev/relative");
@@ -460,15 +551,6 @@ void measure_cold_base::generate_summaries()
     }
   } // bandwidth
 
-  {
-    auto &summ = m_state.add_summary("nv/cold/walltime");
-    summ.set_string("name", "Walltime");
-    summ.set_string("hint", "duration");
-    summ.set_string("description", "Walltime used for isolated measurements");
-    summ.set_float64("value", m_walltime_timer.get_duration());
-    summ.set_string("hide", "Hidden by default.");
-  }
-
   if (m_sm_clock_rate_accumulator != 0.)
   {
     const auto clock_mean = m_sm_clock_rate_accumulator / d_samples;
@@ -500,53 +582,7 @@ void measure_cold_base::generate_summaries()
   {
     auto &printer = *printer_ptr;
 
-    if (m_max_time_exceeded)
-    {
-      const auto timeout = m_walltime_timer.get_duration();
-
-      auto get_param = [this](std::optional<nvbench::float64_t> &param, const std::string &name) {
-        if (m_criterion_params.has_value(name))
-        {
-          param = m_criterion_params.get_float64(name);
-        }
-      };
-
-      std::optional<nvbench::float64_t> max_noise;
-      get_param(max_noise, "max-noise");
-
-      std::optional<nvbench::float64_t> min_time;
-      get_param(min_time, "min-time");
-
-      if (max_noise && cuda_stdev_noise && *cuda_stdev_noise > *max_noise)
-      {
-        printer.log(nvbench::log_level::warn,
-                    fmt::format("Current measurement timed out ({:0.2f}s) "
-                                "while over noise threshold ({:0.2f}% > "
-                                "{:0.2f}%)",
-                                timeout,
-                                *cuda_stdev_noise * 100,
-                                *max_noise * 100));
-      }
-      if (m_total_samples < m_min_samples)
-      {
-        printer.log(nvbench::log_level::warn,
-                    fmt::format("Current measurement timed out ({:0.2f}s) "
-                                "before accumulating min_samples ({} < {})",
-                                timeout,
-                                m_total_samples,
-                                m_min_samples));
-      }
-      if (min_time && m_total_cuda_time < *min_time)
-      {
-        printer.log(nvbench::log_level::warn,
-                    fmt::format("Current measurement timed out ({:0.2f}s) "
-                                "before accumulating min_time ({:0.2f}s < "
-                                "{:0.2f}s)",
-                                timeout,
-                                m_total_cuda_time,
-                                *min_time));
-      }
-    }
+    this->log_timeout_warnings(printer, cuda_stdev_noise);
 
     // Log to stdout:
     printer.log(nvbench::log_level::pass,

--- a/nvbench/detail/measure_cold.cu
+++ b/nvbench/detail/measure_cold.cu
@@ -19,6 +19,7 @@
 #include <nvbench/benchmark_base.cuh>
 #include <nvbench/criterion_manager.cuh>
 #include <nvbench/detail/measure_cold.cuh>
+#include <nvbench/detail/measure_timeout_warnings.cuh>
 #include <nvbench/detail/throw.cuh>
 #include <nvbench/device_info.cuh>
 #include <nvbench/printer_base.cuh>
@@ -33,7 +34,6 @@
 #include <limits>
 #include <optional>
 #include <stdexcept>
-#include <string>
 #include <thread>
 #include <utility>
 
@@ -211,59 +211,13 @@ void measure_cold_base::log_timeout_warnings(nvbench::printer_base &printer,
 
   const auto timeout = m_walltime_timer.get_duration();
 
-  auto get_param = [this](std::optional<nvbench::float64_t> &param, const std::string &name) {
-    if (m_criterion_params.has_value(name))
-    {
-      param = m_criterion_params.get_float64(name);
-    }
-  };
-
-  std::optional<nvbench::float64_t> max_noise;
-  get_param(max_noise, "max-noise");
-
-  std::optional<nvbench::float64_t> min_time;
-  get_param(min_time, "min-time");
-
-  const auto enough_samples_for_noise =
-    statistics::has_enough_samples_for_noise_estimate(m_total_samples);
-  if (max_noise && !enough_samples_for_noise)
-  {
-    printer.log(nvbench::log_level::warn,
-                fmt::format("Current measurement timed out ({:0.2f}s) "
-                            "before accumulating enough samples to estimate noise ({} < {})",
-                            timeout,
-                            m_total_samples,
-                            statistics::min_samples_for_noise_estimate));
-  }
-  else if (max_noise && cuda_stdev_noise && *cuda_stdev_noise > *max_noise)
-  {
-    printer.log(nvbench::log_level::warn,
-                fmt::format("Current measurement timed out ({:0.2f}s) "
-                            "while over noise threshold ({:0.2f}% > "
-                            "{:0.2f}%)",
-                            timeout,
-                            *cuda_stdev_noise * 100,
-                            *max_noise * 100));
-  }
-  if (m_total_samples < m_min_samples)
-  {
-    printer.log(nvbench::log_level::warn,
-                fmt::format("Current measurement timed out ({:0.2f}s) "
-                            "before accumulating min_samples ({} < {})",
-                            timeout,
-                            m_total_samples,
-                            m_min_samples));
-  }
-  if (min_time && m_total_cuda_time < *min_time)
-  {
-    printer.log(nvbench::log_level::warn,
-                fmt::format("Current measurement timed out ({:0.2f}s) "
-                            "before accumulating min_time ({:0.2f}s < "
-                            "{:0.2f}s)",
-                            timeout,
-                            m_total_cuda_time,
-                            *min_time));
-  }
+  log_measurement_timeout_warnings(printer,
+                                   m_criterion_params,
+                                   timeout,
+                                   m_total_samples,
+                                   m_min_samples,
+                                   m_total_cuda_time,
+                                   cuda_stdev_noise);
 }
 
 void measure_cold_base::generate_summaries()

--- a/nvbench/detail/measure_cold.cuh
+++ b/nvbench/detail/measure_cold.cuh
@@ -46,12 +46,14 @@
 #include <cuda_profiler_api.h>
 #include <cuda_runtime.h>
 
+#include <optional>
 #include <utility>
 #include <vector>
 
 namespace nvbench
 {
 
+struct printer_base;
 struct state;
 
 namespace detail
@@ -96,6 +98,11 @@ protected:
   __forceinline__ void unblock_stream() { m_blocker.unblock(); }
   __forceinline__ void unblock_stream_noexcept() noexcept { m_blocker.unblock_noexcept(); }
 
+private:
+  void log_timeout_warnings(nvbench::printer_base &printer,
+                            std::optional<nvbench::float64_t> cuda_stdev_noise = std::nullopt);
+
+protected:
   nvbench::state &m_state;
 
   nvbench::launch m_launch;

--- a/nvbench/detail/measure_cpu_only.cxx
+++ b/nvbench/detail/measure_cpu_only.cxx
@@ -168,7 +168,8 @@ void measure_cpu_only_base::generate_summaries()
     summ.set_string("hide", "Hidden by default.");
   }
 
-  const auto cpu_stdev_noise = statistics::compute_relative_dispersion(cpu_stdev, cpu_mean);
+  const auto cpu_stdev_noise =
+    statistics::compute_standard_deviation_noise(m_total_samples, cpu_stdev, cpu_mean);
   if (cpu_stdev_noise)
   {
     auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/stdev/relative");
@@ -281,7 +282,18 @@ void measure_cpu_only_base::generate_summaries()
       std::optional<nvbench::float64_t> min_time;
       get_param(min_time, "min-time");
 
-      if (max_noise && cpu_stdev_noise && *cpu_stdev_noise > *max_noise)
+      const auto enough_samples_for_noise =
+        statistics::has_enough_samples_for_noise_estimate(m_total_samples);
+      if (max_noise && !enough_samples_for_noise)
+      {
+        printer.log(nvbench::log_level::warn,
+                    fmt::format("Current measurement timed out ({:0.2f}s) "
+                                "before accumulating enough samples to estimate noise ({} < {})",
+                                timeout,
+                                m_total_samples,
+                                statistics::min_samples_for_noise_estimate));
+      }
+      else if (max_noise && cpu_stdev_noise && *cpu_stdev_noise > *max_noise)
       {
         printer.log(nvbench::log_level::warn,
                     fmt::format("Current measurement timed out ({:0.2f}s) "

--- a/nvbench/detail/measure_cpu_only.cxx
+++ b/nvbench/detail/measure_cpu_only.cxx
@@ -19,6 +19,7 @@
 #include <nvbench/benchmark_base.cuh>
 #include <nvbench/criterion_manager.cuh>
 #include <nvbench/detail/measure_cpu_only.cuh>
+#include <nvbench/detail/measure_timeout_warnings.cuh>
 #include <nvbench/detail/throw.cuh>
 #include <nvbench/printer_base.cuh>
 #include <nvbench/state.cuh>
@@ -29,9 +30,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <limits>
-#include <optional>
 #include <stdexcept>
-#include <string>
 #include <utility>
 
 namespace nvbench::detail
@@ -269,59 +268,13 @@ void measure_cpu_only_base::generate_summaries()
     {
       const auto timeout = m_walltime_timer.get_duration();
 
-      auto get_param = [this](std::optional<nvbench::float64_t> &param, const std::string &name) {
-        if (m_criterion_params.has_value(name))
-        {
-          param = m_criterion_params.get_float64(name);
-        }
-      };
-
-      std::optional<nvbench::float64_t> max_noise;
-      get_param(max_noise, "max-noise");
-
-      std::optional<nvbench::float64_t> min_time;
-      get_param(min_time, "min-time");
-
-      const auto enough_samples_for_noise =
-        statistics::has_enough_samples_for_noise_estimate(m_total_samples);
-      if (max_noise && !enough_samples_for_noise)
-      {
-        printer.log(nvbench::log_level::warn,
-                    fmt::format("Current measurement timed out ({:0.2f}s) "
-                                "before accumulating enough samples to estimate noise ({} < {})",
-                                timeout,
-                                m_total_samples,
-                                statistics::min_samples_for_noise_estimate));
-      }
-      else if (max_noise && cpu_stdev_noise && *cpu_stdev_noise > *max_noise)
-      {
-        printer.log(nvbench::log_level::warn,
-                    fmt::format("Current measurement timed out ({:0.2f}s) "
-                                "while over noise threshold ({:0.2f}% > "
-                                "{:0.2f}%)",
-                                timeout,
-                                *cpu_stdev_noise * 100,
-                                *max_noise * 100));
-      }
-      if (m_total_samples < m_min_samples)
-      {
-        printer.log(nvbench::log_level::warn,
-                    fmt::format("Current measurement timed out ({:0.2f}s) "
-                                "before accumulating min_samples ({} < {})",
-                                timeout,
-                                m_total_samples,
-                                m_min_samples));
-      }
-      if (min_time && m_total_cpu_time < *min_time)
-      {
-        printer.log(nvbench::log_level::warn,
-                    fmt::format("Current measurement timed out ({:0.2f}s) "
-                                "before accumulating min_time ({:0.2f}s < "
-                                "{:0.2f}s)",
-                                timeout,
-                                m_total_cpu_time,
-                                *min_time));
-      }
+      log_measurement_timeout_warnings(printer,
+                                       m_criterion_params,
+                                       timeout,
+                                       m_total_samples,
+                                       m_min_samples,
+                                       m_total_cpu_time,
+                                       cpu_stdev_noise);
     }
 
     // Log to stdout:

--- a/nvbench/detail/measure_cpu_only.cxx
+++ b/nvbench/detail/measure_cpu_only.cxx
@@ -169,13 +169,12 @@ void measure_cpu_only_base::generate_summaries()
 
   const auto cpu_stdev_noise =
     statistics::compute_standard_deviation_noise(m_total_samples, cpu_stdev, cpu_mean);
-  if (cpu_stdev_noise)
   {
     auto &summ = m_state.add_summary("nv/cpu_only/time/cpu/stdev/relative");
     summ.set_string("name", "Noise");
     summ.set_string("hint", "percentage");
     summ.set_string("description", "Relative standard deviation of isolated CPU times");
-    summ.set_float64("value", *cpu_stdev_noise);
+    summ.set_float64("value", statistics::stdev_noise_or_sentinel(cpu_stdev_noise));
   }
 
   const auto [cpu_first_quartile, cpu_median, cpu_third_quartile] =

--- a/nvbench/detail/measure_timeout_warnings.cuh
+++ b/nvbench/detail/measure_timeout_warnings.cuh
@@ -1,0 +1,114 @@
+/*
+ *  Copyright 2026 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <nvbench/config.cuh>
+
+#if defined(NVBENCH_IMPLICIT_SYSTEM_HEADER_GCC)
+#pragma GCC system_header
+#elif defined(NVBENCH_IMPLICIT_SYSTEM_HEADER_CLANG)
+#pragma clang system_header
+#elif defined(NVBENCH_IMPLICIT_SYSTEM_HEADER_MSVC)
+#pragma system_header
+#endif
+
+#include <nvbench/detail/statistics.cuh>
+#include <nvbench/printer_base.cuh>
+#include <nvbench/stopping_criterion.cuh>
+#include <nvbench/types.cuh>
+
+#include <fmt/format.h>
+
+#include <optional>
+#include <string>
+
+namespace nvbench::detail
+{
+
+inline std::optional<nvbench::float64_t>
+get_float64_criterion_param(const nvbench::criterion_params &params, const std::string &name)
+{
+  if (!params.has_value(name))
+  {
+    return std::nullopt;
+  }
+  return params.get_float64(name);
+}
+
+inline void log_measurement_timeout_warnings(nvbench::printer_base &printer,
+                                             const nvbench::criterion_params &criterion_params,
+                                             nvbench::float64_t timeout,
+                                             nvbench::int64_t total_samples,
+                                             nvbench::int64_t min_samples,
+                                             nvbench::float64_t accumulated_time,
+                                             std::optional<nvbench::float64_t> stdev_noise)
+{
+  const auto max_noise = get_float64_criterion_param(criterion_params, "max-noise");
+  const auto min_time  = get_float64_criterion_param(criterion_params, "min-time");
+
+  const auto enough_samples_for_noise =
+    statistics::has_enough_samples_for_noise_estimate(total_samples);
+  if (max_noise && !enough_samples_for_noise)
+  {
+    printer.log(nvbench::log_level::warn,
+                fmt::format("Current measurement timed out ({:0.2f}s) "
+                            "before accumulating enough samples to estimate noise ({} < {})",
+                            timeout,
+                            total_samples,
+                            statistics::min_samples_for_noise_estimate));
+  }
+  else if (max_noise && !stdev_noise)
+  {
+    printer.log(nvbench::log_level::warn,
+                fmt::format("Current measurement timed out ({:0.2f}s) "
+                            "while unable to estimate noise for max-noise",
+                            timeout));
+  }
+  else if (max_noise && stdev_noise && *stdev_noise > *max_noise)
+  {
+    printer.log(nvbench::log_level::warn,
+                fmt::format("Current measurement timed out ({:0.2f}s) "
+                            "while over noise threshold ({:0.2f}% > "
+                            "{:0.2f}%)",
+                            timeout,
+                            *stdev_noise * 100,
+                            *max_noise * 100));
+  }
+  if (total_samples < min_samples)
+  {
+    printer.log(nvbench::log_level::warn,
+                fmt::format("Current measurement timed out ({:0.2f}s) "
+                            "before accumulating min_samples ({} < {})",
+                            timeout,
+                            total_samples,
+                            min_samples));
+  }
+  if (min_time && accumulated_time < *min_time)
+  {
+    printer.log(nvbench::log_level::warn,
+                fmt::format("Current measurement timed out ({:0.2f}s) "
+                            "before accumulating min_time ({:0.2f}s < "
+                            "{:0.2f}s)",
+                            timeout,
+                            accumulated_time,
+                            *min_time));
+  }
+}
+
+} // namespace nvbench::detail

--- a/nvbench/detail/measure_timeout_warnings.cuh
+++ b/nvbench/detail/measure_timeout_warnings.cuh
@@ -35,6 +35,7 @@
 
 #include <fmt/format.h>
 
+#include <cmath>
 #include <optional>
 #include <string>
 
@@ -64,6 +65,8 @@ inline void log_measurement_timeout_warnings(nvbench::printer_base &printer,
 
   const auto enough_samples_for_noise =
     statistics::has_enough_samples_for_noise_estimate(total_samples);
+  const auto stdev_noise_unavailable = !stdev_noise || std::isnan(*stdev_noise) ||
+                                       *stdev_noise < nvbench::float64_t{};
   if (max_noise && !enough_samples_for_noise)
   {
     printer.log(nvbench::log_level::warn,
@@ -73,14 +76,14 @@ inline void log_measurement_timeout_warnings(nvbench::printer_base &printer,
                             total_samples,
                             statistics::min_samples_for_noise_estimate));
   }
-  else if (max_noise && !stdev_noise)
+  else if (max_noise && stdev_noise_unavailable)
   {
     printer.log(nvbench::log_level::warn,
                 fmt::format("Current measurement timed out ({:0.2f}s) "
                             "while unable to estimate noise for max-noise",
                             timeout));
   }
-  else if (max_noise && stdev_noise && *stdev_noise > *max_noise)
+  else if (max_noise && *stdev_noise > *max_noise)
   {
     printer.log(nvbench::log_level::warn,
                 fmt::format("Current measurement timed out ({:0.2f}s) "

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -271,7 +271,8 @@ std::array<ValueType, N> compute_percentiles_by_sorting(std::vector<ValueType> &
  * Computes exact percentile values using rank round(p / 100 * (S - 1)).
  *
  * The input range is copied before sorting, so const iterators are supported.
- * If the input has fewer than 1 sample, all percentiles are returned as quiet NaNs.
+ * If the input has fewer than 1 sample or contains a NaN, all percentiles are returned as quiet
+ * NaNs.
  */
 template <typename Iter,
           std::size_t N,

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -54,6 +54,9 @@ namespace nvbench::detail::statistics
 
 inline constexpr nvbench::int64_t min_samples_for_noise_estimate = 5;
 
+// Heuristic crossover near L1-sized float64 data; tune if sorting remains faster.
+inline constexpr std::size_t quartile_selection_threshold = 4096;
+
 inline constexpr bool has_enough_samples_for_noise_estimate(nvbench::int64_t num_samples)
 {
   return num_samples >= min_samples_for_noise_estimate;
@@ -349,10 +352,7 @@ quartiles_t<ValueType> compute_quartiles(Iter first, Iter last)
 
   std::vector<ValueType> samples(first, last);
 
-  // Heuristic crossover near L1-sized float64 data; tune if sorting remains faster.
-  constexpr std::size_t selection_threshold = 4096;
-
-  if (samples.size() >= selection_threshold)
+  if (samples.size() >= quartile_selection_threshold)
   {
     return ::nvbench::detail::statistics::compute_quartiles_by_selection(std::move(samples));
   }

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -54,6 +54,11 @@ namespace nvbench::detail::statistics
 
 inline constexpr nvbench::int64_t min_samples_for_noise_estimate = 5;
 
+inline constexpr bool has_enough_samples_for_noise_estimate(nvbench::int64_t num_samples)
+{
+  return num_samples >= min_samples_for_noise_estimate;
+}
+
 /**
  * Computes and returns the unbiased sample standard deviation.
  *
@@ -66,7 +71,7 @@ ValueType standard_deviation(Iter first, Iter last, ValueType mean)
 
   const auto num = std::distance(first, last);
 
-  if (num < min_samples_for_noise_estimate) // don't bother with low sample sizes.
+  if (!has_enough_samples_for_noise_estimate(num)) // don't bother with low sample sizes.
   {
     return std::numeric_limits<ValueType>::infinity();
   }
@@ -359,13 +364,31 @@ compute_relative_interquartile_range(nvbench::float64_t first_quartile,
   return ::nvbench::detail::statistics::compute_relative_dispersion(interquartile_range, median);
 }
 
+// Returns nullopt until there are enough samples for a meaningful standard deviation estimate.
+inline std::optional<nvbench::float64_t>
+compute_standard_deviation_noise(nvbench::int64_t num_samples,
+                                 nvbench::float64_t standard_deviation,
+                                 nvbench::float64_t center)
+{
+  if (!has_enough_samples_for_noise_estimate(num_samples))
+  {
+    return std::nullopt;
+  }
+  if (!std::isfinite(standard_deviation))
+  {
+    return std::nullopt;
+  }
+
+  return ::nvbench::detail::statistics::compute_relative_dispersion(standard_deviation, center);
+}
+
 // Returns nullopt until there are enough samples for a meaningful robust noise estimate.
 inline std::optional<nvbench::float64_t> compute_robust_noise(nvbench::int64_t num_samples,
                                                               nvbench::float64_t first_quartile,
                                                               nvbench::float64_t median,
                                                               nvbench::float64_t third_quartile)
 {
-  if (num_samples < min_samples_for_noise_estimate)
+  if (!has_enough_samples_for_noise_estimate(num_samples))
   {
     return std::nullopt;
   }

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -310,12 +310,7 @@ quartiles_t<ValueType> compute_quartiles_by_selection(std::vector<ValueType> &&s
   static_assert(std::is_floating_point_v<ValueType>,
                 "compute_quartiles_by_selection requires a floating-point value type.");
 
-  if (samples.empty())
-  {
-    constexpr auto nan = std::numeric_limits<ValueType>::quiet_NaN();
-    return {nan, nan, nan};
-  }
-  if (contains_nan(samples))
+  if (samples.empty() || contains_nan(samples))
   {
     constexpr auto nan = std::numeric_limits<ValueType>::quiet_NaN();
     return {nan, nan, nan};

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -205,10 +205,13 @@ public:
   }
 };
 
-// Compute percentile rank using nearest rank method
+// Use a rounded zero-based percentile rank
 inline std::size_t percentile_rank(int percentile, std::size_t size)
 {
+  // Precondition: sample_size > 0. Public percentile helpers handle empty
+  // inputs before calling this internal rank helper.
   assert(size > 0 && "percentile_rank requires non-empty sample set");
+
   const auto p = std::clamp(percentile, 0, 100);
   const auto q = static_cast<nvbench::float64_t>(p) / 100.0;
 
@@ -274,9 +277,8 @@ template <typename ValueType>
 quartiles_t<ValueType> compute_quartiles_by_sorting(std::vector<ValueType> &&samples)
 {
   constexpr std::array<int, 3> qs{25, 50, 75};
-  const auto r = ::nvbench::detail::statistics::compute_percentiles_by_sorting(
-    std::forward<std::vector<ValueType>>(samples),
-    qs);
+  const auto r = ::nvbench::detail::statistics::compute_percentiles_by_sorting(std::move(samples),
+                                                                               qs);
   return {r[0], r[1], r[2]};
 }
 

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -224,12 +224,20 @@ inline std::size_t percentile_rank(int percentile, std::size_t size)
   return static_cast<std::size_t>(std::round(q * max_rank));
 }
 
+template <typename ValueType>
+bool contains_nan(const std::vector<ValueType> &samples)
+{
+  return std::any_of(samples.cbegin(), samples.cend(), [](ValueType value) {
+    return std::isnan(value);
+  });
+}
+
 template <typename ValueType, std::size_t N>
 std::array<ValueType, N> compute_percentiles_by_sorting(std::vector<ValueType> &&samples,
                                                         const std::array<int, N> &percentiles)
 {
   std::array<ValueType, N> result{};
-  if (samples.empty())
+  if (samples.empty() || contains_nan(samples))
   {
     result.fill(std::numeric_limits<ValueType>::quiet_NaN());
     return result;
@@ -291,6 +299,11 @@ template <typename ValueType>
 quartiles_t<ValueType> compute_quartiles_by_selection(std::vector<ValueType> &&samples)
 {
   if (samples.empty())
+  {
+    constexpr auto nan = std::numeric_limits<ValueType>::quiet_NaN();
+    return {nan, nan, nan};
+  }
+  if (contains_nan(samples))
   {
     constexpr auto nan = std::numeric_limits<ValueType>::quiet_NaN();
     return {nan, nan, nan};

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -339,6 +339,8 @@ quartiles_t<ValueType> compute_quartiles(Iter first, Iter last)
   static_assert(std::is_floating_point_v<ValueType>);
 
   std::vector<ValueType> samples(first, last);
+
+  // Heuristic crossover near L1-sized float64 data; tune if sorting remains faster.
   constexpr std::size_t selection_threshold = 4096;
 
   if (samples.size() >= selection_threshold)

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -62,6 +62,13 @@ inline constexpr bool has_enough_samples_for_noise_estimate(nvbench::int64_t num
   return num_samples >= min_samples_for_noise_estimate;
 }
 
+template <typename ValueType>
+constexpr ValueType standard_deviation_unavailable_sentinel()
+{
+  static_assert(std::is_floating_point_v<ValueType>);
+  return std::numeric_limits<ValueType>::infinity();
+}
+
 /**
  * Computes and returns the unbiased sample standard deviation.
  *
@@ -76,7 +83,7 @@ ValueType standard_deviation(Iter first, Iter last, ValueType mean)
 
   if (!has_enough_samples_for_noise_estimate(num)) // don't bother with low sample sizes.
   {
-    return std::numeric_limits<ValueType>::infinity();
+    return standard_deviation_unavailable_sentinel<ValueType>();
   }
 
   const auto variance = nvbench::detail::transform_reduce(first,
@@ -399,6 +406,11 @@ compute_standard_deviation_noise(nvbench::int64_t num_samples,
   }
 
   return ::nvbench::detail::statistics::compute_relative_dispersion(standard_deviation, center);
+}
+
+inline nvbench::float64_t stdev_noise_or_sentinel(std::optional<nvbench::float64_t> noise)
+{
+  return noise.value_or(standard_deviation_unavailable_sentinel<nvbench::float64_t>());
 }
 
 // Returns nullopt until there are enough samples for a meaningful robust noise estimate.

--- a/nvbench/detail/statistics.cuh
+++ b/nvbench/detail/statistics.cuh
@@ -236,6 +236,9 @@ template <typename ValueType, std::size_t N>
 std::array<ValueType, N> compute_percentiles_by_sorting(std::vector<ValueType> &&samples,
                                                         const std::array<int, N> &percentiles)
 {
+  static_assert(std::is_floating_point_v<ValueType>,
+                "compute_percentiles_by_sorting requires a floating-point value type.");
+
   std::array<ValueType, N> result{};
   if (samples.empty() || contains_nan(samples))
   {
@@ -289,6 +292,9 @@ struct quartiles_t
 template <typename ValueType>
 quartiles_t<ValueType> compute_quartiles_by_sorting(std::vector<ValueType> &&samples)
 {
+  static_assert(std::is_floating_point_v<ValueType>,
+                "compute_quartiles_by_sorting requires a floating-point value type.");
+
   constexpr std::array<int, 3> qs{25, 50, 75};
   const auto r = ::nvbench::detail::statistics::compute_percentiles_by_sorting(std::move(samples),
                                                                                qs);
@@ -298,6 +304,9 @@ quartiles_t<ValueType> compute_quartiles_by_sorting(std::vector<ValueType> &&sam
 template <typename ValueType>
 quartiles_t<ValueType> compute_quartiles_by_selection(std::vector<ValueType> &&samples)
 {
+  static_assert(std::is_floating_point_v<ValueType>,
+                "compute_quartiles_by_selection requires a floating-point value type.");
+
   if (samples.empty())
   {
     constexpr auto nan = std::numeric_limits<ValueType>::quiet_NaN();

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -16,6 +16,7 @@ set(test_srcs
   exception_safety.cu
   float64_axis.cu
   int64_axis.cu
+  measure_timeout_warnings.cu
   named_values.cu
   option_parser.cu
   range.cu

--- a/testing/measure_timeout_warnings.cu
+++ b/testing/measure_timeout_warnings.cu
@@ -24,6 +24,7 @@
 
 #include <cmath>
 #include <limits>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -46,7 +47,8 @@ protected:
   }
 };
 
-void check_noise_warning(nvbench::float64_t stdev_noise, const std::string &expected_message)
+void check_noise_warning(std::optional<nvbench::float64_t> stdev_noise,
+                         const std::string &expected_message)
 {
   std::ostringstream stream;
   recording_printer printer{stream};
@@ -69,6 +71,7 @@ void check_noise_warning(nvbench::float64_t stdev_noise, const std::string &expe
 
 void test_non_finite_or_invalid_stdev_noise_timeout_warning()
 {
+  check_noise_warning(std::nullopt, "unable to estimate noise");
   check_noise_warning(std::numeric_limits<nvbench::float64_t>::quiet_NaN(),
                       "unable to estimate noise");
   check_noise_warning(-1.0, "unable to estimate noise");

--- a/testing/measure_timeout_warnings.cu
+++ b/testing/measure_timeout_warnings.cu
@@ -82,8 +82,37 @@ void test_non_finite_or_invalid_stdev_noise_timeout_warning()
   check_noise_warning(std::numeric_limits<nvbench::float64_t>::infinity(), "over noise threshold");
 }
 
+void test_min_samples_timeout_warning()
+{
+  std::ostringstream stream;
+  recording_printer printer{stream};
+  nvbench::criterion_params params;
+
+  nvbench::detail::log_measurement_timeout_warnings(printer, params, 1.0, 4, 5, 1.0, std::nullopt);
+
+  ASSERT(printer.logs.size() == 1);
+  ASSERT(printer.logs[0].first == nvbench::log_level::warn);
+  ASSERT(printer.logs[0].second.find("before accumulating min_samples") != std::string::npos);
+}
+
+void test_min_time_timeout_warning()
+{
+  std::ostringstream stream;
+  recording_printer printer{stream};
+  nvbench::criterion_params params;
+  params.set_float64("min-time", 2.0);
+
+  nvbench::detail::log_measurement_timeout_warnings(printer, params, 1.0, 5, 1, 1.5, std::nullopt);
+
+  ASSERT(printer.logs.size() == 1);
+  ASSERT(printer.logs[0].first == nvbench::log_level::warn);
+  ASSERT(printer.logs[0].second.find("before accumulating min_time") != std::string::npos);
+}
+
 int main()
 {
   test_non_finite_or_invalid_stdev_noise_timeout_warning();
+  test_min_samples_timeout_warning();
+  test_min_time_timeout_warning();
   return 0;
 }

--- a/testing/measure_timeout_warnings.cu
+++ b/testing/measure_timeout_warnings.cu
@@ -47,22 +47,23 @@ protected:
   }
 };
 
-void check_noise_warning(std::optional<nvbench::float64_t> stdev_noise,
-                         const std::string &expected_message)
+void check_noise_warning(
+  std::optional<nvbench::float64_t> stdev_noise,
+  const std::string &expected_message,
+  nvbench::int64_t total_samples = nvbench::detail::statistics::min_samples_for_noise_estimate)
 {
   std::ostringstream stream;
   recording_printer printer{stream};
   nvbench::criterion_params params;
   params.set_float64("max-noise", 0.01);
 
-  nvbench::detail::log_measurement_timeout_warnings(
-    printer,
-    params,
-    1.0,
-    nvbench::detail::statistics::min_samples_for_noise_estimate,
-    1,
-    1.0,
-    stdev_noise);
+  nvbench::detail::log_measurement_timeout_warnings(printer,
+                                                    params,
+                                                    1.0,
+                                                    total_samples,
+                                                    1,
+                                                    1.0,
+                                                    stdev_noise);
 
   ASSERT(printer.logs.size() == 1);
   ASSERT(printer.logs[0].first == nvbench::log_level::warn);
@@ -71,6 +72,9 @@ void check_noise_warning(std::optional<nvbench::float64_t> stdev_noise,
 
 void test_non_finite_or_invalid_stdev_noise_timeout_warning()
 {
+  check_noise_warning(std::nullopt,
+                      "before accumulating enough samples to estimate noise",
+                      nvbench::detail::statistics::min_samples_for_noise_estimate - 1);
   check_noise_warning(std::nullopt, "unable to estimate noise");
   check_noise_warning(std::numeric_limits<nvbench::float64_t>::quiet_NaN(),
                       "unable to estimate noise");

--- a/testing/measure_timeout_warnings.cu
+++ b/testing/measure_timeout_warnings.cu
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2026 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 with the LLVM exception
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.
+ *
+ *  You may obtain a copy of the License at
+ *
+ *      http://llvm.org/foundation/relicensing/LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <nvbench/detail/measure_timeout_warnings.cuh>
+#include <nvbench/detail/statistics.cuh>
+#include <nvbench/printer_base.cuh>
+#include <nvbench/stopping_criterion.cuh>
+#include <nvbench/types.cuh>
+
+#include <cmath>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "test_asserts.cuh"
+
+struct recording_printer : nvbench::printer_base
+{
+  explicit recording_printer(std::ostream &stream)
+      : nvbench::printer_base{stream}
+  {}
+
+  std::vector<std::pair<nvbench::log_level, std::string>> logs;
+
+protected:
+  void do_log(nvbench::log_level level, const std::string &message) override
+  {
+    logs.emplace_back(level, message);
+  }
+};
+
+void check_noise_warning(nvbench::float64_t stdev_noise, const std::string &expected_message)
+{
+  std::ostringstream stream;
+  recording_printer printer{stream};
+  nvbench::criterion_params params;
+  params.set_float64("max-noise", 0.01);
+
+  nvbench::detail::log_measurement_timeout_warnings(
+    printer,
+    params,
+    1.0,
+    nvbench::detail::statistics::min_samples_for_noise_estimate,
+    1,
+    1.0,
+    stdev_noise);
+
+  ASSERT(printer.logs.size() == 1);
+  ASSERT(printer.logs[0].first == nvbench::log_level::warn);
+  ASSERT(printer.logs[0].second.find(expected_message) != std::string::npos);
+}
+
+void test_non_finite_or_invalid_stdev_noise_timeout_warning()
+{
+  check_noise_warning(std::numeric_limits<nvbench::float64_t>::quiet_NaN(),
+                      "unable to estimate noise");
+  check_noise_warning(-1.0, "unable to estimate noise");
+  check_noise_warning(std::numeric_limits<nvbench::float64_t>::infinity(), "over noise threshold");
+}
+
+int main()
+{
+  test_non_finite_or_invalid_stdev_noise_timeout_warning();
+  return 0;
+}

--- a/testing/statistics.cu
+++ b/testing/statistics.cu
@@ -264,6 +264,12 @@ void test_percentiles()
 
 void test_quartiles_methods_agree()
 {
+  struct threshold_case
+  {
+    std::size_t size;
+    statistics::quartiles_t<nvbench::float64_t> expected;
+  };
+
   {
     const std::vector<nvbench::float64_t> data{40.0, 10.0, 30.0, 20.0};
     const auto sorting =
@@ -284,7 +290,9 @@ void test_quartiles_methods_agree()
   }
 
   // test around threshold when public API switches between implementations
-  for (const auto n : std::array<std::size_t, 3>{4095, 4096, 4097})
+  for (const auto [n, expected] : std::array<threshold_case, 3>{{{4095, {1024.0, 2047.0, 3071.0}},
+                                                                 {4096, {1024.0, 2048.0, 3071.0}},
+                                                                 {4097, {1024.0, 2048.0, 3072.0}}}})
   {
     std::vector<nvbench::float64_t> data(n);
     for (std::size_t i = 0; i < data.size(); ++i)
@@ -299,13 +307,21 @@ void test_quartiles_methods_agree()
       statistics::compute_quartiles_by_selection(std::vector<nvbench::float64_t>(data));
     assert_quartiles_equal(selection, sorting);
     assert_quartiles_equal(public_api, sorting);
+    assert_quartiles_equal(public_api, expected);
   }
 }
 
 void test_quartiles_methods_agree_with_duplicate_heavy_inputs()
 {
+  struct threshold_case
+  {
+    std::size_t size;
+    statistics::quartiles_t<nvbench::float64_t> expected;
+  };
+
   // Test around threshold when public API switches between implementations.
-  for (const auto n : std::array<std::size_t, 3>{4095, 4096, 4097})
+  for (const auto [n, expected] : std::array<threshold_case, 3>{
+         {{4095, {1.0, 1.0, 2.0}}, {4096, {1.0, 2.0, 2.0}}, {4097, {0.0, 1.0, 2.0}}}})
   {
     for (const auto seed : std::array<unsigned int, 3>{17u, 12345u, 987654321u})
     {
@@ -325,6 +341,7 @@ void test_quartiles_methods_agree_with_duplicate_heavy_inputs()
         statistics::compute_quartiles_by_selection(std::vector<nvbench::float64_t>(data));
       assert_quartiles_equal(selection, sorting);
       assert_quartiles_equal(public_api, sorting);
+      assert_quartiles_equal(public_api, expected);
     }
   }
 }

--- a/testing/statistics.cu
+++ b/testing/statistics.cu
@@ -413,6 +413,77 @@ void test_compute_robust_noise()
     ASSERT(actual);
     ASSERT(is_close(*actual, 1.0));
   }
+
+  {
+    const auto actual =
+      statistics::compute_robust_noise(statistics::min_samples_for_noise_estimate, 0.0, 0.0, 1.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual =
+      statistics::compute_robust_noise(statistics::min_samples_for_noise_estimate, -2.0, -1.0, 0.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual =
+      statistics::compute_robust_noise(statistics::min_samples_for_noise_estimate,
+                                       std::numeric_limits<nvbench::float64_t>::quiet_NaN(),
+                                       4.0,
+                                       6.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual =
+      statistics::compute_robust_noise(statistics::min_samples_for_noise_estimate,
+                                       2.0,
+                                       4.0,
+                                       std::numeric_limits<nvbench::float64_t>::infinity());
+    ASSERT(!actual);
+  }
+}
+
+void test_compute_standard_deviation_noise()
+{
+  ASSERT(!statistics::has_enough_samples_for_noise_estimate(
+    statistics::min_samples_for_noise_estimate - 1));
+  ASSERT(
+    statistics::has_enough_samples_for_noise_estimate(statistics::min_samples_for_noise_estimate));
+
+  {
+    const auto actual =
+      statistics::compute_standard_deviation_noise(statistics::min_samples_for_noise_estimate - 1,
+                                                   2.0,
+                                                   1.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual = statistics::compute_standard_deviation_noise(
+      statistics::min_samples_for_noise_estimate,
+      std::numeric_limits<nvbench::float64_t>::quiet_NaN(),
+      1.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual = statistics::compute_standard_deviation_noise(
+      statistics::min_samples_for_noise_estimate,
+      std::numeric_limits<nvbench::float64_t>::infinity(),
+      1.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual =
+      statistics::compute_standard_deviation_noise(statistics::min_samples_for_noise_estimate,
+                                                   2.0,
+                                                   4.0);
+    ASSERT(actual);
+    ASSERT(is_close(*actual, 0.5));
+  }
 }
 
 void test_relative_interquartile_range()
@@ -528,6 +599,7 @@ int main()
   test_compute_relative_dispersion_nominal_input();
   test_compute_relative_dispersion_invalid_inputs();
   test_relative_interquartile_range();
+  test_compute_standard_deviation_noise();
   test_compute_robust_noise();
   test_lin_regression();
   test_r2();

--- a/testing/statistics.cu
+++ b/testing/statistics.cu
@@ -563,6 +563,24 @@ void test_compute_standard_deviation_noise()
   }
 }
 
+void test_stdev_noise_or_sentinel()
+{
+  {
+    const auto actual = statistics::standard_deviation_unavailable_sentinel<nvbench::float64_t>();
+    ASSERT(std::isinf(actual));
+  }
+
+  {
+    const auto actual = statistics::stdev_noise_or_sentinel(nvbench::float64_t{0.25});
+    ASSERT(is_close(actual, 0.25));
+  }
+
+  {
+    const auto actual = statistics::stdev_noise_or_sentinel(std::nullopt);
+    ASSERT(actual == statistics::standard_deviation_unavailable_sentinel<nvbench::float64_t>());
+  }
+}
+
 void test_relative_interquartile_range()
 {
   {
@@ -677,6 +695,7 @@ int main()
   test_compute_relative_dispersion_invalid_inputs();
   test_relative_interquartile_range();
   test_compute_standard_deviation_noise();
+  test_stdev_noise_or_sentinel();
   test_compute_robust_noise();
   test_lin_regression();
   test_r2();

--- a/testing/statistics.cu
+++ b/testing/statistics.cu
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <iterator>
 #include <limits>
+#include <random>
 #include <sstream>
 #include <vector>
 
@@ -301,6 +302,33 @@ void test_quartiles_methods_agree()
   }
 }
 
+void test_quartiles_methods_agree_with_duplicate_heavy_inputs()
+{
+  // Test around threshold when public API switches between implementations.
+  for (const auto n : std::array<std::size_t, 3>{4095, 4096, 4097})
+  {
+    for (const auto seed : std::array<unsigned int, 3>{17u, 12345u, 987654321u})
+    {
+      std::vector<nvbench::float64_t> data(n);
+      for (std::size_t i = 0; i < data.size(); ++i)
+      {
+        data[i] = static_cast<nvbench::float64_t>((4 * i) / data.size());
+      }
+
+      std::mt19937 rng{seed};
+      std::shuffle(data.begin(), data.end(), rng);
+
+      const auto public_api = statistics::compute_quartiles(data.cbegin(), data.cend());
+      const auto sorting =
+        statistics::compute_quartiles_by_sorting(std::vector<nvbench::float64_t>(data));
+      const auto selection =
+        statistics::compute_quartiles_by_selection(std::vector<nvbench::float64_t>(data));
+      assert_quartiles_equal(selection, sorting);
+      assert_quartiles_equal(public_api, sorting);
+    }
+  }
+}
+
 void test_quartiles()
 {
   // special case inputs produce expected results
@@ -496,6 +524,7 @@ int main()
   test_percentiles();
   test_quartiles();
   test_quartiles_methods_agree();
+  test_quartiles_methods_agree_with_duplicate_heavy_inputs();
   test_compute_relative_dispersion_nominal_input();
   test_compute_relative_dispersion_invalid_inputs();
   test_relative_interquartile_range();

--- a/testing/statistics.cu
+++ b/testing/statistics.cu
@@ -532,6 +532,30 @@ void test_compute_standard_deviation_noise()
   {
     const auto actual =
       statistics::compute_standard_deviation_noise(statistics::min_samples_for_noise_estimate,
+                                                   1.0,
+                                                   0.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual =
+      statistics::compute_standard_deviation_noise(statistics::min_samples_for_noise_estimate,
+                                                   1.0,
+                                                   -1.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual =
+      statistics::compute_standard_deviation_noise(statistics::min_samples_for_noise_estimate,
+                                                   -1.0,
+                                                   1.0);
+    ASSERT(!actual);
+  }
+
+  {
+    const auto actual =
+      statistics::compute_standard_deviation_noise(statistics::min_samples_for_noise_estimate,
                                                    2.0,
                                                    4.0);
     ASSERT(actual);

--- a/testing/statistics.cu
+++ b/testing/statistics.cu
@@ -260,6 +260,16 @@ void test_percentiles()
     ASSERT(std::isnan(actual[1]));
     ASSERT(std::isnan(actual[2]));
   }
+
+  {
+    constexpr auto nan = std::numeric_limits<nvbench::float64_t>::quiet_NaN();
+    const std::vector<nvbench::float64_t> data{10.0, nan, 30.0, 20.0};
+    const auto actual =
+      statistics::compute_percentiles(data.cbegin(), data.cend(), std::array<int, 3>{25, 50, 75});
+    ASSERT(std::isnan(actual[0]));
+    ASSERT(std::isnan(actual[1]));
+    ASSERT(std::isnan(actual[2]));
+  }
 }
 
 void test_quartiles_methods_agree()
@@ -287,6 +297,16 @@ void test_quartiles_methods_agree()
     const auto selection =
       statistics::compute_quartiles_by_selection(std::vector<nvbench::float64_t>(data));
     assert_quartiles_equal(selection, sorting);
+  }
+
+  {
+    constexpr auto nan = std::numeric_limits<nvbench::float64_t>::quiet_NaN();
+    const std::vector<nvbench::float64_t> data{40.0, 10.0, nan, 20.0};
+    assert_quartiles_nan(
+      statistics::compute_quartiles_by_sorting(std::vector<nvbench::float64_t>(data)));
+    assert_quartiles_nan(
+      statistics::compute_quartiles_by_selection(std::vector<nvbench::float64_t>(data)));
+    assert_quartiles_nan(statistics::compute_quartiles(data.cbegin(), data.cend()));
   }
 
   // test around threshold when public API switches between implementations

--- a/testing/statistics.cu
+++ b/testing/statistics.cu
@@ -66,16 +66,20 @@ void assert_quartiles_nan(statistics::quartiles_t<T> actual)
 
 statistics::quartiles_t<nvbench::float64_t> expected_rank_quartiles(std::size_t num_samples)
 {
-  return {static_cast<nvbench::float64_t>(statistics::percentile_rank(25, num_samples)),
-          static_cast<nvbench::float64_t>(statistics::percentile_rank(50, num_samples)),
-          static_cast<nvbench::float64_t>(statistics::percentile_rank(75, num_samples))};
+  const auto expected_value = [num_samples](int percentile) {
+    const auto q = static_cast<nvbench::float64_t>(percentile) / 100.0;
+    return std::round(q * static_cast<nvbench::float64_t>(num_samples - 1));
+  };
+  return {expected_value(25), expected_value(50), expected_value(75)};
 }
 
 statistics::quartiles_t<nvbench::float64_t>
 expected_duplicate_heavy_quartiles(std::size_t num_samples)
 {
   const auto value_at_percentile = [num_samples](int percentile) {
-    const auto rank = statistics::percentile_rank(percentile, num_samples);
+    const auto q = static_cast<nvbench::float64_t>(percentile) / 100.0;
+    const auto rank =
+      static_cast<std::size_t>(std::round(q * static_cast<nvbench::float64_t>(num_samples - 1)));
     return static_cast<nvbench::float64_t>((4 * rank) / num_samples);
   };
   return {value_at_percentile(25), value_at_percentile(50), value_at_percentile(75)};

--- a/testing/statistics.cu
+++ b/testing/statistics.cu
@@ -64,6 +64,23 @@ void assert_quartiles_nan(statistics::quartiles_t<T> actual)
   ASSERT(std::isnan(actual.third_quartile));
 }
 
+statistics::quartiles_t<nvbench::float64_t> expected_rank_quartiles(std::size_t num_samples)
+{
+  return {static_cast<nvbench::float64_t>(statistics::percentile_rank(25, num_samples)),
+          static_cast<nvbench::float64_t>(statistics::percentile_rank(50, num_samples)),
+          static_cast<nvbench::float64_t>(statistics::percentile_rank(75, num_samples))};
+}
+
+statistics::quartiles_t<nvbench::float64_t>
+expected_duplicate_heavy_quartiles(std::size_t num_samples)
+{
+  const auto value_at_percentile = [num_samples](int percentile) {
+    const auto rank = statistics::percentile_rank(percentile, num_samples);
+    return static_cast<nvbench::float64_t>((4 * rank) / num_samples);
+  };
+  return {value_at_percentile(25), value_at_percentile(50), value_at_percentile(75)};
+}
+
 void test_mean()
 {
   {
@@ -274,12 +291,6 @@ void test_percentiles()
 
 void test_quartiles_methods_agree()
 {
-  struct threshold_case
-  {
-    std::size_t size;
-    statistics::quartiles_t<nvbench::float64_t> expected;
-  };
-
   {
     const std::vector<nvbench::float64_t> data{40.0, 10.0, 30.0, 20.0};
     const auto sorting =
@@ -310,15 +321,21 @@ void test_quartiles_methods_agree()
   }
 
   // test around threshold when public API switches between implementations
-  for (const auto [n, expected] : std::array<threshold_case, 3>{{{4095, {1024.0, 2047.0, 3071.0}},
-                                                                 {4096, {1024.0, 2048.0, 3071.0}},
-                                                                 {4097, {1024.0, 2048.0, 3072.0}}}})
+  constexpr auto threshold = statistics::quartile_selection_threshold;
+  if constexpr (threshold < 2)
+  {
+    return;
+  }
+
+  for (const auto n : std::array<std::size_t, 3>{threshold - 1, threshold, threshold + 1})
   {
     std::vector<nvbench::float64_t> data(n);
     for (std::size_t i = 0; i < data.size(); ++i)
     {
-      data[i] = static_cast<nvbench::float64_t>((i * 37) % data.size());
+      data[i] = static_cast<nvbench::float64_t>(i);
     }
+    std::mt19937 rng{37u};
+    std::shuffle(data.begin(), data.end(), rng);
 
     const auto public_api = statistics::compute_quartiles(data.cbegin(), data.cend());
     const auto sorting =
@@ -327,21 +344,20 @@ void test_quartiles_methods_agree()
       statistics::compute_quartiles_by_selection(std::vector<nvbench::float64_t>(data));
     assert_quartiles_equal(selection, sorting);
     assert_quartiles_equal(public_api, sorting);
-    assert_quartiles_equal(public_api, expected);
+    assert_quartiles_equal(public_api, expected_rank_quartiles(n));
   }
 }
 
 void test_quartiles_methods_agree_with_duplicate_heavy_inputs()
 {
-  struct threshold_case
-  {
-    std::size_t size;
-    statistics::quartiles_t<nvbench::float64_t> expected;
-  };
-
   // Test around threshold when public API switches between implementations.
-  for (const auto [n, expected] : std::array<threshold_case, 3>{
-         {{4095, {1.0, 1.0, 2.0}}, {4096, {1.0, 2.0, 2.0}}, {4097, {0.0, 1.0, 2.0}}}})
+  constexpr auto threshold = statistics::quartile_selection_threshold;
+  if constexpr (threshold < 2)
+  {
+    return;
+  }
+
+  for (const auto n : std::array<std::size_t, 3>{threshold - 1, threshold, threshold + 1})
   {
     for (const auto seed : std::array<unsigned int, 3>{17u, 12345u, 987654321u})
     {
@@ -361,7 +377,7 @@ void test_quartiles_methods_agree_with_duplicate_heavy_inputs()
         statistics::compute_quartiles_by_selection(std::vector<nvbench::float64_t>(data));
       assert_quartiles_equal(selection, sorting);
       assert_quartiles_equal(public_api, sorting);
-      assert_quartiles_equal(public_api, expected);
+      assert_quartiles_equal(public_api, expected_duplicate_heavy_quartiles(n));
     }
   }
 }


### PR DESCRIPTION
This PR hardens the robust timing-summary utilities and the measurement paths that consume them.

  Changes include:
  - Use `std::move` instead of `std::forward` when consuming an rvalue vector.
  - Avoid generating derived cold-measurement timing summaries when no samples were accepted, but keep wall-time summaries and timeout diagnostics available for zero-sample timeout cases.
  - Constrain direct percentile/quartile helpers to floating-point value types.
  - Guard percentile/quartile routines against NaN inputs before sorting or selection.
  - Add regression coverage for quartile behavior around the sort/selection threshold, including duplicate-heavy inputs.
  - Document the sort/selection threshold rationale.
  - Preserve legacy `stdev/relative` summary tags for low-sample runs by emitting the standard-deviation unavailable sentinel.
  - Treat missing, NaN, and negative stdev noise as unavailable in timeout diagnostics, while preserving `+inf` as the over-threshold sentinel.
  - Share timeout-warning logic between cold and CPU-only measurement paths.

  ## Testing

  - Added/updated `testing/statistics.cu` coverage for quartiles, NaN inputs, invalid noise inputs, and threshold-boundary behavior.
  - Added `testing/measure_timeout_warnings.cu` coverage for timeout-warning noise diagnostics.
  - Existing measurement tests continue to exercise cold and CPU-only summary generation.

Changes are driven by agentic review.

closes #402 