### PR TITLE
Readability improvement by using device_clock alias

### DIFF
--- a/nvbench/blocking_kernel.cu
+++ b/nvbench/blocking_kernel.cu
@@ -33,6 +33,9 @@
 namespace
 {
 
+// high_resolution_clock is suitable for measuring elapsed time within device code.
+using device_clock = cuda::std::chrono::high_resolution_clock;
+
 // Once launched, this kernel will block the stream until `flag` updates is
 // non-zero. If `timeout` seconds pass, an error will be printed and the stream
 // will unblock.
@@ -40,16 +43,16 @@ __global__ void block_stream(const volatile nvbench::int32_t *flag,
                              volatile nvbench::int32_t *timeout_flag,
                              nvbench::float64_t timeout)
 {
-  const auto start_point = cuda::std::chrono::high_resolution_clock::now();
+  const auto start_point = device_clock::now();
   const auto timeout_ns =
     cuda::std::chrono::nanoseconds(static_cast<nvbench::int64_t>(timeout * 1e9));
   const auto timeout_point = start_point + timeout_ns;
 
   const bool use_timeout = timeout >= 0.;
-  auto now               = cuda::std::chrono::high_resolution_clock::now();
+  auto now               = device_clock::now();
   while (!(*flag) && (!use_timeout || now < timeout_point))
   {
-    now = cuda::std::chrono::high_resolution_clock::now();
+    now = device_clock::now();
   }
 
   if (now >= timeout_point)

--- a/nvbench/test_kernels.cuh
+++ b/nvbench/test_kernels.cuh
@@ -46,20 +46,23 @@
 namespace nvbench
 {
 
+// high_resolution_clock is suitable for measuring elapsed time within device code.
+using device_clock = cuda::std::chrono::high_resolution_clock;
+
 /*!
  * Each launched thread just sleeps for `seconds`.
  */
 __global__ void sleep_kernel(double seconds)
 {
-  const auto start = cuda::std::chrono::high_resolution_clock::now();
+  const auto start = device_clock::now();
   const auto ns =
     cuda::std::chrono::nanoseconds(static_cast<nvbench::int64_t>(seconds * 1000 * 1000 * 1000));
   const auto finish = start + ns;
 
-  auto now = cuda::std::chrono::high_resolution_clock::now();
+  auto now = device_clock::now();
   while (now < finish)
   {
-    now = cuda::std::chrono::high_resolution_clock::now();
+    now = device_clock::now();
   }
 }
 


### PR DESCRIPTION
Use alias `device_clock = cuda::std::chrono::high_resolution_clock;` for readability improvement, and a chance for comment to state that using it in device code for timing purposes is correct and intentional.

I looked at this as a follow-up to #371, which replaced std::chrono::high_resolution_clock with std::chrono::steady_clock.

Per https://nvidia.github.io/cccl/unstable/libcudacxx/standard_api/time_library.html type ``cuda::std::chrono::steady_clock`` is not provided, and while `cuda::std::chrono::high_resolution_clock` is not heterogeneously steady, but is steady within device code and suitable for device-side performance measurement.