### PR TITLE
Fix test failure for nvbench tooling deps in editable install

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -104,6 +104,12 @@ jobs:
       contents: read
     uses: ./.github/workflows/build-and-test-python-wheels.yml
 
+  python-editable:
+    name: Python Editable Install
+    permissions:
+      contents: read
+    uses: ./.github/workflows/test-python-editable.yml
+
   verify-devcontainers:
     name: Verify Dev Containers
     if: ${{ !contains(github.event.head_commit.message, '[skip-vdc]') }}
@@ -126,6 +132,7 @@ jobs:
       - nvbench
       - nvbench-windows
       - python-wheels
+      - python-editable
       - verify-devcontainers
     steps:
       - name: Check status of all precursor jobs

--- a/.github/workflows/test-python-editable.yml
+++ b/.github/workflows/test-python-editable.yml
@@ -1,0 +1,75 @@
+name: Test Python Editable Install
+
+on:
+  workflow_call:
+    inputs:
+      python:
+        type: string
+        required: false
+      cuda:
+        type: string
+        required: false
+      host:
+        type: string
+        required: false
+      devcontainer_version:
+        type: string
+        required: false
+  workflow_dispatch:
+    inputs:
+      python:
+        description: "Python major.minor version override"
+        type: string
+        required: false
+      cuda:
+        description: "CUDA Toolkit major.minor version override"
+        type: string
+        required: false
+      host:
+        description: "Host compiler tag override"
+        type: string
+        required: false
+      devcontainer_version:
+        description: "RAPIDS devcontainer version override"
+        type: string
+        required: false
+
+defaults:
+  run:
+    shell: bash --noprofile --norc -euo pipefail {0}
+
+jobs:
+  test-editable-install:
+    name: Test editable install
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Test editable install
+        env:
+          PYTHON_INPUT: ${{ inputs.python }}
+          CUDA_INPUT: ${{ inputs.cuda }}
+          HOST_INPUT: ${{ inputs.host }}
+          DEVCONTAINER_INPUT: ${{ inputs.devcontainer_version }}
+        run: |
+          args=()
+          if [[ -n "${PYTHON_INPUT}" ]]; then
+            args+=("-py-version" "${PYTHON_INPUT}")
+          fi
+          if [[ -n "${CUDA_INPUT}" ]]; then
+            args+=("-cuda-version" "${CUDA_INPUT}")
+          fi
+          if [[ -n "${HOST_INPUT}" ]]; then
+            args+=("-host" "${HOST_INPUT}")
+          fi
+          if [[ -n "${DEVCONTAINER_INPUT}" ]]; then
+            args+=("-devcontainer-version" "${DEVCONTAINER_INPUT}")
+          fi
+          bash ci/test_cuda_bench_editable.sh "${args[@]}"

