### PR TITLE
Avoid std::back_insert_iterator of fmt::memory_buffer in fmt::format

### DIFF
--- a/nvbench/csv_printer.cu
+++ b/nvbench/csv_printer.cu
@@ -161,9 +161,9 @@ void csv_printer::do_print_benchmark_results(const benchmark_vector &benches)
     std::size_t remaining = table.m_columns.size();
     for (const auto &col : table.m_columns)
     {
-      fmt::format_to(std::back_inserter(buffer), "{}{}", col.header, (--remaining == 0) ? "" : ",");
+      fmt::format_to(fmt::appender(buffer), "{}{}", col.header, (--remaining == 0) ? "" : ",");
     }
-    fmt::format_to(std::back_inserter(buffer), "\n");
+    fmt::format_to(fmt::appender(buffer), "\n");
   }
 
   { // Rows
@@ -172,12 +172,9 @@ void csv_printer::do_print_benchmark_results(const benchmark_vector &benches)
       std::size_t remaining = table.m_columns.size();
       for (const auto &col : table.m_columns)
       {
-        fmt::format_to(std::back_inserter(buffer),
-                       "{}{}",
-                       col.rows[i],
-                       (--remaining == 0) ? "" : ",");
+        fmt::format_to(fmt::appender(buffer), "{}{}", col.rows[i], (--remaining == 0) ? "" : ",");
       }
-      fmt::format_to(std::back_inserter(buffer), "\n");
+      fmt::format_to(fmt::appender(buffer), "\n");
     }
   }
 

--- a/nvbench/internal/markdown_table.cuh
+++ b/nvbench/internal/markdown_table.cuh
@@ -73,15 +73,15 @@ struct markdown_table : private table_builder
 
     this->fix_row_lengths();
 
-    std::vector<char> buffer;
+    fmt::memory_buffer buffer;
     buffer.reserve(4096);
-    auto iter = std::back_inserter(buffer);
+    auto iter = fmt::appender(buffer);
 
     iter = this->print_header(iter);
     iter = this->print_divider(iter);
     iter = this->print_rows(iter);
 
-    return std::string(buffer.data(), buffer.size());
+    return fmt::to_string(buffer);
   }
 
 private:

--- a/nvbench/markdown_printer.cu
+++ b/nvbench/markdown_printer.cu
@@ -44,7 +44,7 @@ namespace nvbench
 void markdown_printer::do_print_device_info()
 {
   fmt::memory_buffer buffer;
-  fmt::format_to(std::back_inserter(buffer), "# Devices\n\n");
+  fmt::format_to(fmt::appender(buffer), "# Devices\n\n");
 
   const auto &device_mgr = nvbench::device_manager::get();
   const auto &devices = device_mgr.get_number_of_used_devices() > 0 ? device_mgr.get_used_devices()
@@ -53,46 +53,46 @@ void markdown_printer::do_print_device_info()
   {
     const auto [gmem_free, gmem_used] = device.get_global_memory_usage();
 
-    fmt::format_to(std::back_inserter(buffer), "## [{}] `{}`\n", device.get_id(), device.get_name());
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer), "## [{}] `{}`\n", device.get_id(), device.get_name());
+    fmt::format_to(fmt::appender(buffer),
                    "* SM Version: {} (PTX Version: {})\n",
                    device.get_sm_version(),
                    device.get_ptx_version());
-    fmt::format_to(std::back_inserter(buffer), "* Number of SMs: {}\n", device.get_number_of_sms());
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer), "* Number of SMs: {}\n", device.get_number_of_sms());
+    fmt::format_to(fmt::appender(buffer),
                    "* SM Default Clock Rate: {} MHz\n",
                    device.get_sm_default_clock_rate() / 1000 / 1000);
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    "* Global Memory: {} MiB Free / {} MiB Total\n",
                    gmem_free / 1024 / 1024,
                    gmem_used / 1024 / 1024);
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    "* Global Memory Bus Peak: {} GB/sec ({}-bit DDR @{}MHz)\n",
                    device.get_global_memory_bus_bandwidth() / 1000 / 1000 / 1000,
                    device.get_global_memory_bus_width(),
                    device.get_global_memory_bus_peak_clock_rate() / 1000 / 1000);
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    "* Max Shared Memory: {} KiB/SM, {} KiB/Block\n",
                    device.get_shared_memory_per_sm() / 1024,
                    device.get_shared_memory_per_block() / 1024);
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    "* L2 Cache Size: {} KiB\n",
                    device.get_l2_cache_size() / 1024);
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    "* Maximum Active Blocks: {}/SM\n",
                    device.get_max_blocks_per_sm());
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    "* Maximum Active Threads: {}/SM, {}/Block\n",
                    device.get_max_threads_per_sm(),
                    device.get_max_threads_per_block());
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    "* Available Registers: {}/SM, {}/Block\n",
                    device.get_registers_per_sm(),
                    device.get_registers_per_block());
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    "* ECC Enabled: {}\n",
                    device.get_ecc_state() ? "Yes" : "No");
