### PR TITLE
Implemented the NVBench PR review workflow.

### DIFF
--- a/.agents/skills/review-nvbench/SKILL.md
+++ b/.agents/skills/review-nvbench/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: review-nvbench
+description: Use this skill when the user invokes /review-nvbench to review an NVBench pull request, PR branch, commit range, or diff. Supports context, feedback, and adversarial modes.
+---
+
+# Review NVBench Pull Request
+
+Read `AGENTS.md` and `docs/pr_review.md` before acting.
+
+Use one of these modes:
+
+- `context`: Gather PR context and explain the change without review findings.
+- `feedback`: Produce normal review findings after the human reviewer has inspected the PR.
+- `adversarial`: Challenge assumptions, design direction, compatibility risks, and hidden failure modes after the PR context is understood.
+
+If no mode is provided, default to `context`.
+
+## Context Mode
+
+Run or inspect `ci/util/pr_review_context.sh` when reviewing a checked-out PR branch. If the user provided a PR number, pass `--pr <number>`. If the user provided an issue number, pass `--issue <number>`.
+
+Summarize:
+
+- The linked issue or PR context.
+- The problem the PR is trying to solve.
+- How the PR attempts to solve it.
+- The important changed files and a sensible human review order.
+- Any missing context, such as no discoverable linked issue.
+
+Do not produce review findings in context mode.
+
+## Feedback Mode
+
+Before producing findings, make sure the context pass has happened. If it has not, gather and summarize the PR context first.
+
+Review for correctness, benchmark validity, performance, API compatibility, build and packaging impact, and consistency with existing code. Let the changed files determine which risks matter, while paying attention to relevant NVBench contracts such as CUDA stream ordering, timing boundaries, cold/batch/CPU-only measurement behavior, manual timer semantics, axis generation, output schemas, optional CUPTI/NVML behavior, CMake options, Python bindings, and test coverage.
+
+Report findings first, ordered by severity, with file and line references. Do not post comments to GitHub; the human reviewer decides which findings to use.
+
+## Adversarial Mode
+
+Before producing adversarial feedback, make sure the PR intent and implementation strategy are understood.
+
+Focus on whether the approach is sound:
+
+- Hidden assumptions that could fail.
+- Simpler or safer alternative designs.
+- Compatibility, layering, maintenance, or rollout risks.
+- Cases where the implementation solves the local issue but weakens a broader NVBench contract.
+
+Keep this distinct from normal feedback. It is acceptable for adversarial mode to produce questions or risks rather than concrete blocking findings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Agent Guidance
+
+## PR Review Workflow
+
+When helping with a pull request review, separate context gathering from review comments. Use the repo-local `review-nvbench` skill when available.
+
+The default mode is context gathering: use `ci/util/pr_review_context.sh`, explain the issue, PR intent, implementation strategy, and suggested file review order, but do not produce review findings until the user explicitly asks for feedback. If no issue or PR context is discoverable, explicitly flag that the review is missing required context before proceeding.
+
+Follow `docs/pr_review.md` for the full review workflow and NVBench-specific review focus.

