### PR TITLE
Fix cuda_timer move ownership

### DIFF
--- a/nvbench/cuda_timer.cuh
+++ b/nvbench/cuda_timer.cuh
@@ -33,6 +33,8 @@
 
 #include <cuda_runtime_api.h>
 
+#include <utility>
+
 namespace nvbench
 {
 
@@ -44,17 +46,27 @@ struct cuda_timer
     NVBENCH_CUDA_CALL(cudaEventCreate(&m_stop));
   }
 
-  __forceinline__ ~cuda_timer()
-  {
-    NVBENCH_CUDA_CALL(cudaEventDestroy(m_start));
-    NVBENCH_CUDA_CALL(cudaEventDestroy(m_stop));
-  }
+  __forceinline__ ~cuda_timer() { this->destroy(); }
 
   // move-only
   cuda_timer(const cuda_timer &)            = delete;
-  cuda_timer(cuda_timer &&)                 = default;
   cuda_timer &operator=(const cuda_timer &) = delete;
-  cuda_timer &operator=(cuda_timer &&)      = default;
+
+  cuda_timer(cuda_timer &&other) noexcept
+      : m_start{std::exchange(other.m_start, nullptr)}
+      , m_stop{std::exchange(other.m_stop, nullptr)}
+  {}
+
+  cuda_timer &operator=(cuda_timer &&other) noexcept
+  {
+    if (this != &other)
+    {
+      this->destroy();
+      m_start = std::exchange(other.m_start, nullptr);
+      m_stop  = std::exchange(other.m_stop, nullptr);
+    }
+    return *this;
+  }
 
   __forceinline__ void start(cudaStream_t stream)
   {
@@ -88,6 +100,18 @@ struct cuda_timer
   }
 
 private:
+  __forceinline__ void destroy() noexcept
+  {
+    if (m_start != nullptr)
+    {
+      NVBENCH_CUDA_CALL_NOEXCEPT(cudaEventDestroy(m_start));
+    }
+    if (m_stop != nullptr)
+    {
+      NVBENCH_CUDA_CALL_NOEXCEPT(cudaEventDestroy(m_stop));
+    }
+  }
+
   cudaEvent_t m_start;
   cudaEvent_t m_stop;
 };

--- a/testing/cuda_timer.cu
+++ b/testing/cuda_timer.cu
@@ -23,7 +23,27 @@
 
 #include <fmt/format.h>
 
+#include <type_traits>
+#include <utility>
+
 #include "test_asserts.cuh"
+
+static_assert(std::is_nothrow_move_constructible_v<nvbench::cuda_timer>);
+static_assert(std::is_nothrow_move_assignable_v<nvbench::cuda_timer>);
+
+void test_move()
+{
+  nvbench::cuda_timer source;
+  nvbench::cuda_timer moved{std::move(source)};
+  nvbench::cuda_timer assigned;
+  assigned = std::move(moved);
+
+  nvbench::cuda_stream stream;
+  assigned.start(stream);
+  assigned.stop(stream);
+  NVBENCH_CUDA_CALL(cudaDeviceSynchronize());
+  ASSERT(assigned.ready());
+}
 
 void test_basic(cudaStream_t time_stream, cudaStream_t exec_stream, bool expected)
 {
@@ -52,4 +72,8 @@ void test_basic()
   test_basic(stream1, stream2, false);
 }
 
-int main() { test_basic(); }
+int main()
+{
+  test_move();
+  test_basic();
+}

--- a/testing/cuda_timer.cu
+++ b/testing/cuda_timer.cu
@@ -74,6 +74,6 @@ void test_basic()
 
 int main()
 {
-  test_move();
   test_basic();
+  test_move();
 }


### PR DESCRIPTION
## Summary

- transfer `cuda_timer` event ownership in its move operations
- clean up existing destination events during move assignment
- cover move construction and move assignment in the timer test

## Why

`cuda_timer` owns two raw `cudaEvent_t` handles. Its default move operations copy those handles without clearing the source, so destroying the moved-to and moved-from timers destroys the same events twice. Move assignment also overwrites the destination's existing events without destroying them.

The custom moves preserve the timer's original move-only API while ensuring each event has exactly one owner.

## Validation

- `pre-commit run --files nvbench/cuda_timer.cuh testing/cuda_timer.cu`
- `git diff --check`

CUDA tests were not run locally because the development machine does not have a CUDA compiler.