-    fmt::format_to(std::back_inserter(buffer), "\n");
+    fmt::format_to(fmt::appender(buffer), "\n");
   }
   m_ostream << fmt::to_string(buffer);
 }
@@ -165,20 +165,20 @@ void markdown_printer::do_print_benchmark_list(const printer_base::benchmark_vec
   }
 
   fmt::memory_buffer buffer;
-  fmt::format_to(std::back_inserter(buffer), "# Benchmarks\n\n");
+  fmt::format_to(fmt::appender(buffer), "# Benchmarks\n\n");
   std::size_t benchmark_id{0};
   for (const auto &bench_ptr : benches)
   {
     const auto &axes              = bench_ptr->get_axes().get_axes();
     const std::size_t num_configs = bench_ptr->get_config_count();
 
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    "## [{}] `{}` ({} configurations)\n\n",
                    benchmark_id++,
                    bench_ptr->get_name(),
                    num_configs);
 
-    fmt::format_to(std::back_inserter(buffer), "### Axes\n\n");
+    fmt::format_to(fmt::appender(buffer), "### Axes\n\n");
     for (const auto &axis_ptr : axes)
     {
       std::string flags_str(axis_ptr->get_flags_as_string());
@@ -186,7 +186,7 @@ void markdown_printer::do_print_benchmark_list(const printer_base::benchmark_vec
       {
         flags_str = fmt::format(" [{}]", flags_str);
       }
-      fmt::format_to(std::back_inserter(buffer),
+      fmt::format_to(fmt::appender(buffer),
                      "* `{}` : {}{}\n",
                      axis_ptr->get_name(),
                      axis_ptr->get_type_as_string(),
@@ -200,13 +200,10 @@ void markdown_printer::do_print_benchmark_list(const printer_base::benchmark_vec
         {
           desc = fmt::format(" ({})", desc);
         }
-        fmt::format_to(std::back_inserter(buffer),
-                       "  * `{}`{}\n",
-                       axis_ptr->get_input_string(i),
-                       desc);
+        fmt::format_to(fmt::appender(buffer), "  * `{}`{}\n", axis_ptr->get_input_string(i), desc);
       } // end foreach value
     } // end foreach axis
-    fmt::format_to(std::back_inserter(buffer), "\n");
+    fmt::format_to(fmt::appender(buffer), "\n");
   } // end foreach bench
 
   m_ostream << fmt::to_string(buffer);
@@ -231,7 +228,7 @@ void markdown_printer::do_print_benchmark_results(const printer_base::benchmark_
 
   // Start printing benchmarks
   fmt::memory_buffer buffer;
-  fmt::format_to(std::back_inserter(buffer), "# Benchmark Results\n");
+  fmt::format_to(fmt::appender(buffer), "# Benchmark Results\n");
 
   for (const auto &bench_ptr : benches)
   {
@@ -239,7 +236,7 @@ void markdown_printer::do_print_benchmark_results(const printer_base::benchmark_
     const auto &devices = bench.get_devices();
     const auto &axes    = bench.get_axes();
 
-    fmt::format_to(std::back_inserter(buffer), "\n## {}\n\n", bench.get_name());
+    fmt::format_to(fmt::appender(buffer), "\n## {}\n\n", bench.get_name());
 
     // Do a single pass when no devices are specified. This happens for
     // benchmarks with `cpu` exec_tags.
@@ -252,7 +249,7 @@ void markdown_printer::do_print_benchmark_results(const printer_base::benchmark_
 
       if (device)
       {
-        fmt::format_to(std::back_inserter(buffer),
+        fmt::format_to(fmt::appender(buffer),
                        "### [{}] {}\n\n",
                        device->get_id(),
                        device->get_name());
@@ -336,7 +333,7 @@ void markdown_printer::do_print_benchmark_results(const printer_base::benchmark_
       }
 
       auto table_str = table.to_string();
-      fmt::format_to(std::back_inserter(buffer),
+      fmt::format_to(fmt::appender(buffer),
                      "{}",
                      table_str.empty() ? "No data -- check log.\n" : std::move(table_str));
     } // end foreach device_pass

--- a/nvbench/state.cxx
+++ b/nvbench/state.cxx
@@ -204,7 +204,7 @@ std::string state::get_axis_values_as_string(bool color) const
       constexpr auto key_format   = fmt::emphasis::italic;
       constexpr auto value_format = fmt::emphasis::bold;
 
-      fmt::format_to(std::back_inserter(buffer),
+      fmt::format_to(fmt::appender(buffer),
                      "{}{}={}",
                      buffer.size() == 0 ? "" : " ",
                      fmt::format(style(key_format), "{}", key),

--- a/testing/axes_metadata.cu
+++ b/testing/axes_metadata.cu
@@ -126,13 +126,13 @@ void test_type_axes()
   fmt::memory_buffer buffer;
   for (const auto &axis : axes.get_axes())
   {
-    fmt::format_to(std::back_inserter(buffer), "Axis: {}\n", axis->get_name());
+    fmt::format_to(fmt::appender(buffer), "Axis: {}\n", axis->get_name());
     const auto num_values = axis->get_size();
     for (std::size_t i = 0; i < num_values; ++i)
     {
       auto input_string = axis->get_input_string(i);
       auto description  = axis->get_description(i);
-      fmt::format_to(std::back_inserter(buffer),
+      fmt::format_to(fmt::appender(buffer),
                      " - {}{}\n",
                      input_string,
                      description.empty() ? "" : fmt::format(" ({})", description));

--- a/testing/benchmark.cu
+++ b/testing/benchmark.cu
@@ -45,13 +45,13 @@ std::vector<T> sort(std::vector<T> &&vec)
 void no_op_generator(nvbench::state &state)
 {
   fmt::memory_buffer params;
-  fmt::format_to(std::back_inserter(params), "Params:");
+  fmt::format_to(fmt::appender(params), "Params:");
   const auto &axis_values = state.get_axis_values();
   for (const auto &name : sort(axis_values.get_names()))
   {
     std::visit(
       [&params, &name](const auto &value) {
-        fmt::format_to(std::back_inserter(params), " {}: {}", name, value);
+        fmt::format_to(fmt::appender(params), " {}: {}", name, value);
       },
       axis_values.get_value(name));
   }
@@ -94,13 +94,13 @@ void test_type_axes()
   const auto &axes = bench.get_axes().get_axes();
   for (const auto &axis : axes)
   {
-    fmt::format_to(std::back_inserter(buffer), "Axis: {}\n", axis->get_name());
+    fmt::format_to(fmt::appender(buffer), "Axis: {}\n", axis->get_name());
     const auto num_values = axis->get_size();
     for (std::size_t i = 0; i < num_values; ++i)
     {
       auto input_string = axis->get_input_string(i);
       auto description  = axis->get_description(i);
-      fmt::format_to(std::back_inserter(buffer),
+      fmt::format_to(fmt::appender(buffer),
                      " - {}{}\n",
                      input_string,
                      description.empty() ? "" : fmt::format(" ({})", description));
@@ -140,7 +140,7 @@ void test_type_configs()
       using Integer = nvbench::tl::get<0, Conf>;
       using Float   = nvbench::tl::get<1, Conf>;
       using Other   = nvbench::tl::get<2, Conf>;
-      fmt::format_to(std::back_inserter(buffer),
+      fmt::format_to(fmt::appender(buffer),
                      "type_configs[{:2d}] = <{:>3}, {:>3}, {:>4}>\n",
                      idx++,
                      nvbench::type_strings<Integer>::input_string(),

--- a/testing/create.cu
+++ b/testing/create.cu
@@ -43,13 +43,13 @@ std::vector<T> sort(std::vector<T> &&vec)
 void no_op_generator(nvbench::state &state)
 {
   fmt::memory_buffer params;
-  fmt::format_to(std::back_inserter(params), "Params:");
+  fmt::format_to(fmt::appender(params), "Params:");
   const auto &axis_values = state.get_axis_values();
   for (const auto &name : sort(axis_values.get_names()))
   {
     std::visit(
       [&params, &name](const auto &value) {
-        fmt::format_to(std::back_inserter(params), " {}: {}", name, value);
+        fmt::format_to(fmt::appender(params), " {}: {}", name, value);
       },
       axis_values.get_value(name));
   }
@@ -104,7 +104,7 @@ std::string run_and_get_state_string(nvbench::benchmark_base &bench,
   for (const auto &state : states)
   {
     ASSERT(state.is_skipped());
-    fmt::format_to(std::back_inserter(buffer), "{}\n", state.get_skip_reason());
+    fmt::format_to(fmt::appender(buffer), "{}\n", state.get_skip_reason());
   }
   return fmt::to_string(buffer);
 }

--- a/testing/option_parser.cu
+++ b/testing/option_parser.cu
@@ -105,8 +105,8 @@ struct temp_tree
   std::string table_format = "| {:^5} | {:^10} | {:^4} | {:^4} | {:^4} "
                              "| {:^4} | {:^6} | {:^8} |\n";
 
-  fmt::format_to(std::back_inserter(buffer), "\n");
-  fmt::format_to(std::back_inserter(buffer),
+  fmt::format_to(fmt::appender(buffer), "\n");
+  fmt::format_to(fmt::appender(buffer),
                  table_format,
                  "State",
                  "TypeConfig",
@@ -120,7 +120,7 @@ struct temp_tree
   std::size_t config = 0;
   for (const auto &state : states)
   {
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    table_format,
                    config++,
                    state.get_type_config_index(),

--- a/testing/runner.cu
+++ b/testing/runner.cu
@@ -42,13 +42,13 @@ std::vector<T> sort(std::vector<T> &&vec)
 void no_op_generator(nvbench::state &state)
 {
   fmt::memory_buffer params;
-  fmt::format_to(std::back_inserter(params), "Params:");
+  fmt::format_to(fmt::appender(params), "Params:");
   const auto &axis_values = state.get_axis_values();
   for (const auto &name : sort(axis_values.get_names()))
   {
     std::visit(
       [&params, &name](const auto &value) {
-        fmt::format_to(std::back_inserter(params), " {}: {}", name, value);
+        fmt::format_to(fmt::appender(params), " {}: {}", name, value);
       },
       axis_values.get_value(name));
   }
@@ -118,7 +118,7 @@ void test_non_types()
   for (const auto &state : bench.get_states())
   {
     ASSERT(state.is_skipped() == true);
-    fmt::format_to(std::back_inserter(buffer), "{}\n", state.get_skip_reason());
+    fmt::format_to(fmt::appender(buffer), "{}\n", state.get_skip_reason());
   }
 
   const std::string ref = R"expected(Params: Float: 11 Int: 1 String: One
@@ -178,7 +178,7 @@ void test_types()
   for (const auto &state : bench.get_states())
   {
     ASSERT(state.is_skipped() == true);
-    fmt::format_to(std::back_inserter(buffer), "{}\n", state.get_skip_reason());
+    fmt::format_to(fmt::appender(buffer), "{}\n", state.get_skip_reason());
   }
 
   const std::string ref = R"expected(Params: FloatT: F32 IntT: I32 MiscT: bool
@@ -222,7 +222,7 @@ void test_both()
   for (const auto &state : bench.get_states())
   {
     ASSERT(state.is_skipped() == true);
-    fmt::format_to(std::back_inserter(buffer), "{}\n", state.get_skip_reason());
+    fmt::format_to(fmt::appender(buffer), "{}\n", state.get_skip_reason());
   }
 
   const std::string ref =

--- a/testing/state_generator.cu
+++ b/testing/state_generator.cu
@@ -88,17 +88,17 @@ void test_basic()
   for (sg.init(); sg.iter_valid(); sg.next())
   {
     line.clear();
-    fmt::format_to(std::back_inserter(line), "| {:^2}", line_num++);
+    fmt::format_to(fmt::appender(line), "| {:^2}", line_num++);
     for (auto &axis_index : sg.get_current_indices())
     {
       ASSERT(axis_index.type == nvbench::axis_type::string);
-      fmt::format_to(std::back_inserter(line),
+      fmt::format_to(fmt::appender(line),
                      " | {}: {}/{}",
                      axis_index.axis,
                      axis_index.index,
                      axis_index.size);
     }
-    fmt::format_to(std::back_inserter(buffer), "{} |\n", fmt::to_string(line));
+    fmt::format_to(fmt::appender(buffer), "{} |\n", fmt::to_string(line));
   }
 
   const std::string ref =
@@ -161,8 +161,8 @@ void test_create()
   fmt::memory_buffer buffer;
   const std::string table_format = "| {:^5} | {:^10} | {:^7} | {:^7} | {:^9} | {:^9} |\n";
 
-  fmt::format_to(std::back_inserter(buffer), "\n");
-  fmt::format_to(std::back_inserter(buffer),
+  fmt::format_to(fmt::appender(buffer), "\n");
+  fmt::format_to(fmt::appender(buffer),
                  table_format,
                  "State",
                  "TypeConfig",
@@ -174,7 +174,7 @@ void test_create()
   std::size_t config = 0;
   for (const auto &state : states)
   {
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    table_format,
                    config++,
                    state.get_type_config_index(),
@@ -250,8 +250,8 @@ void test_create_with_types()
   std::string table_format = "| {:^5} | {:^10} | {:^6} | {:^4} | {:^4} | {:^7} "
                              "| {:^7} | {:^9} | {:^9} |\n";
 
-  fmt::format_to(std::back_inserter(buffer), "\n");
-  fmt::format_to(std::back_inserter(buffer),
+  fmt::format_to(fmt::appender(buffer), "\n");
+  fmt::format_to(fmt::appender(buffer),
                  table_format,
                  "State",
                  "TypeConfig",
@@ -266,7 +266,7 @@ void test_create_with_types()
   std::size_t config = 0;
   for (const auto &state : states)
   {
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    table_format,
                    config++,
                    state.get_type_config_index(),
@@ -596,8 +596,8 @@ void test_create_with_masked_types()
   std::string table_format = "| {:^5} | {:^10} | {:^6} | {:^4} | {:^4} | {:^7} "
                              "| {:^7} | {:^9} | {:^9} |\n";
 
-  fmt::format_to(std::back_inserter(buffer), "\n");
-  fmt::format_to(std::back_inserter(buffer),
+  fmt::format_to(fmt::appender(buffer), "\n");
+  fmt::format_to(fmt::appender(buffer),
                  table_format,
                  "State",
                  "TypeConfig",
@@ -612,7 +612,7 @@ void test_create_with_masked_types()
   std::size_t config = 0;
   for (const auto &state : states)
   {
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    table_format,
                    config++,
                    state.get_type_config_index(),
@@ -725,13 +725,13 @@ void test_devices()
   fmt::memory_buffer buffer;
   const std::string table_format = "| {:^5} | {:^6} | {:^5} | {:^3} |\n";
 
-  fmt::format_to(std::back_inserter(buffer), "\n");
-  fmt::format_to(std::back_inserter(buffer), table_format, "State", "Device", "S", "I");
+  fmt::format_to(fmt::appender(buffer), "\n");
+  fmt::format_to(fmt::appender(buffer), table_format, "State", "Device", "S", "I");
 
   std::size_t config = 0;
   for (const auto &state : states)
   {
-    fmt::format_to(std::back_inserter(buffer),
+    fmt::format_to(fmt::appender(buffer),
                    table_format,
                    config++,
                    state.get_device()->get_id(),


### PR DESCRIPTION
closes #396 

fmt 12.2 changed the implementation path used by `fmt::format_to` with `std::back_insert_iterator`. Under nvcc, that path rejects `std::back_insert_iterator<fmt::memory_buffer>` because fmt’s constexpr helper takes a non-literal iterator type. Replacing `std::back_inserter(buffer)` with `fmt::appender(buffer)` for `fmt::memory_buffer` outputs avoids that path and is the fmt-native way to append to `memory_buffer`.