--- a/ci/util/pr_review_context.sh
+++ b/ci/util/pr_review_context.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Collect the standard context needed before a Codex PR review.
+
+usage() {
+  cat <<USAGE
+Usage: $0 [options]
+
+Options:
+  -h, --help          Show this help and exit
+  --base-ref REF      Base ref for the PR comparison (default: upstream/main)
+  --no-fetch          Do not fetch the base ref before computing the merge base
+  --issue NUMBER      Fetch this GitHub issue explicitly
+  --pr NUMBER         Fetch this GitHub PR explicitly
+  --repo OWNER/REPO   GitHub repository for gh commands (default: NVIDIA/nvbench)
+  --patch             Include the full git diff from merge base to HEAD
+USAGE
+}
+
+BASE_REF="${CODEX_PR_BASE_REF:-upstream/main}"
+FETCH_BASE=1
+GH_REPO="${CODEX_PR_REPO:-NVIDIA/nvbench}"
+ISSUE_NUMBER=""
+PR_NUMBER=""
+INCLUDE_PATCH=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --base-ref)
+      BASE_REF="${2:-}"
+      shift 2
+      ;;
+    --no-fetch)
+      FETCH_BASE=0
+      shift
+      ;;
+    --issue)
+      ISSUE_NUMBER="${2:-}"
+      shift 2
+      ;;
+    --pr)
+      PR_NUMBER="${2:-}"
+      shift 2
+      ;;
+    --repo)
+      GH_REPO="${2:-}"
+      shift 2
+      ;;
+    --patch)
+      INCLUDE_PATCH=1
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${BASE_REF}" ]]; then
+  echo "--base-ref must not be empty" >&2
+  exit 2
+fi
+
+if [[ -z "${GH_REPO}" ]]; then
+  echo "--repo must not be empty" >&2
+  exit 2
+fi
+
+if ! repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  echo "This script must be run from inside a git repository." >&2
+  exit 1
+fi
+
+cd "${repo_root}"
+
+if [[ ! -f "./CMakeLists.txt" || ! -d "./nvbench" ]] ||
+   ! grep -Eq '^project\(NVBench\b' "./CMakeLists.txt"; then
+  echo "This script must be run from inside the NVBench repository." >&2
+  exit 1
+fi
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+warn() {
+  printf '!! %s\n' "$1"
+}
+
+current_branch="$(git branch --show-current || true)"
+if [[ -z "${PR_NUMBER}" && "${current_branch}" =~ (^|/)(pull-request|pr)[/-]([0-9]+)$ ]]; then
+  PR_NUMBER="${BASH_REMATCH[3]}"
+fi
+
+if [[ "${FETCH_BASE}" -eq 1 ]]; then
+  if [[ "${BASE_REF}" == */* ]]; then
+    remote="${BASE_REF%%/*}"
+    branch="${BASE_REF#*/}"
+    section "Fetch base ref"
+    if ! git fetch "${remote}" "${branch}"; then
+      warn "Could not fetch ${remote} ${branch}. Continuing with local ${BASE_REF} if available."
+    fi
+  else
+    warn "Skipping fetch for base ref '${BASE_REF}' because it does not name a remote branch."
+  fi
+fi
+
+if ! merge_base="$(git merge-base HEAD "${BASE_REF}" 2>/dev/null)"; then
+  echo "Could not compute merge base between HEAD and ${BASE_REF}." >&2
+  echo "Check that the base ref exists locally, or pass --base-ref." >&2
+  exit 1
+fi
+
+section "Review range"
+printf 'Repository: %s\n' "${repo_root}"
+printf 'Base ref:   %s\n' "${BASE_REF}"
+printf 'Merge base: %s\n' "${merge_base}"
+printf 'HEAD:       %s\n' "$(git rev-parse HEAD)"
+printf 'Branch:     %s\n' "${current_branch}"
+
+section "Commits"
+git log --oneline "${merge_base}"..HEAD
+
+section "Diff stat"
+git diff --stat "${merge_base}"..HEAD
+
+section "Changed files"
+git diff --name-status "${merge_base}"..HEAD
+
+commit_and_branch_text="$(
+  git log --format=%B "${merge_base}"..HEAD
+  printf '%s\n' "${current_branch}"
+)"
+
+referenced_issues="$(
+  printf '%s\n' "${commit_and_branch_text}" \
+    | grep -Eo '(NVIDIA/nvbench#[0-9]+|#[0-9]+|[Gg][Hh]-[0-9]+)' \
+    | grep -Eo '[0-9]+' \
+    | sort -u || true
+)"
+
+if [[ -n "${ISSUE_NUMBER}" ]]; then
+  referenced_issues="$(printf '%s\n%s\n' "${referenced_issues}" "${ISSUE_NUMBER}" | sed '/^$/d' | sort -u)"
+fi
+
+if command -v gh >/dev/null 2>&1; then
+  pr_issue_numbers=""
+  if [[ -n "${PR_NUMBER}" ]]; then
+    section "GitHub PR ${PR_NUMBER}"
+    gh pr view "${PR_NUMBER}" --repo "${GH_REPO}" --json number,title,url,body,closingIssuesReferences,commits,files || \
+      warn "Could not fetch PR ${PR_NUMBER} with gh."
+    pr_issue_numbers="$(
+      gh pr view "${PR_NUMBER}" --repo "${GH_REPO}" --json closingIssuesReferences --jq '.closingIssuesReferences[].number' 2>/dev/null || true
+    )"
+  else
+    section "GitHub PR for current branch"
+    gh pr view --repo "${GH_REPO}" --json number,title,url,body,closingIssuesReferences,commits,files || \
+      warn "Could not infer a GitHub PR for the current branch."
+    pr_issue_numbers="$(
+      gh pr view --repo "${GH_REPO}" --json closingIssuesReferences --jq '.closingIssuesReferences[].number' 2>/dev/null || true
+    )"
+  fi
+
+  if [[ -n "${pr_issue_numbers}" ]]; then
+    referenced_issues="$(printf '%s\n%s\n' "${referenced_issues}" "${pr_issue_numbers}" | sed '/^$/d' | sort -u)"
+  fi
+
+  if [[ -n "${referenced_issues}" ]]; then
+    while IFS= read -r issue; do
+      [[ -z "${issue}" ]] && continue
+      section "GitHub issue ${issue}"
+      gh issue view "${issue}" --repo "${GH_REPO}" || warn "Could not fetch issue ${issue} with gh."
+    done <<< "${referenced_issues}"
+  else
+    section "GitHub issue"
+    warn "No linked GitHub issue found in commit messages, branch name, or PR metadata. Pass --issue if the PR context lives elsewhere."
+  fi
+else
+  section "GitHub context"
+  warn "gh is not available. Install or authenticate GitHub CLI, or provide issue/PR context manually."
+  if [[ -n "${referenced_issues}" ]]; then
+    printf 'Referenced issue numbers found locally:\n%s\n' "${referenced_issues}"
+  else
+    warn "No linked GitHub issue found in commit messages or branch name."
+  fi
+fi
+
+if [[ "${INCLUDE_PATCH}" -eq 1 ]]; then
+  section "Patch"
+  git diff "${merge_base}"..HEAD
+fi

