### PR TITLE
Destroy CUDA stream after timing is finished

### DIFF
--- a/nvbench/runner.cxx
+++ b/nvbench/runner.cxx
@@ -75,6 +75,8 @@ void runner_base::run_state_epilogue(state &exec_state) const
     auto &printer = *printer_ptr;
     printer.add_completed_state();
   }
+  // Clean up stream if it was used https://github.com/NVIDIA/nvbench/issues/437
+  exec_state.reset_cuda_stream();
 }
 
 void runner_base::print_skip_notification(state &exec_state) const

--- a/nvbench/runner.cxx
+++ b/nvbench/runner.cxx
@@ -69,14 +69,14 @@ void runner_base::run_state_prologue(nvbench::state &exec_state) const
 
 void runner_base::run_state_epilogue(state &exec_state) const
 {
+  // Clean up stream if it was used https://github.com/NVIDIA/nvbench/issues/437
+  exec_state.reset_cuda_stream();
   // Notify the printer that the state has completed::
   if (auto printer_ptr = exec_state.get_benchmark().get_printer())
   {
     auto &printer = *printer_ptr;
     printer.add_completed_state();
   }
-  // Clean up stream if it was used https://github.com/NVIDIA/nvbench/issues/437
-  exec_state.reset_cuda_stream();
 }
 
 void runner_base::print_skip_notification(state &exec_state) const

--- a/nvbench/runner.cxx
+++ b/nvbench/runner.cxx
@@ -69,8 +69,10 @@ void runner_base::run_state_prologue(nvbench::state &exec_state) const
 
 void runner_base::run_state_epilogue(state &exec_state) const
 {
-  // Clean up stream if it was used https://github.com/NVIDIA/nvbench/issues/437
+  // Release per-state stream resources after state execution has completed.
+  // See: https://github.com/NVIDIA/nvbench/issues/437
   exec_state.reset_cuda_stream();
+
   // Notify the printer that the state has completed::
   if (auto printer_ptr = exec_state.get_benchmark().get_printer())
   {

--- a/nvbench/state.cuh
+++ b/nvbench/state.cuh
@@ -92,6 +92,7 @@ struct state
     return m_cuda_stream;
   }
   void set_cuda_stream(nvbench::cuda_stream &&stream) { m_cuda_stream = std::move(stream); }
+  void reset_cuda_stream() { m_cuda_stream.reset(); }
 
   /// The CUDA device associated with with this benchmark state. May be
   /// nullopt for CPU-only benchmarks.

--- a/nvbench/state.cuh
+++ b/nvbench/state.cuh
@@ -47,6 +47,7 @@ namespace nvbench
 {
 
 struct benchmark_base;
+struct runner_base;
 
 namespace detail
 {
@@ -92,7 +93,6 @@ struct state
     return m_cuda_stream;
   }
   void set_cuda_stream(nvbench::cuda_stream &&stream) { m_cuda_stream = std::move(stream); }
-  void reset_cuda_stream() { m_cuda_stream.reset(); }
 
   /// The CUDA device associated with with this benchmark state. May be
   /// nullopt for CPU-only benchmarks.
@@ -329,6 +329,7 @@ struct state
   }
 
 private:
+  friend struct nvbench::runner_base;
   friend struct nvbench::detail::state_generator;
   friend struct nvbench::detail::state_tester;
 
@@ -340,6 +341,7 @@ private:
         std::size_t type_config_index);
 
   [[nodiscard]] bool skip_hot_measurement() const { return get_run_once() || get_skip_batched(); }
+  void reset_cuda_stream() { m_cuda_stream.reset(); }
 
   const nvbench::benchmark_base *m_benchmark_ptr;
 

--- a/testing/runner.cu
+++ b/testing/runner.cu
@@ -58,6 +58,14 @@ void no_op_generator(nvbench::state &state)
 }
 NVBENCH_DEFINE_CALLABLE(no_op_generator, no_op_callable);
 
+void stream_allocating_generator(nvbench::state &state)
+{
+  // Force stream creation without running kernels
+  static_cast<void>(state.get_cuda_stream());
+  state.skip("stream allocated, skipping");
+}
+NVBENCH_DEFINE_CALLABLE(stream_allocating_generator, stream_allocating_callable);
+
 using float_types = nvbench::type_list<nvbench::float32_t, nvbench::float64_t>;
 using int_types   = nvbench::type_list<nvbench::int32_t, nvbench::int64_t>;
 using misc_types  = nvbench::type_list<bool, void>;
@@ -448,10 +456,30 @@ Params: Float: 13 FloatT: F64 Int: 3 IntT: I64 MiscT: void String: Three
   ASSERT_MSG(test == ref, "Expected:\n\"{}\"\n\nActual:\n\"{}\"", ref, test);
 }
 
+void test_no_stream_kept()
+{
+  using benchmark_type = nvbench::benchmark<stream_allocating_callable>;
+  using runner_type    = nvbench::runner<benchmark_type>;
+
+  benchmark_type bench;
+  bench.set_devices(std::vector<int>{0});
+
+  runner_type runner{bench};
+  runner.generate_states();
+  runner.run();
+
+  for (auto &state : bench.get_states())
+  {
+    // Epilogue must free the stream
+    ASSERT(!state.get_cuda_stream_optional().has_value());
+  }
+}
+
 int main()
 {
   test_empty();
   test_non_types();
   test_types();
   test_both();
+  test_no_stream_kept();
 }


### PR DESCRIPTION
This previously lead to a slowly growing memory allocation on the GPU that was only freed after a benchmark ends, and thus made benchmarks with millions of states/cases impossible.

Closes #437 