### PR TITLE
Avoid vertical pipe in markdown output in --display explain

### DIFF
--- a/python/scripts/nvbench_compare_robust.py
+++ b/python/scripts/nvbench_compare_robust.py
@@ -58,6 +58,7 @@ def current_tool_name() -> str:
 
 np: Any = None
 Fore: Any = None
+MARKDOWN_TABLE_PIPE_REPLACEMENT = "\u2758"
 
 
 def load_nvbench_compare_tooling(*, load_color: bool = True) -> None:
@@ -2709,10 +2710,10 @@ def format_timing_with_explicit_interval(center, interval, *, value_widths=None)
     prefix = longest_common_prefix(values)
     if not common_numeric_prefix_is_useful(prefix):
         values = align_interval_values(values, value_widths)
-        return f"[{values[0]} | {values[1]} | {values[2]}] {units}"
+        return f"[{values[0]} / {values[1]} / {values[2]}] {units}"
 
     suffixes = [value[len(prefix) :] for value in values]
-    return f"{prefix}[{suffixes[0]} | {suffixes[1]} | {suffixes[2]}] {units}"
+    return f"{prefix}[{suffixes[0]} / {suffixes[1]} / {suffixes[2]}] {units}"
 
 
 def format_percentage(percentage):
@@ -2762,8 +2763,8 @@ def get_display_headers(display):
     if display == "explain":
         return (
             [
-                "Ref [Lo | Ce | Hi]",
-                "Cmp [Lo | Ce | Hi]",
+                "Ref [Lo / Ce / Hi]",
+                "Cmp [Lo / Ce / Hi]",
                 "Ref Noise",
                 "Cmp Noise",
                 "Reason",
@@ -2780,6 +2781,19 @@ def get_display_headers(display):
     return (
         ["Ref", "Cmp", "Change", "Status"],
         ["right", "right", "right", "center"],
+    )
+
+
+def sanitize_markdown_table_cell(value):
+    if isinstance(value, str) and "|" in value:
+        return value.replace("|", MARKDOWN_TABLE_PIPE_REPLACEMENT)
+    return value
+
+
+def sanitize_markdown_table(headers, rows):
+    return (
+        [sanitize_markdown_table_cell(header) for header in headers],
+        [[sanitize_markdown_table_cell(value) for value in row] for row in rows],
     )
 
 
@@ -3185,16 +3199,24 @@ def compare_benches(
                         f"## [{ref_device['id']}] {ref_device['name']} vs. "
                         f"[{cmp_device['id']}] {cmp_device['name']}\n"
                     )
+                table_headers, table_rows = sanitize_markdown_table(headers, rows)
                 tabulate, tabulate_version = load_tabulate_for_table_output()
                 # colalign and github format require tabulate 0.8.3
                 if tabulate_version >= (0, 8, 3):
                     print(
                         tabulate.tabulate(
-                            rows, headers=headers, colalign=colalign, tablefmt="github"
+                            table_rows,
+                            headers=table_headers,
+                            colalign=colalign,
+                            tablefmt="github",
                         )
                     )
                 else:
-                    print(tabulate.tabulate(rows, headers=headers, tablefmt="pipe"))
+                    print(
+                        tabulate.tabulate(
+                            table_rows, headers=table_headers, tablefmt="pipe"
+                        )
+                    )
 
                 print("")
 

--- a/python/scripts/nvbench_compare_robust.py
+++ b/python/scripts/nvbench_compare_robust.py
@@ -56,6 +56,14 @@ def current_tool_name() -> str:
     return os.path.basename(sys.argv[0]) or "nvbench-compare-robust"
 
 
+def configure_utf8_stdio() -> None:
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except AttributeError:
+            pass
+
+
 np: Any = None
 Fore: Any = None
 MARKDOWN_TABLE_PIPE_REPLACEMENT = "\u2758"
@@ -3240,6 +3248,8 @@ def main() -> int:
 
     The number of detected regressions is reported in the summary output.
     """
+    configure_utf8_stdio()
+
     help_text = "%(prog)s [reference.json compare.json | reference_dir/ compare_dir/]"
     parser = argparse.ArgumentParser(usage=help_text)
     parser.add_argument(

--- a/python/test/test_nvbench_compare_robust.py
+++ b/python/test/test_nvbench_compare_robust.py
@@ -349,8 +349,8 @@ SIMPLE_DISPLAY_HEADERS = [
 ]
 INTERVAL_DISPLAY_HEADERS = ["Ref", "Cmp", "Change", "Status"]
 EXPLAIN_DISPLAY_HEADERS = [
-    "Ref [Lo | Ce | Hi]",
-    "Cmp [Lo | Ce | Hi]",
+    "Ref [Lo / Ce / Hi]",
+    "Cmp [Lo / Ce / Hi]",
     "Ref Noise",
     "Cmp Noise",
     "Reason",
@@ -1826,7 +1826,7 @@ def test_format_timing_with_explicit_interval(nvbench_compare):
     )
     assert (
         nvbench_compare.format_timing_with_explicit_interval(0.001446, interval)
-        == "1.4[34 | 46 | 58] ms"
+        == "1.4[34 / 46 / 58] ms"
     )
 
     interval = nvbench_compare.TimingInterval(
@@ -1834,7 +1834,7 @@ def test_format_timing_with_explicit_interval(nvbench_compare):
     )
     assert (
         nvbench_compare.format_timing_with_explicit_interval(18.736e-6, interval)
-        == "[18.400 | 18.736 | 19.464] us"
+        == "[18.400 / 18.736 / 19.464] us"
     )
 
     interval = nvbench_compare.TimingInterval(
@@ -1842,7 +1842,7 @@ def test_format_timing_with_explicit_interval(nvbench_compare):
     )
     assert (
         nvbench_compare.format_timing_with_explicit_interval(19.944e-6, interval)
-        == "[19.380 | 19.944 | 20.508] us"
+        == "[19.380 / 19.944 / 20.508] us"
     )
 
     interval = nvbench_compare.TimingInterval(
@@ -1850,7 +1850,7 @@ def test_format_timing_with_explicit_interval(nvbench_compare):
     )
     assert (
         nvbench_compare.format_timing_with_explicit_interval(99.988e-6, interval)
-        == "[ 99.094 |  99.988 | 100.882] us"
+        == "[ 99.094 /  99.988 / 100.882] us"
     )
 
 
@@ -1899,10 +1899,10 @@ def test_align_explain_interval_columns_pads_values_across_rows(nvbench_compare)
 
     nvbench_compare.align_explain_interval_columns(rows, comparisons, axis_count=0)
 
-    assert rows[0][0] == "[ 19.380 |  19.944 |  20.508] us"
-    assert rows[1][0] == "[102.739 | 103.466 | 104.193] us"
-    assert rows[0][1] == "[ 96.849 |  97.712 |  98.574] us"
-    assert rows[1][1] == "[100.916 | 101.868 | 102.819] us"
+    assert rows[0][0] == "[ 19.380 /  19.944 /  20.508] us"
+    assert rows[1][0] == "[102.739 / 103.466 / 104.193] us"
+    assert rows[0][1] == "[ 96.849 /  97.712 /  98.574] us"
+    assert rows[1][1] == "[100.916 / 101.868 / 102.819] us"
 
 
 def test_align_timing_interval_columns_reserves_missing_interval_slot(nvbench_compare):
@@ -4032,10 +4032,54 @@ def test_compare_benches_explain_display_uses_explicit_intervals(
 
     table = find_tabulate_call(tabulate_calls, EXPLAIN_DISPLAY_HEADERS)
     row = table["rows"][0]
-    assert row[-7] == "1.0[00 | 20 | 30] s"
-    assert row[-6] == "1.0[10 | 30 | 40] s"
+    assert row[-7] == "1.0[00 / 20 / 30] s"
+    assert row[-6] == "1.0[10 / 30 / 40] s"
     assert row[-3] == "centers-far"
     assert row[-2] == ""
+
+
+def test_compare_benches_explain_display_sanitizes_markdown_cells(
+    monkeypatch, nvbench_compare
+):
+    run_data = make_comparison_run_data(nvbench_compare)
+    tabulate_calls = capture_tabulate_calls(monkeypatch, nvbench_compare)
+    axis_name = "Config|Mode"
+    axis_value = "Fast|Path"
+    axis_metadata = [{"name": axis_name, "type": "string", "flags": ""}]
+
+    ref_state = make_state(nvbench_compare, "state", mean="1.0")
+    ref_state["axis_values"] = [
+        {"name": axis_name, "type": "string", "value": axis_value}
+    ]
+    cmp_state = make_state(nvbench_compare, "state", mean="1.01")
+    cmp_state["axis_values"] = [
+        {"name": axis_name, "type": "string", "value": axis_value}
+    ]
+
+    ref_bench = make_benchmark([ref_state])
+    ref_bench["axes"] = axis_metadata
+    cmp_bench = make_benchmark([cmp_state])
+    cmp_bench["axes"] = axis_metadata
+
+    nvbench_compare.compare_benches(
+        run_data,
+        [ref_bench],
+        [cmp_bench],
+        threshold=0.0,
+        plot_along=None,
+        plot=False,
+        dark=False,
+        filter_plan=make_filter_plan(nvbench_compare),
+        no_color=True,
+        display="explain",
+    )
+
+    table = find_tabulate_call(tabulate_calls, EXPLAIN_DISPLAY_HEADERS)
+
+    assert table["headers"][0] == "Config\u2758Mode"
+    assert table["rows"][0][0] == "Fast\u2758Path"
+    assert all("|" not in header for header in table["headers"])
+    assert all("|" not in value for row in table["rows"] for value in row)
 
 
 def test_main_passes_selected_preset_to_compare_benches(monkeypatch, nvbench_compare):


### PR DESCRIPTION
Closes #453

> [!NOTE] 
> Output of command below is pasted as is, so that GitHub may render markdown.
> The output table should render as a valid table

<details>
<summary>Sample script output with --display explain</summary>


```
$ nvbench-compare-robust -a "T{ct}=F16" --display explain --no-color \
    base/cub.bench.reduce.min.base.json \
    test/cub.bench.reduce.min.base.json 
```
# base

## [0] NVIDIA RTX A6000

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |               Ref [Lo / Ce / Hi] |               Cmp [Lo / Ce / Hi] |   Ref Noise |   Cmp Noise | Reason      |   Change |  Status  |
|---------|---------------|----------------|----------------------------------|----------------------------------|-------------|-------------|-------------|----------|----------|
|   F16   |      I32      |      2^16      | [  5.984 /   6.528 /   6.560] us | [  6.080 /   6.688 /   6.752] us |       7.35% |       7.18% | centers-far |          |  🤷 AMBG  |
|   F16   |      I32      |      2^20      | [  9.088 /  10.112 /  10.208] us | [  9.184 /  10.208 /  10.336] us |       1.90% |       1.88% | centers-far |          |  🤷 AMBG  |
|   F16   |      I32      |      2^24      | [ 66.080 /  66.496 /  66.592] us | [ 66.208 /  66.560 /  66.656] us |       0.29% |       0.34% | bulk-same   |          |  🔵 SAME  |
|   F16   |      I32      |      2^28      | [879.392 / 880.672 / 881.024] us | [879.744 / 880.928 / 881.312] us |       0.08% |       0.09% | bc-sup-miss |          |  🤷 AMBG  |
|   F16   |      I64      |      2^16      | [  5.856 /   6.464 /   6.560] us | [  5.888 /   6.400 /   6.560] us |       6.93% |       7.00% | centers-far |          |  🤷 AMBG  |
|   F16   |      I64      |      2^20      | [  9.888 /  10.368 /  10.624] us | [ 10.016 /  10.560 /  10.784] us |       5.25% |       4.85% | centers-far |          |  🤷 AMBG  |
|   F16   |      I64      |      2^24      | [ 67.040 /  67.424 /  67.520] us | [ 67.072 /  67.456 /  67.584] us |       0.28% |       0.28% | bc-sup-miss |          |  🤷 AMBG  |
|   F16   |      I64      |      2^28      | [882.240 / 883.904 / 884.512] us | [882.464 / 884.096 / 884.608] us |       0.12% |       0.12% | bc-sup-miss |          |  🤷 AMBG  |

# Summary

- Total Matches: 8
  - Unchanged   (classified as SAME): 1
  - Improvement (clear timing gap, %Diff < 0): 0
  - Regression  (clear timing gap, %Diff > 0): 0
  - Ambiguous (comparison requires more evidence): 7
    - Reasons:
      - centers_not_close: 4 (timing centers are not close enough to declare same)
      - bulk_cycle_support_mismatch: 3 (sample: min(ref=0.0%, cmp=0.0%) >= 97.0%; support: min(ref=0.0%, cmp=0.0%) >= 80.0%)
  - Reason legend: bc-sup-miss = bulk_cycle_support_mismatch; centers-far = centers_not_close
  - Unknown     (input data unavailable or unusable): 0

</details>