### PR TITLE
Made some classes immovable, in addition to already being not-copyable

### DIFF
--- a/nvbench/blocking_kernel.cuh
+++ b/nvbench/blocking_kernel.cuh
@@ -113,11 +113,12 @@ struct blocking_kernel
     flag                            = 1;
   }
 
-  // move-only
+  // The device pointers refer to registered storage inside this object.
+  // Moving would leave them pointing at the moved-from object.
   blocking_kernel(const blocking_kernel &)            = delete;
-  blocking_kernel(blocking_kernel &&)                 = default;
+  blocking_kernel(blocking_kernel &&)                 = delete;
   blocking_kernel &operator=(const blocking_kernel &) = delete;
-  blocking_kernel &operator=(blocking_kernel &&)      = default;
+  blocking_kernel &operator=(blocking_kernel &&)      = delete;
 
 private:
   nvbench::int32_t m_host_flag{};

--- a/nvbench/detail/device_scope.cuh
+++ b/nvbench/detail/device_scope.cuh
@@ -48,9 +48,9 @@ struct [[maybe_unused]] device_scope
   }
   ~device_scope() { NVBENCH_CUDA_CALL(cudaSetDevice(m_old_device_id)); }
 
-  // move-only
-  device_scope(device_scope &&)                 = default;
-  device_scope &operator=(device_scope &&)      = default;
+  // This scope guard must restore the previous device exactly once.
+  device_scope(device_scope &&)                 = delete;
+  device_scope &operator=(device_scope &&)      = delete;
   device_scope(const device_scope &)            = delete;
   device_scope &operator=(const device_scope &) = delete;
 

--- a/nvbench/detail/device_scope.cuh
+++ b/nvbench/detail/device_scope.cuh
@@ -49,10 +49,10 @@ struct [[maybe_unused]] device_scope
   ~device_scope() { NVBENCH_CUDA_CALL(cudaSetDevice(m_old_device_id)); }
 
   // This scope guard must restore the previous device exactly once.
-  device_scope(device_scope &&)                 = delete;
-  device_scope &operator=(device_scope &&)      = delete;
   device_scope(const device_scope &)            = delete;
+  device_scope(device_scope &&)                 = delete;
   device_scope &operator=(const device_scope &) = delete;
+  device_scope &operator=(device_scope &&)      = delete;
 
 private:
   static int get_current_device()

--- a/nvbench/detail/gpu_frequency.cuh
+++ b/nvbench/detail/gpu_frequency.cuh
@@ -43,11 +43,11 @@ struct gpu_frequency
 {
   gpu_frequency() = default;
 
-  // move-only
+  // timestamps_kernel members are tied to their own registered host storage.
   gpu_frequency(const gpu_frequency &)            = delete;
-  gpu_frequency(gpu_frequency &&)                 = default;
+  gpu_frequency(gpu_frequency &&)                 = delete;
   gpu_frequency &operator=(const gpu_frequency &) = delete;
-  gpu_frequency &operator=(gpu_frequency &&)      = default;
+  gpu_frequency &operator=(gpu_frequency &&)      = delete;
 
   void start(const nvbench::cuda_stream &stream) { m_start.record(stream); }
 

--- a/nvbench/detail/l2flush.cuh
+++ b/nvbench/detail/l2flush.cuh
@@ -60,6 +60,7 @@ struct l2flush
     }
   }
 
+  // This object owns a CUDA allocation that must be freed exactly once.
   l2flush(const l2flush &)            = delete;
   l2flush(l2flush &&)                 = delete;
   l2flush &operator=(const l2flush &) = delete;

--- a/nvbench/detail/l2flush.cuh
+++ b/nvbench/detail/l2flush.cuh
@@ -60,6 +60,11 @@ struct l2flush
     }
   }
 
