### PR TITLE
print_constraints_candidate return status of 1 should not fail job

### DIFF
--- a/ci/test_python_examples_inner.sh
+++ b/ci/test_python_examples_inner.sh
@@ -167,5 +167,5 @@ if [[ "${include_heavy_examples:-0}" == "1" ]]; then
         cute
 fi
 
-print_constraints_candidate
+print_constraints_candidate || true
 exit "${overall_status}"


### PR DESCRIPTION
Return values of 1 for `print_constraints_candidate`  bash script function should not fail workflow job.

This function's purpose is to record information a maintainer might find useful in updating python/examples/requirements/constraints-cu13-py313.txt file

Closes #449 