### PR TITLE
Fix duplicate fmt ALIAS targets when fmt is already provided

### DIFF
--- a/cmake/NVBenchDependencies.cmake
+++ b/cmake/NVBenchDependencies.cmake
@@ -1,29 +1,42 @@
 ################################################################################
 # fmtlib/fmt
+set(fmt_export_set)
 set(export_set_details)
 set(install_fmt OFF)
 if(NOT BUILD_SHARED_LIBS AND NVBench_ENABLE_INSTALL_RULES)
-  set(export_set_details BUILD_EXPORT_SET nvbench-targets
-                         INSTALL_EXPORT_SET nvbench-targets)
+  set(fmt_export_set nvbench-targets)
+  set(export_set_details BUILD_EXPORT_SET ${fmt_export_set}
+                         INSTALL_EXPORT_SET ${fmt_export_set})
   set(install_fmt ON)
 endif()
 
-rapids_cpm_find(fmt 12.2.0 ${export_set_details}
-  CPM_ARGS
-    GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"
-    GIT_TAG "12.2.0"
-    OPTIONS
-      # Force static to keep fmt internal.
-      "BUILD_SHARED_LIBS OFF"
-      # Suppress warnings from fmt headers by marking them as system.
-      "FMT_SYSTEM_HEADERS ON"
-      # Disable install rules since we're linking statically.
-      "FMT_INSTALL ${install_fmt}"
-      "CMAKE_POSITION_INDEPENDENT_CODE ON"
-)
-
-if(NOT fmt_ADDED)
+# fmt may already be provided by the enclosing project
+if(TARGET fmt::fmt)
+  message(STATUS "NVBench: using externally provided fmt ${fmt_VERSION}")
   set(fmt_is_external TRUE)
+  if(fmt_export_set)
+    include("${rapids-cmake-dir}/export/package.cmake")
+    rapids_export_package(BUILD fmt ${fmt_export_set})
+    rapids_export_package(INSTALL fmt ${fmt_export_set})
+  endif()
+else()
+  rapids_cpm_find(fmt 12.2.0 ${export_set_details}
+    CPM_ARGS
+      GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"
+      GIT_TAG "12.2.0"
+      OPTIONS
+        # Force static to keep fmt internal.
+        "BUILD_SHARED_LIBS OFF"
+        # Suppress warnings from fmt headers by marking them as system.
+        "FMT_SYSTEM_HEADERS ON"
+        # Disable install rules since we're linking statically.
+        "FMT_INSTALL ${install_fmt}"
+        "CMAKE_POSITION_INDEPENDENT_CODE ON"
+  )
+
+  if(NOT fmt_ADDED)
+    set(fmt_is_external TRUE)
+  endif()
 endif()
 
 ################################################################################


### PR DESCRIPTION
When an enclosing project already provides `fmt::fmt` — imported from an install tree, or built from source via a hard-coded `add_subdirectory` — configuring NVBench fails (see NVIDIA/cudf-spark-jni#4932, where `fmt` comes via `libcudf`):

```
CMake Error at .../_deps/fmt-src/CMakeLists.txt:300 (add_library):
  add_library cannot create ALIAS target "fmt::fmt" because another target
  with the same name already exists.
```

`rapids_cpm_find` used `GLOBAL_TARGETS` to gate a package presence check, so when #281 dropped `GLOBAL_TARGETS fmt::fmt fmt::fmt-header-only` to fix #279, it also disabled this deduplication. Since `fmt::fmt` is imported by `find_package` outside of CPM, the already-added check in CPM didn't fire either.

This PR adds the guard @robertmaynard suggested in https://github.com/NVIDIA/nvbench/issues/279#issuecomment-5058713721 — skip `rapids_cpm_find` when `fmt::fmt` already exists and treat `fmt` as external. An existing `fmt` is recorded via `rapids_export_package` when export sets are enabled, so consumers could still use `find_dependency(fmt)`.

### Testing

Verified with a minimal project that imports `fmt` from an install tree and then adds NVBench as a subproject:

- stock `main`: reproduces both ALIAS errors
- PR branch: reports `NVBench: using externally provided fmt 11.0.2` and builds `libnvbench.so`
- PR branch, `BUILD_SHARED_LIBS=OFF` and `NVBench_ENABLE_INSTALL_RULES=ON`: configures clean, and the generated build/install dependency files both have `find_dependency(fmt)`, with build using the correct `fmt_DIR`
- standalone NVBench with no pre-existing fmt: unchanged, still adds `fmt` 12.2.0 via CPM