+  l2flush(const l2flush &)            = delete;
+  l2flush(l2flush &&)                 = delete;
+  l2flush &operator=(const l2flush &) = delete;
+  l2flush &operator=(l2flush &&)      = delete;
+
   __forceinline__ void flush(cudaStream_t stream)
   {
     if (m_l2_size > 0)

--- a/nvbench/detail/timestamps_kernel.cuh
+++ b/nvbench/detail/timestamps_kernel.cuh
@@ -45,11 +45,12 @@ struct timestamps_kernel
 
   void record(const nvbench::cuda_stream &stream);
 
-  // move-only
+  // The device pointer refers to registered storage inside this object.
+  // Moving would leave it pointing at the moved-from object.
   timestamps_kernel(const timestamps_kernel &)            = delete;
-  timestamps_kernel(timestamps_kernel &&)                 = default;
+  timestamps_kernel(timestamps_kernel &&)                 = delete;
   timestamps_kernel &operator=(const timestamps_kernel &) = delete;
-  timestamps_kernel &operator=(timestamps_kernel &&)      = default;
+  timestamps_kernel &operator=(timestamps_kernel &&)      = delete;
 
   nvbench::uint64_t m_host_timestamps[2];
   nvbench::uint64_t *m_device_timestamps{};

--- a/testing/cleanup_guards.cu
+++ b/testing/cleanup_guards.cu
@@ -3,10 +3,14 @@
 
 #include <nvbench/blocking_kernel.cuh>
 #include <nvbench/cpu_timer.cuh>
+#include <nvbench/detail/device_scope.cuh>
+#include <nvbench/detail/gpu_frequency.cuh>
+#include <nvbench/detail/l2flush.cuh>
 #include <nvbench/detail/measure_cold.cuh>
 #include <nvbench/detail/measure_cold_launch_timer_core.cuh>
 #include <nvbench/detail/measure_hot.cuh>
 #include <nvbench/detail/stream_cleanup_guard.cuh>
+#include <nvbench/detail/timestamps_kernel.cuh>
 
 #include <cuda_runtime_api.h>
 
@@ -97,11 +101,25 @@ constexpr void verify_stream_cleanup_guard_noexcept_contract()
                 "stream_cleanup_guard release must remain noexcept.");
 }
 
+template <typename T>
+constexpr void verify_immovable_resource_owner()
+{
+  static_assert(!std::is_copy_constructible_v<T>, "Resource owner must not be copy constructible.");
+  static_assert(!std::is_copy_assignable_v<T>, "Resource owner must not be copy assignable.");
+  static_assert(!std::is_move_constructible_v<T>, "Resource owner must not be move constructible.");
+  static_assert(!std::is_move_assignable_v<T>, "Resource owner must not be move assignable.");
+}
+
 constexpr void verify_noexcept_contracts()
 {
   verify_cpu_timer_noexcept_contract<nvbench::cpu_timer>();
   static_assert(noexcept(std::declval<nvbench::blocking_kernel &>().unblock_noexcept()),
                 "blocking_kernel unblock_noexcept must remain noexcept.");
+  verify_immovable_resource_owner<nvbench::blocking_kernel>();
+  verify_immovable_resource_owner<nvbench::detail::device_scope>();
+  verify_immovable_resource_owner<nvbench::detail::gpu_frequency>();
+  verify_immovable_resource_owner<nvbench::detail::l2flush>();
+  verify_immovable_resource_owner<nvbench::detail::timestamps_kernel>();
 
   verify_stream_cleanup_measure_noexcept_contract<hot_cleanup_probe>();
   verify_cold_measure_noexcept_contract<cold_cleanup_probe>();


### PR DESCRIPTION
Closes #421

Defaulted move-constructor/move-assignment-operator did not the right thing for these classes as described in the issue.

Since current code-base does not require these classes to be movable, explicitly delete move-constructor and move-assignment operator until it is needed and a proper implementation is added.

The following entities are modified in this PR:

- `nvbench::blocking_kernel`
- `nvbench::detail::timestamps_kernel`
- `nvbench::detail::gpu_frequency`
- `nvbench::detail::device_scope`
- `nvbench::detail::l2flush`

For `l2flush` class the PR explicitly deletes copy-constructor/copy-assignment-operator in addition to move-constructor/move-assignment-operator because it was implicitly defaulted and did not do the right job.