--- a/ci/test_cuda_bench_editable.sh
+++ b/ci/test_cuda_bench_editable.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+set -euo pipefail
+
+ci_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage="Usage: $0 [-py-version <python_version>] [-cuda-version <cuda_version>] [-host <host_tag>] [-devcontainer-version <version>]"
+
+# shellcheck source=ci/util/python/common_arg_parser.sh
+source "$ci_dir/util/python/common_arg_parser.sh"
+
+die_usage() {
+    echo "Error: $1" >&2
+    echo "$usage" >&2
+    exit 1
+}
+
+require_option_value() {
+    local option_name="$1"
+    local option_value="${2-}"
+    if [[ -z "${option_value}" || "${option_value}" == -* ]]; then
+        die_usage "${option_name} requires a value"
+    fi
+}
+
+if ! parse_python_args "$@"; then
+    echo "$usage" >&2
+    exit 1
+fi
+
+cuda_version="13.3"
+host_tag="gcc15"
+devcontainer_version="26.08"
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -cuda-version=*)
+            [[ -n "${1#*=}" ]] || die_usage "-cuda-version requires a value"
+            cuda_version="${1#*=}"
+            shift
+            ;;
+        -cuda-version)
+            require_option_value "-cuda-version" "${2-}"
+            cuda_version="$2"
+            shift 2
+            ;;
+        -host=*)
+            [[ -n "${1#*=}" ]] || die_usage "-host requires a value"
+            host_tag="${1#*=}"
+            shift
+            ;;
+        -host)
+            require_option_value "-host" "${2-}"
+            host_tag="$2"
+            shift 2
+            ;;
+        -devcontainer-version=*)
+            [[ -n "${1#*=}" ]] || die_usage "-devcontainer-version requires a value"
+            devcontainer_version="${1#*=}"
+            shift
+            ;;
+        -devcontainer-version)
+            require_option_value "-devcontainer-version" "${2-}"
+            devcontainer_version="$2"
+            shift 2
+            ;;
+        -py-version=*)
+            [[ -n "${1#*=}" ]] || die_usage "-py-version requires a value"
+            shift
+            ;;
+        -py-version)
+            require_option_value "-py-version" "${2-}"
+            shift 2
+            ;;
+        *)
+            die_usage "Unknown option: $1"
+            ;;
+    esac
+done
+
+if [[ -z "${py_version:-}" ]]; then
+    py_version="3.14"
+fi
+
+cuda_major="${cuda_version%%.*}"
+if [[ "${cuda_major}" != "12" && "${cuda_major}" != "13" ]]; then
+    die_usage "Unsupported CUDA version: $cuda_version"
+fi
+cuda_extra="cu${cuda_major}"
+readonly cuda_extra
+cuda_image="rapidsai/devcontainers:${devcontainer_version}-cpp-${host_tag}-cuda${cuda_version}"
+readonly cuda_image
+
+if [[ -z "${HOST_WORKSPACE:-}" ]]; then
+  HOST_WORKSPACE="$(cd "${ci_dir}/.." && pwd)"
+fi
+readonly HOST_WORKSPACE
+
+echo "::group::🧪 Testing editable cuda-bench install on ${cuda_image}"
+(
+  set -x
+  # Prevent GHA runners from exhausting available storage with leftover images,
+  # even when the containerized build or tests fail.
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    trap 'docker rmi -f "${cuda_image}" || true' EXIT
+  fi
+
+  docker pull "${cuda_image}"
+  docker run --rm -i \
+      --workdir /workspace \
+      --mount "type=bind,source=${HOST_WORKSPACE},target=/workspace/" \
+      --env "py_version=${py_version}" \
+      --env "cuda_extra=${cuda_extra}" \
+      "${cuda_image}" \
+      /bin/bash -euo pipefail <<'EOF'
+  source /workspace/ci/pyenv_helper.sh
+  setup_python_env "${py_version}"
+
+  cd /workspace/python
+
+  python --version
+  nvcc --version
+  export CXX="$(which g++)"
+  export CUDACXX="$(which nvcc)"
+  export CUDAHOSTCXX="$(which g++)"
+  # Build one supported architecture only; this job validates editable
+  # packaging, not GPU execution or architecture coverage.
+  export CUDAARCHS="75-real"
+
+  python -m pip install --upgrade pip
+  python -m pip install -e ".[${cuda_extra},tools]" pytest
+
+  cd /tmp
+
+  python - <<'PY'
+import importlib.util
+
+from cuda.bench._paths import _get_cuda_major_version
+
+cuda_major = _get_cuda_major_version()
+extension_name = f"cuda.bench.cu{cuda_major}._nvbench"
+extension_spec = importlib.util.find_spec(extension_name)
+if extension_spec is None:
+    raise RuntimeError(f"{extension_name} is not discoverable")
+
+print(f"Found editable extension module: {extension_spec.origin}")
+PY
+
+  python -m pytest -v \
+    /workspace/python/test/test_benchmark_result.py \
+    /workspace/python/test/test_cuda_bench_nvbench.py \
+    /workspace/python/test/test_cuda_bench_paths.py \
+    /workspace/python/test/test_nvbench_compare_robust.py \
+    /workspace/python/test/test_nvbench_json_summary.py \
+    /workspace/python/test/test_nvbench_tooling_deps.py
+EOF
+)
+echo "::endgroup::"

--- a/python/test/test_nvbench_tooling_deps.py
+++ b/python/test/test_nvbench_tooling_deps.py
@@ -2,23 +2,61 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import importlib
+import importlib.metadata
 import shutil
 import sys
 from pathlib import Path
 
 import pytest
 
+SCRIPT_SOURCE_FILES = [
+    "nvbench_compare.py",
+    "nvbench_compare_robust.py",
+    "nvbench_histogram.py",
+    "nvbench_json_summary.py",
+    "nvbench_plot_bwutil.py",
+    "nvbench_tooling_deps.py",
+    "nvbench_walltime.py",
+]
+
 
 @pytest.fixture
 def tooling_deps(monkeypatch):
-    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    scripts_dir = find_script_sources()
     monkeypatch.syspath_prepend(str(scripts_dir))
     monkeypatch.delitem(sys.modules, "nvbench_tooling_deps", raising=False)
     return importlib.import_module("nvbench_tooling_deps")
 
 
-def make_packaged_scripts_tree(tmp_path: Path) -> Path:
-    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+def is_script_source_dir(path: Path) -> bool:
+    return (
+        all((path / filename).is_file() for filename in SCRIPT_SOURCE_FILES)
+        and (path / "nvbench_json").is_dir()
+    )
+
+
+def find_script_sources() -> Path:
+    source_tree_scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    if source_tree_scripts_dir.is_dir() and is_script_source_dir(
+        source_tree_scripts_dir
+    ):
+        return source_tree_scripts_dir
+
+    try:
+        packaged_spec = importlib.util.find_spec(
+            "cuda.bench.scripts.nvbench_tooling_deps"
+        )
+    except ModuleNotFoundError:
+        packaged_spec = None
+    if packaged_spec is not None and packaged_spec.origin is not None:
+        scripts_dir = Path(packaged_spec.origin).resolve().parent
+        if is_script_source_dir(scripts_dir):
+            return scripts_dir
+
+    pytest.skip("NVBench script sources are not available in this test layout")
+
+
+def make_packaged_scripts_tree(tmp_path: Path, scripts_dir: Path) -> Path:
     package_dir = tmp_path / "cuda" / "bench" / "scripts"
     results_dir = tmp_path / "cuda" / "bench" / "results"
     package_dir.mkdir(parents=True)
