### PR TITLE
Reintroduce support for CLI option to disable blocking kernel

### DIFF
--- a/docs/cli_help.md
+++ b/docs/cli_help.md
@@ -130,6 +130,13 @@
   * Applies to the most recent `--benchmark`, or all benchmarks if specified
     before any `--benchmark` arguments.
 
+* `--disable-blocking-kernel`
+  * Do not use the `blocking_kernel`.
+  * This is narrower than `--profile`: it preserves normal repeated benchmark
+    execution. Use `--profile` for external profiling workflows.
+  * Applies to the most recent `--benchmark`, or all benchmarks if specified
+    before any `--benchmark` arguments.
+
 * `--no-batch`
   * Do not run batched measurements even if enabled.
   * Intended to shorten run-time when batched measurements are not of interest.

--- a/docs/cli_help.md
+++ b/docs/cli_help.md
@@ -131,7 +131,7 @@
     before any `--benchmark` arguments.
 
 * `--disable-blocking-kernel`
-  * Do not use the `blocking_kernel`.
+  * Disable NVBench's stream-blocking timing helper for cold measurements.
   * This is narrower than `--profile`: it preserves normal repeated benchmark
     execution. Use `--profile` for external profiling workflows.
   * Applies to the most recent `--benchmark`, or all benchmarks if specified

--- a/nvbench/blocking_kernel.cu
+++ b/nvbench/blocking_kernel.cu
@@ -87,8 +87,8 @@ __global__ void block_stream(const volatile nvbench::int32_t *flag,
            "NVBench documentation.\n"
            "\n"
            "If this happens while profiling with an external tool,\n"
-           "pass the `--profile` flag to the executable to disable use of blocking kernel\n"
-           "and to also run the benchmark only once.\n"
+           "pass the `--profile` flag to the executable. If normal repeated\n"
+           "benchmark execution is still desired, pass `--disable-blocking-kernel`.\n"
            "\n"
            "For more information, see the 'Benchmark Properties' section of the\n"
            "NVBench documentation.\n\n",

--- a/nvbench/option_parser.cu
+++ b/nvbench/option_parser.cu
@@ -512,6 +512,11 @@ void option_parser::parse_range(option_parser::arg_iterator_t first,
       this->enable_profile();
       first += 1;
     }
+    else if (arg == "--disable-blocking-kernel")
+    {
+      this->disable_blocking_kernel();
+      first += 1;
+    }
     else if (arg == "--no-batch")
     {
       this->disable_batched();
@@ -819,6 +824,18 @@ void option_parser::enable_profile()
   benchmark_base &bench = *m_benchmarks.back();
   bench.set_disable_blocking_kernel(true);
   bench.set_run_once(true);
+}
+
+void option_parser::disable_blocking_kernel()
+{
+  // If no active benchmark, save args as global
+  if (m_benchmarks.empty())
+  {
+    m_global_benchmark_args.push_back("--disable-blocking-kernel");
+    return;
+  }
+  benchmark_base &bench = *m_benchmarks.back();
+  bench.set_disable_blocking_kernel(true);
 }
 
 void option_parser::disable_batched()

--- a/nvbench/option_parser.cuh
+++ b/nvbench/option_parser.cuh
@@ -101,6 +101,7 @@ private:
   void set_stopping_criterion(const std::string &criterion);
 
   void enable_profile();
+  void disable_blocking_kernel();
   void disable_batched();
 
   void add_benchmark(const std::string &name);

--- a/testing/option_parser.cu
+++ b/testing/option_parser.cu
@@ -156,6 +156,18 @@ struct temp_tree
   return states_to_string(parser_to_states(parser));
 }
 
+void assert_state_flags(const std::vector<nvbench::state> &states,
+                        bool disable_blocking_kernel,
+                        bool run_once)
+{
+  ASSERT(!states.empty());
+  for (const auto &state : states)
+  {
+    ASSERT(state.get_disable_blocking_kernel() == disable_blocking_kernel);
+    ASSERT(state.get_run_once() == run_once);
+  }
+}
+
 } // namespace
 
 void test_empty()
