### PR TITLE
Do not set --stopping-criterion entropy via CLI in autotune Python example

### DIFF
--- a/python/examples/benchmark_result_autotune.py
+++ b/python/examples/benchmark_result_autotune.py
@@ -188,8 +188,6 @@ def run_driver(args: argparse.Namespace, nvbench_args: list[str]) -> int:
                 sys.executable,
                 str(Path(__file__).resolve()),
                 "--run-benchmark",
-                "--stopping-criterion",
-                "entropy",
                 "--tile-shape",
                 tile_shape,
                 "--image-width",
@@ -303,6 +301,7 @@ def run_benchmark(args: argparse.Namespace, nvbench_args: list[str]) -> None:
 
     benchmark = bench.register(stencil_autotune)
     benchmark.set_name(BENCHMARK_NAME)
+    benchmark.set_stopping_criterion("entropy")
     tile_shapes = [args.tile_shape] if args.tile_shape is not None else TILE_SHAPES
     benchmark.add_string_axis("TileShape", tile_shapes)
     bench.run_all_benchmarks([sys.argv[0], *nvbench_args])


### PR DESCRIPTION
Use `Benchmark.set_stopping_criterion("entropy")` in the script instead.

This declares correct intent for benchmark to use entropy-criterion by default.

Closes #456 

---

Using `benchmak.set_stopping_criterion("entropy")` in the script effectively communicates that default stopping criterion for this benchmark is entropy-criterion. So a user may just provide this criterion's parameters `python script.py --min-r2 0.85` and they will be recognized. 

To resolve issues outlined in #441 the PR #455 disallowed overriding explicitly specified stopping criterion. Since the script used `--stopping-criterion entropy` before appending other user-provided options, Python example workflow broke, because those options included `--stopping-criterion sample-count` so that invocation line was `python script.py --stopping-criterion entropy --stopping-criterion sample-count ...` triggering workflow error.  