### PR TITLE
Use UV to build Python wheels

### DIFF
--- a/ci/build_multi_cuda_wheel.sh
+++ b/ci/build_multi_cuda_wheel.sh
@@ -111,18 +111,13 @@ done
 
 echo "Merging CUDA wheels..."
 
-# Detect python command
-if command -v python &> /dev/null; then
-  PYTHON=python
-elif command -v python3 &> /dev/null; then
-  PYTHON=python3
-else
-  echo "Error: No python found"
-  exit 1
-fi
+# Use the requested Python version for wheel merge/repair operations too.
+# shellcheck source=ci/pyenv_helper.sh
+source "$ci_dir/pyenv_helper.sh"
+setup_python_env "${py_version}"
 
 # Needed for unpacking and repacking wheels.
-$PYTHON -m pip install --break-system-packages wheel
+python -m pip install wheel
 
 # Find the built wheels (temporarily suffixed with .cu12/.cu13 to avoid collision)
 cu12_wheel=$(find wheelhouse -name "*cu12*.whl" | head -1)
@@ -158,13 +153,13 @@ mkdir -p wheelhouse_merged
 cd wheelhouse_merged
 
 # Unpack CUDA 12 wheel (this will be our base)
-$PYTHON -m wheel unpack "$cu12_wheel"
+python -m wheel unpack "$cu12_wheel"
 base_dir=$(find . -maxdepth 1 -type d -name "cuda_bench-*" | head -1)
 
 # Unpack CUDA 13 wheel into a temporary subdirectory
 mkdir cu13_tmp
 cd cu13_tmp
-$PYTHON -m wheel unpack "$cu13_wheel"
+python -m wheel unpack "$cu13_wheel"
 cu13_dir=$(find . -maxdepth 1 -type d -name "cuda_bench-*" | head -1)
 
 # Copy the cu13/ directory from CUDA 13 wheel into the base wheel
@@ -178,15 +173,15 @@ rm -rf cu13_tmp
 rm -f "$base_dir"/*.dist-info/RECORD
 
 # Repack the merged wheel
-$PYTHON -m wheel pack "$base_dir"
+python -m wheel pack "$base_dir"
 
 cd ..
 
 # Install auditwheel and repair the merged wheel
-$PYTHON -m pip install --break-system-packages auditwheel
+python -m pip install auditwheel
 for wheel in wheelhouse_merged/cuda_bench-*.whl; do
     echo "Repairing merged wheel: $wheel"
-    $PYTHON -m auditwheel repair \
+    python -m auditwheel repair \
         --exclude 'libcuda.so.1' \
         --exclude 'libnvidia-ml.so.1' \
         --exclude 'libcupti.so.12' \

--- a/ci/pyenv_helper.sh
+++ b/ci/pyenv_helper.sh
@@ -2,67 +2,37 @@
 
 setup_python_env() {
     local py_version=$1
-    local python_bin=""
-    local python_bin_quoted=""
-    local python_shim_dir=""
+    local script_dir=""
+    local uv_installer=""
+    local venv_dir=""
+    local actual_py_version=""
 
-    if command -v "python${py_version}" &> /dev/null; then
-        python_bin="$(command -v "python${py_version}")"
-    elif command -v python &> /dev/null &&
-         [[ "$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" == "${py_version}" ]]; then
-        python_bin="$(command -v python)"
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    export PATH="$HOME/.local/bin:$PATH"
+
+    if ! command -v uv &> /dev/null; then
+        uv_installer="$(mktemp)"
+        "${script_dir}/util/retry.sh" 5 30 curl -LsSf https://astral.sh/uv/install.sh -o "${uv_installer}"
+        sh "${uv_installer}"
+        rm -f "${uv_installer}"
+        export PATH="$HOME/.local/bin:$PATH"
     fi
 
-    if [[ -n "${python_bin}" ]]; then
-        python_shim_dir="${TMPDIR:-/tmp}/nvbench-python-${py_version}/bin"
-        mkdir -p "${python_shim_dir}"
-        python_bin_quoted="$(printf '%q' "${python_bin}")"
-        printf '#!/bin/bash\nexec %s "$@"\n' "${python_bin_quoted}" > "${python_shim_dir}/python"
-        chmod +x "${python_shim_dir}/python"
-        export PATH="${python_shim_dir}:$PATH"
-        python -m pip install --upgrade pip
-        return 0
+    venv_dir="${NVBENCH_PYTHON_VENV:-${HOME}/.nvbench-venv-${py_version}}"
+    uv venv --seed --python "${py_version}" "${venv_dir}"
+
+    if [[ -f "${venv_dir}/Scripts/activate" ]]; then
+        # Windows venvs use Scripts/.
+        # shellcheck source=/dev/null
+        source "${venv_dir}/Scripts/activate"
+    else
+        # shellcheck source=/dev/null
+        source "${venv_dir}/bin/activate"
     fi
 
-    # check if pyenv is installed
-    if ! command -v pyenv &> /dev/null; then
-        rm -f /pyenv
-        curl -fsSL https://pyenv.run | bash
+    actual_py_version="$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+    if [[ "${actual_py_version}" != "${py_version}" ]]; then
+        echo "Error: expected Python ${py_version}, got ${actual_py_version}"
+        exit 1
     fi
-
-    # Install the build dependencies, check /etc/os-release to see if we are on ubuntu or rocky
-    if [ -f /etc/os-release ]; then
-        source /etc/os-release
-        if [ "$ID" = "ubuntu" ]; then
-            # Use the retry helper to mitigate issues with apt network errors:
-            script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-            retry() {
-              "${script_dir}/util/retry.sh" 5 30 "$@"
-            }
-
-            retry sudo apt update
-            retry sudo apt install -y make libssl-dev zlib1g-dev \
-            libbz2-dev libreadline-dev libsqlite3-dev curl git \
-            libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-        elif [ "$ID" = "rocky" ]; then
-            # we're inside the rockylinux container, sudo not required/available
-            dnf install -y make patch zlib-devel bzip2 bzip2-devel readline-devel \
-            sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz-devel libuuid-devel \
-            gdbm-libs libnsl2
-        else
-            echo "Unsupported Linux distribution"
-            exit 1
-        fi
-    fi
-
-    # Always set up pyenv environment
-    export PYENV_ROOT="$HOME/.pyenv"
-    [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
-    eval "$(pyenv init - bash)"
-
-    # Using pyenv, install the Python version
-    PYENV_DEBUG=1 pyenv install -v "${py_version}"
-    pyenv local "${py_version}"
-
-    pip install --upgrade pip
 }


### PR DESCRIPTION
1. This follows the lead of similar change on CCCL side: NVIDIA/cccl#8398
2. Transitioning away from using pyenv allows avoiding the need to build CPython on every pull request, cutting down build time.

Closes #399 

