### PR TITLE
Avoid redefining existing preprocessor variable in version.cuh

### DIFF
--- a/nvbench/version.cuh
+++ b/nvbench/version.cuh
@@ -31,6 +31,11 @@
 // Include the auto-generated version header:
 #include <nvbench/detail/version.cuh>
 
+#ifdef NVBENCH_VERSION
+// undefine auto-generated string NVBENCH_VERSION
+#undef NVBENCH_VERSION
+#endif
+
 // clang-format off
 
 /// Numeric version as "MMmmpp"


### PR DESCRIPTION
After `#include <nvbench/detail/version.cuh>`, make sure to undefine `NVBENCH_VERSION` if defined before redefining the macro. 

This resolves recent build break due to external change.

Closes #427 