@@ -1294,6 +1306,49 @@ void test_json_stream_destinations()
   }
 }
 
+void test_disable_blocking_kernel()
+{
+  {
+    nvbench::option_parser parser;
+    parser.parse({"--benchmark", "DummyBench", "--disable-blocking-kernel"});
+    assert_state_flags(parser_to_states(parser), true, false);
+  }
+
+  {
+    nvbench::option_parser parser;
+    parser.parse(
+      {"--disable-blocking-kernel", "--benchmark", "DummyBench", "--benchmark", "TestBench"});
+
+    const auto &benches = parser.get_benchmarks();
+    ASSERT(benches.size() == 2);
+    ASSERT(benches[0] != nullptr);
+    ASSERT(benches[1] != nullptr);
+
+    assert_state_flags(nvbench::detail::state_generator::create(*benches[0]), true, false);
+    assert_state_flags(nvbench::detail::state_generator::create(*benches[1]), true, false);
+  }
+
+  {
+    nvbench::option_parser parser;
+    parser.parse(
+      {"--benchmark", "DummyBench", "--disable-blocking-kernel", "--benchmark", "TestBench"});
+
+    const auto &benches = parser.get_benchmarks();
+    ASSERT(benches.size() == 2);
+    ASSERT(benches[0] != nullptr);
+    ASSERT(benches[1] != nullptr);
+
+    assert_state_flags(nvbench::detail::state_generator::create(*benches[0]), true, false);
+    assert_state_flags(nvbench::detail::state_generator::create(*benches[1]), false, false);
+  }
+
+  {
+    nvbench::option_parser parser;
+    parser.parse({"--benchmark", "DummyBench", "--profile"});
+    assert_state_flags(parser_to_states(parser), true, true);
+  }
+}
+
 void test_output_parent_directories_created()
 {
   const auto unique_suffix = std::chrono::steady_clock::now().time_since_epoch().count();
@@ -1677,7 +1732,11 @@ try
   test_skip_time();
   test_cold_max_warmup_walltime();
   test_timeout();
+<<<<<<< HEAD
   test_json_stream_destinations();
+=======
+  test_disable_blocking_kernel();
+>>>>>>> 445da5d (Reintroduce support for CLI option to disable blocking kernel)
   test_output_parent_directories_created();
 
   test_stopping_criterion();

--- a/testing/option_parser.cu
+++ b/testing/option_parser.cu
@@ -1347,6 +1347,18 @@ void test_disable_blocking_kernel()
     parser.parse({"--benchmark", "DummyBench", "--profile"});
     assert_state_flags(parser_to_states(parser), true, true);
   }
+
+  {
+    nvbench::option_parser parser;
+    parser.parse({"--benchmark", "DummyBench", "--profile", "--disable-blocking-kernel"});
+    assert_state_flags(parser_to_states(parser), true, true);
+  }
+
+  {
+    nvbench::option_parser parser;
+    parser.parse({"--benchmark", "DummyBench", "--disable-blocking-kernel", "--profile"});
+    assert_state_flags(parser_to_states(parser), true, true);
+  }
 }
 
 void test_output_parent_directories_created()

--- a/testing/option_parser.cu
+++ b/testing/option_parser.cu
@@ -1732,11 +1732,8 @@ try
   test_skip_time();
   test_cold_max_warmup_walltime();
   test_timeout();
-<<<<<<< HEAD
   test_json_stream_destinations();
-=======
   test_disable_blocking_kernel();
->>>>>>> 445da5d (Reintroduce support for CLI option to disable blocking kernel)
   test_output_parent_directories_created();
 
   test_stopping_criterion();


### PR DESCRIPTION
This PR reintroduced `--disable-blocking-kernel` CLI option at downstream user's request. 

I was removed in #254, to disallow specifying once existing `--run-once` option without using `--disable-blocking-kernel`.

Closes #425