@@ -30,15 +68,7 @@ def make_packaged_scripts_tree(tmp_path: Path) -> Path:
         results_dir,
     ]:
         (package / "__init__.py").write_text("", encoding="utf-8")
-    for filename in [
-        "nvbench_compare.py",
-        "nvbench_compare_robust.py",
-        "nvbench_histogram.py",
-        "nvbench_json_summary.py",
-        "nvbench_plot_bwutil.py",
-        "nvbench_tooling_deps.py",
-        "nvbench_walltime.py",
-    ]:
+    for filename in SCRIPT_SOURCE_FILES:
         shutil.copy(scripts_dir / filename, package_dir / filename)
     shutil.copytree(
         scripts_dir / "nvbench_json",
@@ -65,15 +95,26 @@ def clear_packaged_cuda_modules(monkeypatch):
             monkeypatch.delitem(sys.modules, module_name, raising=False)
 
 
+def assert_packaged_script_module(module, module_name: str, filename: str) -> None:
+    # Editable installs may redirect cuda.bench.scripts.* to the source-tree
+    # scripts/ directory, so assert the import contract rather than a physical
+    # package directory.
+    assert module.__name__ == module_name
+    assert module.__package__ == "cuda.bench.scripts"
+    assert Path(module.__file__).name == filename
+
+
 def test_tooling_deps_imports_from_packaged_script_path(tmp_path, monkeypatch):
-    package_dir = make_packaged_scripts_tree(tmp_path)
+    scripts_dir = find_script_sources()
+    make_packaged_scripts_tree(tmp_path, scripts_dir)
 
     monkeypatch.syspath_prepend(str(tmp_path))
     clear_packaged_cuda_modules(monkeypatch)
 
-    module = importlib.import_module("cuda.bench.scripts.nvbench_tooling_deps")
+    module_name = "cuda.bench.scripts.nvbench_tooling_deps"
+    module = importlib.import_module(module_name)
 
-    assert Path(module.__file__) == package_dir / "nvbench_tooling_deps.py"
+    assert_packaged_script_module(module, module_name, "nvbench_tooling_deps.py")
     assert module.ToolingDependency("math", "math", "testing").extra == "tools"
 
 
@@ -91,7 +132,8 @@ def test_tooling_deps_imports_from_packaged_script_path(tmp_path, monkeypatch):
 def test_console_script_modules_import_from_packaged_paths(
     tmp_path, monkeypatch, module_name, expected_entry
 ):
-    package_dir = make_packaged_scripts_tree(tmp_path)
+    scripts_dir = find_script_sources()
+    make_packaged_scripts_tree(tmp_path, scripts_dir)
     leaf_module = module_name.rsplit(".", 1)[-1]
 
     monkeypatch.syspath_prepend(str(tmp_path))
@@ -99,12 +141,27 @@ def test_console_script_modules_import_from_packaged_paths(
 
     module = importlib.import_module(module_name)
 
-    assert Path(module.__file__) == package_dir / f"{leaf_module}.py"
+    assert_packaged_script_module(module, module_name, f"{leaf_module}.py")
     assert callable(getattr(module, expected_entry))
 
 
 def test_compare_console_scripts_are_explicitly_named():
     pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    if not pyproject.exists():
+        entry_points = importlib.metadata.entry_points(group="console_scripts")
+        scripts = {entry_point.name: entry_point.value for entry_point in entry_points}
+
+        assert (
+            scripts["nvbench-compare-robust"]
+            == "cuda.bench.scripts.nvbench_compare_robust:main"
+        )
+        assert (
+            scripts["nvbench-compare-legacy"]
+            == "cuda.bench.scripts.nvbench_compare:main"
+        )
+        assert "nvbench-compare" not in scripts
+        return
+
     contents = pyproject.read_text(encoding="utf-8")
 
     assert (
@@ -118,7 +175,7 @@ def test_compare_console_scripts_are_explicitly_named():
 
 
 def test_nvbench_compare_script_path_uses_legacy_behavior(monkeypatch):
-    scripts_dir = Path(__file__).resolve().parents[1] / "scripts"
+    scripts_dir = find_script_sources()
     monkeypatch.syspath_prepend(str(scripts_dir))
     monkeypatch.delitem(sys.modules, "nvbench_compare", raising=False)
 

--- a/python/test/test_nvbench_tooling_deps.py
+++ b/python/test/test_nvbench_tooling_deps.py
@@ -3,6 +3,7 @@
 
 import importlib
 import importlib.metadata
+import importlib.util
 import shutil
 import sys
 from pathlib import Path


### PR DESCRIPTION
Using editable installation of `cuda-bench`, the test test_nvbench_tooling_deps.py had test failures.

The test used ``__file__`` and checked it against layout expected in regular install. 
actual value is different in editable installs, so test failed.

This PR fixes the test, and adds a workflow that runs editable install and tests that do not require a GPU.

Closes #431 