### PR TITLE
Reject conflicting stopping criterion options

### DIFF
--- a/nvbench/option_parser.cu
+++ b/nvbench/option_parser.cu
@@ -133,6 +133,20 @@ std::string format_criterion_param_options(const nvbench::criterion_params &para
   return fmt::to_string(buffer);
 }
 
+std::string format_cli_options(const std::vector<std::string> &options)
+{
+  fmt::memory_buffer buffer;
+  for (std::size_t i = 0; i < options.size(); ++i)
+  {
+    if (i != 0)
+    {
+      fmt::format_to(fmt::appender(buffer), ", ");
+    }
+    fmt::format_to(fmt::appender(buffer), "{}", options[i]);
+  }
+  return fmt::to_string(buffer);
+}
+
 [[noreturn]] void
 throw_unrecognized_criterion_param(const std::string &prop_arg,
                                    const std::string &criterion_name,
@@ -441,6 +455,8 @@ void option_parser::parse(std::vector<std::string> args)
 void option_parser::parse_impl()
 {
   m_global_benchmark_args.clear();
+  m_global_criterion_cli_scope_state = {};
+  m_local_criterion_cli_scope_state  = {};
 
   // Initialize to all devices:
   m_recent_devices = nvbench::device_manager::get().get_devices();
@@ -845,16 +861,43 @@ catch (std::exception &e)
 void option_parser::set_stopping_criterion(const std::string &criterion)
 try
 {
+  auto &scope_state = m_benchmarks.empty() ? m_global_criterion_cli_scope_state
+                                           : m_local_criterion_cli_scope_state;
+
+  if (scope_state.explicitly_selected_criterion)
+  {
+    NVBENCH_THROW(std::runtime_error,
+                  "--stopping-criterion {} would overwrite a stopping criterion already "
+                  "specified in this option scope: --stopping-criterion {}.\n"
+                  "Move benchmark-specific overrides after --benchmark, or remove the earlier "
+                  "--stopping-criterion.",
+                  criterion,
+                  *scope_state.explicitly_selected_criterion);
+  }
+
+  if (!scope_state.explicitly_set_criterion_params.empty())
+  {
+    NVBENCH_THROW(std::runtime_error,
+                  "--stopping-criterion {} would discard previously specified stopping-criterion "
+                  "parameter(s): {}.\n"
+                  "Move --stopping-criterion before criterion-specific parameters.",
+                  criterion,
+                  format_cli_options(scope_state.explicitly_set_criterion_params));
+  }
+
   // If no active benchmark, save args as global.
   if (m_benchmarks.empty())
   {
     m_global_benchmark_args.push_back("--stopping-criterion");
     m_global_benchmark_args.push_back(criterion);
-    return;
+  }
+  else
+  {
+    benchmark_base &bench = *m_benchmarks.back();
+    bench.set_stopping_criterion(criterion);
   }
 
-  benchmark_base &bench = *m_benchmarks.back();
-  bench.set_stopping_criterion(criterion);
+  scope_state.explicitly_selected_criterion = criterion;
 }
 catch (std::exception &e)
 {
@@ -917,7 +960,9 @@ catch (std::exception &e)
 
 void option_parser::replay_global_args()
 {
+  m_local_criterion_cli_scope_state = {};
   this->parse_range(m_global_benchmark_args.cbegin(), m_global_benchmark_args.cend());
+  m_local_criterion_cli_scope_state = {};
 }
 
 void option_parser::update_devices(const std::string &devices)
@@ -1124,6 +1169,8 @@ void option_parser::update_criterion_prop(const std::string &prop_arg,
 try
 {
   const std::string name(prop_arg.begin() + 2, prop_arg.end());
+  auto &scope_state = m_benchmarks.empty() ? m_global_criterion_cli_scope_state
+                                           : m_local_criterion_cli_scope_state;
 
   // If no active benchmark, save args as global.
   if (m_benchmarks.empty())
@@ -1137,6 +1184,7 @@ try
 
     m_global_benchmark_args.push_back(prop_arg);
     m_global_benchmark_args.push_back(prop_val);
+    scope_state.explicitly_set_criterion_params.push_back(prop_arg);
     return;
   }
 
@@ -1174,6 +1222,8 @@ try
   {
     NVBENCH_THROW(std::runtime_error, "Unrecognized type for property: `{}`", name);
   }
+
+  scope_state.explicitly_set_criterion_params.push_back(prop_arg);
 }
 catch (std::exception &e)
 {

--- a/nvbench/option_parser.cu
+++ b/nvbench/option_parser.cu
@@ -136,13 +136,15 @@ std::string format_criterion_param_options(const nvbench::criterion_params &para
 std::string format_cli_options(const std::vector<std::string> &options)
 {
   fmt::memory_buffer buffer;
-  for (std::size_t i = 0; i < options.size(); ++i)
+  bool first = true;
+  for (const auto &option : options)
   {
-    if (i != 0)
+    if (!first)
     {
       fmt::format_to(fmt::appender(buffer), ", ");
     }
-    fmt::format_to(fmt::appender(buffer), "{}", options[i]);
+    fmt::format_to(fmt::appender(buffer), "{}", option);
+    first = false;
   }
   return fmt::to_string(buffer);
 }

--- a/nvbench/option_parser.cuh
+++ b/nvbench/option_parser.cuh
@@ -34,6 +34,7 @@
 
 #include <iosfwd>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -79,6 +80,12 @@ struct option_parser
   [[nodiscard]] nvbench::printer_base &get_printer();
 
 private:
+  struct criterion_cli_scope_state
+  {
+    std::optional<std::string> explicitly_selected_criterion;
+    std::vector<std::string> explicitly_set_criterion_params;
+  };
+
   void parse_impl();
 
   using arg_iterator_t = std::vector<std::string>::const_iterator;
@@ -137,6 +144,9 @@ private:
   // Store benchmark modifiers passed in before any benchmarks are requested as
   // "global args". Replay them after every benchmark.
   std::vector<std::string> m_global_benchmark_args;
+
+  criterion_cli_scope_state m_global_criterion_cli_scope_state;
+  criterion_cli_scope_state m_local_criterion_cli_scope_state;
 
   // List of devices specified by the most recent --devices option, or all
   // devices if --devices has not been used.

--- a/testing/option_parser.cu
+++ b/testing/option_parser.cu
@@ -1601,6 +1601,38 @@ void test_stopping_criterion()
     ASSERT(states[0].get_stopping_criterion() == "stdrel");
     ASSERT(states[0].get_criterion_params().get_float64("min-time") == 0.7);
   }
+  { // Per-benchmark criterion state does not leak to the next benchmark:
+    nvbench::option_parser parser;
+    parser.parse({
+      "--stopping-criterion",
+      "entropy",
+      "--min-r2",
+      "0.2",
+      "--benchmark",
+      "DummyBench",
+      "--stopping-criterion",
+      "stdrel",
+      "--min-time",
+      "0.7",
+      "--benchmark",
+      "TestBench",
+    });
+
+    auto &benches = parser.get_benchmarks();
+    ASSERT(benches.size() == 2);
+
+    benches[0]->run();
+    const auto &dummy_states = benches[0]->get_states();
+    ASSERT(dummy_states.size() == 1);
+    ASSERT(dummy_states[0].get_stopping_criterion() == "stdrel");
+    ASSERT(dummy_states[0].get_criterion_params().get_float64("min-time") == 0.7);
+
+    benches[1]->run();
+    const auto &test_states = benches[1]->get_states();
+    ASSERT(test_states.size() == 9);
+    ASSERT(test_states[0].get_stopping_criterion() == "entropy");
+    ASSERT(test_states[0].get_criterion_params().get_float64("min-r2") == 0.2);
+  }
   { // Sample-count criterion default params
     nvbench::option_parser parser;
     parser.parse({

--- a/testing/option_parser.cu
+++ b/testing/option_parser.cu
@@ -1521,6 +1521,38 @@ void test_stopping_criterion()
         "Current criterion 'entropy' accepts: --max-angle, --min-r2.",
       });
   }
+  { // Multiple global criteria are ambiguous:
+    assert_parse_error_contains(
+      {
+        "--stopping-criterion",
+        "entropy",
+        "--stopping-criterion",
+        "sample-count",
+      },
+      {
+        "--stopping-criterion sample-count would overwrite a stopping criterion already specified "
+        "in this option scope: --stopping-criterion entropy.",
+        "Move benchmark-specific overrides after --benchmark, or remove the earlier "
+        "--stopping-criterion.",
+      });
+  }
+  { // Multiple per-benchmark criteria are ambiguous:
+    assert_parse_error_contains(
+      {
+        "--benchmark",
+        "DummyBench",
+        "--stopping-criterion",
+        "entropy",
+        "--stopping-criterion",
+        "sample-count",
+      },
+      {
+        "--stopping-criterion sample-count would overwrite a stopping criterion already specified "
+        "in this option scope: --stopping-criterion entropy.",
+        "Move benchmark-specific overrides after --benchmark, or remove the earlier "
+        "--stopping-criterion.",
+      });
+  }
   { // Global params to default criterion should work:
     nvbench::option_parser parser;
     parser.parse({
@@ -1548,6 +1580,26 @@ void test_stopping_criterion()
 
     ASSERT(criterion_params.get_float64("max-angle") == 0.42);
     ASSERT(criterion_params.get_float64("min-r2") == 0.6);
+  }
+  { // Per-benchmark criterion may override an inherited global criterion:
+    nvbench::option_parser parser;
+    parser.parse({
+      "--stopping-criterion",
+      "entropy",
+      "--min-r2",
+      "0.2",
+      "--benchmark",
+      "DummyBench",
+      "--stopping-criterion",
+      "stdrel",
+      "--min-time",
+      "0.7",
+    });
+    const auto &states = parser_to_states(parser);
+
+    ASSERT(states.size() == 1);
+    ASSERT(states[0].get_stopping_criterion() == "stdrel");
+    ASSERT(states[0].get_criterion_params().get_float64("min-time") == 0.7);
   }
   { // Sample-count criterion default params
     nvbench::option_parser parser;
@@ -1717,45 +1769,37 @@ void test_stopping_criterion()
     }
     ASSERT(exception_thrown);
   }
-  { // global param-before-criterion throws exception:
-    bool exception_thrown = false;
-    try
-    {
-      nvbench::option_parser parser;
-      parser.parse({
-        "--min-r2", //
-        "0.6",
+  { // Global criterion does not discard earlier explicit parameters:
+    assert_parse_error_contains(
+      {
+        "--min-time",
+        "0.1",
         "--stopping-criterion",
         "entropy",
         "--benchmark",
         "DummyBench",
+      },
+      {
+        "--stopping-criterion entropy would discard previously specified stopping-criterion "
+        "parameter(s): --min-time.",
+        "Move --stopping-criterion before criterion-specific parameters.",
       });
-    }
-    catch (const std::runtime_error & /*ex*/)
-    {
-      exception_thrown = true;
-    }
-    ASSERT(exception_thrown);
   }
-  { // per-benchmark param-before-criterion throws exception:
-    bool exception_thrown = false;
-    try
-    {
-      nvbench::option_parser parser;
-      parser.parse({
-        "--benchmark", //
+  { // Per-benchmark criterion does not discard earlier explicit parameters:
+    assert_parse_error_contains(
+      {
+        "--benchmark",
         "DummyBench",
-        "--min-r2",
-        "0.6",
+        "--min-time",
+        "0.1",
         "--stopping-criterion",
         "entropy",
+      },
+      {
+        "--stopping-criterion entropy would discard previously specified stopping-criterion "
+        "parameter(s): --min-time.",
+        "Move --stopping-criterion before criterion-specific parameters.",
       });
-    }
-    catch (const std::runtime_error & /*ex*/)
-    {
-      exception_thrown = true;
-    }
-    ASSERT(exception_thrown);
   }
   { // Invalid param type throws exception:
     bool exception_thrown = false;


### PR DESCRIPTION
@oleksandr-pavlyk could you please vet this PR for copy-pr-bot when you have a chance? Thank you

Closes #441

## Summary

Reject `--stopping-criterion` changes that would discard parameters or overwrite a criterion set earlier in the same scope. Benchmark-local criterion options can still override inherited global settings.

## Testing

- `pre-commit run --files nvbench/option_parser.cuh nvbench/option_parser.cu testing/option_parser.cu`
- `ctest --test-dir /build --output-on-failure` (46/46 passed)