--- a/docs/pr_review.md
+++ b/docs/pr_review.md
@@ -1,0 +1,76 @@
+# PR Review Workflow
+
+This workflow gives Codex and human reviewers a consistent way to review NVBench pull requests. The goal is to start from the issue and PR intent, not from an isolated diff.
+
+## Quick Start
+
+Start from the checked-out PR branch in the repository root. Use the repo-local `review-nvbench` skill with an explicit mode:
+
+```text
+/review-nvbench context
+/review-nvbench feedback
+/review-nvbench adversarial
+```
+
+If no mode is provided, the workflow defaults to `context`.
+
+Context mode is the first pass. It gathers PR context and explains the change, but does not produce review comments:
+
+```bash
+ci/util/pr_review_context.sh
+```
+
+Ask Codex to summarize the linked issue, PR intent, implementation strategy, and a sensible file review order. Codex should not produce review findings in this phase.
+
+By default, the helper fetches `upstream/main`, computes the merge base with `HEAD`, prints commits, diff summaries, changed files, and any linked GitHub issues it can find in commit messages, the branch name, or PR metadata. Use `--no-fetch` if the base ref is already fresh.
+
+Use an explicit PR or issue when the local branch cannot reveal it:
+
+```bash
+ci/util/pr_review_context.sh --pr 1234
+ci/util/pr_review_context.sh --issue 1234
+```
+
+After the human reviewer has inspected the PR, use `/review-nvbench feedback` to request a normal review pass. For high-risk changes, use `/review-nvbench adversarial` after the PR context is understood.
+
+## Review Protocol
+
+1. Read `AGENTS.md` first.
+2. Run `ci/util/pr_review_context.sh` or manually gather the same context.
+3. If no issue or PR context is discoverable, clearly flag that the review is missing required context. Do not silently review a context-free diff.
+4. Read the linked issue description and PR description before reviewing the implementation.
+5. Summarize the exact problem the PR is solving, how the PR attempts to solve it, and a sensible file review order.
+6. Pause for the human reviewer to inspect the PR. Answer code-explanation questions during this phase, but do not produce review findings yet.
+7. When the user asks for a review pass, review for correctness, benchmark validity, performance, API compatibility, maintainability, and test coverage.
+8. Report findings first, ordered by severity, with file and line references. Keep summaries secondary to concrete review comments.
+
+Useful Git commands:
+
+```bash
+git fetch upstream main
+base="$(git merge-base HEAD upstream/main)"
+git log --oneline "$base"..HEAD
+git diff --stat "$base"..HEAD
+git diff "$base"..HEAD
+```
+
+Useful GitHub CLI commands:
+
+```bash
+gh pr view --repo NVIDIA/nvbench --json number,title,body,closingIssuesReferences,commits,files
+gh issue view <issue-number> --repo NVIDIA/nvbench
+```
+
+## Review Focus
+
+When asked for a review pass, focus on correctness, performance, and consistency with existing code. Let the changed files determine which risks matter, but pay special attention to NVBench-specific contracts when they are relevant:
+
+- CUDA stream ordering and synchronization semantics, especially `launch::get_stream`, `state::set_cuda_stream`, and work that uses the default stream.
+- Timing boundaries for cold, batch, CPU-only, and manual timer measurements.
+- `exec_tag` behavior, including `sync`, `timer`, `no_batch`, `gpu`, and `no_gpu`.
+- Axis generation, cartesian-product behavior, type-axis filtering, and CLI axis overrides.
+- Output compatibility for markdown, CSV, JSON, logs, summaries, and generated bulk data.
+- Optional CUPTI and NVML behavior, including builds where those features are disabled or unavailable.
+- CMake options, install/export rules, wheel packaging, and compiler/CUDA version coverage.
+- Python bindings and Python package behavior when changed.
+- Tests that cover both host-only logic and CUDA-device behavior where applicable.

--- a/docs/pr_review.md
+++ b/docs/pr_review.md
@@ -7,9 +7,9 @@ This workflow gives Codex and human reviewers a consistent way to review NVBench
 Start from the checked-out PR branch in the repository root. Use the repo-local `review-nvbench` skill with an explicit mode:
 
 ```text
-/review-nvbench context
-/review-nvbench feedback
-/review-nvbench adversarial
+$review-nvbench context
+$review-nvbench feedback
+$review-nvbench adversarial
 ```
 
 If no mode is provided, the workflow defaults to `context`.


### PR DESCRIPTION
Added:

  - .agents/skills/review-nvbench/SKILL.md: with /review-nvbench modes: context, feedback, adversarial
  - AGENTS.md: with repo-level PR review guidance
  - ci/util/pr_review_context.sh: executable helper modeled on the CCCL script but adapted for NVIDIA/nvbench
  - docs/pr_review.md: with the human/Codex review workflow and NVBench-specific review focus

This change is inspired by NVIDIA/cccl#8697